### PR TITLE
Fixing definition of supported_signature_algorithms. Closes #12

### DIFF
--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -3539,21 +3539,21 @@ connection state. SecurityParameters includes:
     MACAlgorithm. */
 
     struct {
-	    ConnectionEnd          entity;
-	    PRFAlgorithm           prf_algorithm;
-	    BulkCipherAlgorithm    bulk_cipher_algorithm;
-	    CipherType             cipher_type;
-	    uint8                  enc_key_length;
-	    uint8                  block_length;
-	    uint8                  fixed_iv_length;
-	    uint8                  record_iv_length;
-	    MACAlgorithm           mac_algorithm;
-	    uint8                  mac_length;
-	    uint8                  mac_key_length;
-	    CompressionMethod      compression_algorithm;
-	    opaque                 master_secret[48];
-	    opaque                 client_random[32];
-	    opaque                 server_random[32];
+        ConnectionEnd          entity;
+        PRFAlgorithm           prf_algorithm;
+        BulkCipherAlgorithm    bulk_cipher_algorithm;
+        CipherType             cipher_type;
+        uint8                  enc_key_length;
+        uint8                  block_length;
+        uint8                  fixed_iv_length;
+        uint8                  record_iv_length;
+        MACAlgorithm           mac_algorithm;
+        uint8                  mac_length;
+        uint8                  mac_key_length;
+        CompressionMethod      compression_algorithm;
+        opaque                 master_secret[48];
+        opaque                 client_random[32];
+        opaque                 server_random[32];
       } SecurityParameters;
 
 ## Changes to RFC 4492
@@ -4474,5 +4474,3 @@ Archives of the list can be found at:
     Tim Wright
     Vodafone
     timothy.wright@vodafone.com
-
-

--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -2502,7 +2502,7 @@ Structure of this message:
        struct {
            ClientCertificateType certificate_types<1..2^8-1>;
            SignatureAndHashAlgorithm
-             supported_signature_algorithms<2^16-1>;
+             supported_signature_algorithms<2..2^16-2>;
            DistinguishedName certificate_authorities<0..2^16-1>;
        } CertificateRequest;
 
@@ -3371,6 +3371,8 @@ This section describes protocol types and constants.
 
     struct {
         ClientCertificateType certificate_types<1..2^8-1>;
+        SignatureAndHashAlgorithm
+          supported_signature_algorithms<2..2^16-2>;
         DistinguishedName certificate_authorities<0..2^16-1>;
     } CertificateRequest;
 


### PR DESCRIPTION
As agreed in Erratum.