### PR TITLE
Remove renegotiation

### DIFF
--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -311,7 +311,7 @@ interpreted as described in RFC 2119 {{RFC2119}}.
 
 draft-03
 
--  Remove renegotiation; add rekeying.
+-  Remove renegotiation; add rekeying using ChangeCipherSpec.
 
 draft-03
 


### PR DESCRIPTION
So I started here with the intent to just put in a proposal for key exhaustion.  Turned out doing the whole thing for #38.

There are a few things to note here, mostly related to the key renewal stuff:
- ChangeCipherSpec does double duty here.  The first time it's used, it moves from the null initial state to the first encrypted mode.  Subsequent times, it's used to crank the master secret over.
- I'm requiring that implementations answer a ChangeCipherSpec with a ChangeCipherSpec.  This means that the master secrets used for read and write are basically in sync.
- I've removed HelloRequest and deprecated its code point and the no_renegotiation alert code
- The text around connection state could be improved further, I'm sure.
