### PR TITLE
revise backwards compatibility & fix record layer version

### DIFF
--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -3418,19 +3418,19 @@ Cryptographic details:
 
 ## Compatibility with prior versions {#compatibility}
 
-[[TODO: Revise backward compatibility section for TLS 1.3.
-https://github.com/tlswg/tls13-spec/issues/54]]
 Since there are various versions of TLS (1.0, 1.1, 1.2, 1.3, and any future
 versions) and SSL (2.0 and 3.0), means are needed to negotiate the specific
 protocol version to use. The TLS protocol provides a built-in mechanism for
 version negotiation so as not to bother other protocol components with the
 complexities of version selection.
 
-TLS versions 1.0, 1.1, and 1.2, and SSL 3.0 are very similar, and use
-compatible ClientHello messages; thus, supporting all of them is relatively
-easy. Similarly, servers can easily handle clients trying to use future
-versions of TLS as long as the ClientHello format remains compatible, and the
-client supports the highest protocol version available in the server.
+TLS 1.x and SSL 3.0 use compatible ClientHello messages, so supporting all
+of them is relatively easy. Similarly, servers can easily handle clients trying
+to use future versions of TLS as long as the ClientHello format remains
+compatible, and the client supports the highest protocol version available
+in the server.
+
+### Negotiating with an older server
 
 A TLS 1.3 client who wishes to negotiate with such older servers will send a
 normal TLS 1.3 ClientHello, containing { 3, 4 } (TLS 1.3) in
@@ -3447,20 +3447,30 @@ If a TLS server receives a ClientHello containing a version number greater than
 the highest version supported by the server, it MUST reply according to the
 highest version supported by the server.
 
+### Negotiating with an older client
+
 A TLS server can also receive a ClientHello containing a version number smaller
 than the highest supported version. If the server wishes to negotiate with old
 clients, it will proceed as appropriate for the highest version supported by
 the server that is not greater than ClientHello.client_version. For example, if
 the server supports TLS 1.0, 1.1, and 1.2, and client_version is TLS 1.0, the
-server will proceed with a TLS 1.0 ServerHello. If server supports (or is
-willing to use) only versions greater than client_version, it MUST send a
-"protocol_version" alert message and close the connection.
+server will proceed with a TLS 1.0 ServerHello. If the server only supports
+versions greater than client_version, it MUST send a "protocol_version"
+alert message and close the connection.
 
 Whenever a client already knows the highest protocol version known to a server
 (for example, when resuming a session), it SHOULD initiate the connection in
 that native protocol.
 
-Note: some server implementations are known to implement version negotiation
+Earlier versions of the TLS specification were not fully clear on what the
+record layer version number (TLSPlaintext.version) should contain when sending
+ClientHello (i.e., before it is known which version of the protocol will be
+employed). Thus, TLS servers compliant with this specification MUST accept any
+value { 03, XX } as the record layer version number for ClientHello.
+
+### Negotiating with buggy servers
+
+Some server implementations are known to implement version negotiation
 incorrectly. For example, there are buggy TLS 1.0 servers that simply close the
 connection when the client offers a version newer than TLS 1.0. Also, it is
 known that some servers will refuse the connection if any TLS extensions are
@@ -3468,14 +3478,8 @@ included in ClientHello. Interoperability with such buggy servers is a complex
 topic beyond the scope of this document, and may require multiple connection
 attempts by the client.
 
-Earlier versions of the TLS specification were not fully clear on what the
-record layer version number (TLSPlaintext.version) should contain when sending
-ClientHello (i.e., before it is known which version of the protocol will be
-employed). Thus, TLS servers compliant with this specification MUST accept any
-value {03,XX} as the record layer version number for ClientHello.
-
 TLS clients that wish to negotiate with older servers MAY send any value
-{03,XX} as the record layer version number. Typical values would be {03,00},
+{ 03, XX } as the record layer version number. Typical values would be { 3, 0 },
 the lowest version number supported by the client, and the value of
 ClientHello.client_version. No single value will guarantee interoperability
 with all old servers, but this is a complex topic beyond the scope of this

--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -996,8 +996,8 @@ TLS servers MUST accept any value { 03, XX } for this version in a ClientHello.
 See {{backward-compatibility}} for more information regarding
 negotiations with endpoints supporting other versions.
 
-Implementations MUST NOT send zero-length fragments of Handshake, Alert, or
-ChangeCipherSpec content types. Zero-length fragments of Application data MAY
+Implementations MUST NOT send zero-length fragments of Handshake or Alert
+types. Zero-length fragments of Application data MAY
 be sent as they are potentially useful as a traffic analysis countermeasure.
 
 
@@ -3501,13 +3501,6 @@ known that some servers will refuse the connection if any TLS extensions are
 included in ClientHello. Interoperability with such buggy servers is a complex
 topic beyond the scope of this document, and may require multiple connection
 attempts by the client.
-
-TLS clients that wish to negotiate with older servers MAY send any value
-{ 03, XX } as the record layer version number. Typical values would be { 3, 0 },
-the lowest version number supported by the client, and the value of
-ClientHello.client_version. No single value will guarantee interoperability
-with all old servers, but this is a complex topic beyond the scope of this
-document.
 
 ## Compatibility with SSL
 

--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -116,6 +116,7 @@ informative:
   RFC6066:
   RFC6176:
   I-D.ietf-tls-negotiated-ff-dhe:
+  I-D.ietf-tls-prohibiting-rc4:
   I-D.ietf-tls-session-hash:
   I-D.ietf-tls-sslv3-diediedie:
 
@@ -3476,6 +3477,14 @@ record layer version number (TLSPlaintext.version) should contain when sending
 ClientHello (i.e., before it is known which version of the protocol will be
 employed). Thus, TLS servers compliant with this specification MUST accept any
 value { 03, XX } as the record layer version number for ClientHello.
+
+### Negotiating ciphers with older endpoints
+
+If an implementation negotiates usage of TLS 1.2, then negotiation of cipher
+suites also supported by TLS 1.3 SHOULD be preferred, if available.
+
+Implementations MUST NOT offer or negotiate RC4 cipher suites for any version.
+[I-D.ietf-tls-prohibiting-rc4]
 
 ### Negotiating with buggy servers
 

--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -3394,6 +3394,11 @@ TLS protocol issues:
 
 -  Do you ignore the TLS record layer version number in all TLS
   records? (see {{backward-compatibility}})
+  
+-  Have you ensured that all support for SSL, RC4, and EXPORT ciphers
+  is completely removed from all possible configurations that support
+  TLS 1.3 or later, and that attempts to use these obsolete capabilities
+  fail correctly? (see {{backward-compatibility}})
 
 -  Do you handle TLS extensions in ClientHello correctly, including
   omitting the extensions field completely?

--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -3438,6 +3438,10 @@ purposes. (TLSPlaintext.record_version & TLSCiphertext.record_version)
 As of TLS 1.3, this field is deprecated and its value MUST be ignored by all
 implementations. Version negotiation is performed using only the handshake versions.
 (ClientHello.client_version & ServerHello.server_version)
+In order to maximize interoperability with older endpoints, implementations
+that negotiate the usage of TLS 1.0-1.2 SHOULD set the record layer
+version number to the negotiated version for the ServerHello and all
+records thereafter.
 
 ## Negotiating with an older server
 

--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -961,7 +961,7 @@ message MAY be fragmented across several records).
 
        struct {
            ContentType type;
-           ProtocolVersion record_version;
+           ProtocolVersion record_version = { 3, 1 };    /* TLS v1.x */
            uint16 length;
            opaque fragment[TLSPlaintext.length];
        } TLSPlaintext;
@@ -1013,7 +1013,7 @@ of {{RFC5116}}. The key is either the client_write_key or the server_write_key.
 %%% Record Layer
        struct {
            ContentType type;
-           ProtocolVersion record_version;
+           ProtocolVersion record_version = { 3, 1 };    /* TLS v1.x */
            uint16 length;
            opaque nonce_explicit[SecurityParameters.record_iv_length];
            aead-ciphered struct {
@@ -1025,7 +1025,7 @@ type
 : The type field is identical to TLSPlaintext.type.
 
 record_version
-: The record_version field is identical to TLSPlaintext.record_version.
+: The record_version field is identical to TLSPlaintext.record_version and is always { 3, 1 }.
 
 length
 : The length (in bytes) of the following TLSCiphertext.fragment.
@@ -1725,7 +1725,7 @@ cipher suites, and process the remaining ones as usual.
        enum { null(0), (255) } CompressionMethod;
 
        struct {
-           ProtocolVersion client_version;
+           ProtocolVersion client_version = { 3, 4 };    /* TLS v1.3 */
            Random random;
            SessionID session_id;
            CipherSuite cipher_suites<2..2^16-2>;

--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -963,14 +963,18 @@ type
 : The higher-level protocol used to process the enclosed fragment.
 
 version
-: The version of the protocol being employed.  This document
-  describes TLS Version 1.3, which uses the version { 3, 4 }.  The
-  version value 3.4 is historical, deriving from the use of {3, 1}
-  for TLS 1.0.  (See {{record-layer-1}}.)  Note that a client that
-  supports multiple versions of TLS may not know what version will
-  be employed before it receives the ServerHello.  See
-  {{backward-compatibility}} for discussion about what record layer
-  version number should be employed for ClientHello.
+: The version of the protocol currently being employed. This document
+  describes TLS Version 1.3, which uses the version { 3, 4 }. The
+  version value 3.4 is historical, deriving from the use of { 3, 1 }
+  for TLS 1.0. (See {{record-layer-1}}) A client that supports
+  multiple versions of TLS will not know what version will
+  be employed for the connection before it receives the ServerHello.
+  Thus, the ClientHello MUST use the version { 3, 1 } for the
+  record layer version number. (the minium TLS version with which
+  the ClientHello format is compatible) All other record layer version
+  numbers MUST equal the negotiated version number. See
+  {{backward-compatibility}} for more information regarding negotiations
+  with endpoints supporting other versions.
 
 length
 : The length (in bytes) of the following TLSPlaintext.fragment.  The

--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -115,8 +115,8 @@ informative:
   RFC5705:
   RFC6066:
   RFC6176:
+  RFC7465:
   I-D.ietf-tls-negotiated-ff-dhe:
-  I-D.ietf-tls-prohibiting-rc4:
   I-D.ietf-tls-session-hash:
   I-D.ietf-tls-sslv3-diediedie:
 
@@ -307,7 +307,7 @@ document are to be interpreted as described in RFC 2119 {{RFC2119}}.
 
 draft-05
 
-- Prohibit SSL negotiation for backwards compatibility.
+- Prohibit SSL or RC4 negotiation for backwards compatibility.
 
 - Fix which MS is used for exporters.
 
@@ -3485,8 +3485,9 @@ value { 03, XX } as the record layer version number for ClientHello.
 If an implementation negotiates usage of TLS 1.2, then negotiation of cipher
 suites also supported by TLS 1.3 SHOULD be preferred, if available.
 
-Implementations MUST NOT offer or negotiate RC4 cipher suites for any version.
-[I-D.ietf-tls-prohibiting-rc4]
+The security of RC4 cipher suites is considered insufficient for the reasons
+cited in [RFC7465]. Implementations MUST NOT offer or negotiate RC4 cipher suites
+for any version of TLS for any reason.
 
 Old versions of TLS permitted the usage of very low strength ciphers.
 Ciphers with a strength less than 112 bits MUST NOT be offered or

--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -1749,8 +1749,8 @@ client_version
 : The version of the TLS protocol by which the client wishes to
   communicate during this session.  This SHOULD be the latest
   (highest valued) version supported by the client.  For this
-  version of the specification, the version will be 3.4 (see
-  {{backward-compatibility}} for details about backward compatibility).
+  version of the specification, the version will be 3.4. (See
+  {{backward-compatibility}} for details about backward compatibility.)
 
 random
 : A client-generated random structure.
@@ -1929,7 +1929,7 @@ bytes following the cipher_suite field at the end of the ServerHello.
 server_version
 : This field will contain the lower of that suggested by the client
   in the client hello and the highest supported by the server.  For
-  this version of the specification, the version is 3.4.  (See
+  this version of the specification, the version is 3.4. (See
   {{backward-compatibility}} for details about backward compatibility.)
 
 random
@@ -3393,7 +3393,7 @@ TLS protocol issues:
   handshake messages can be large enough to require fragmentation.
 
 -  Do you ignore the TLS record layer version number in all TLS
-  records (see {{backward-compatibility}})?
+  records? (see {{backward-compatibility}})
 
 -  Do you handle TLS extensions in ClientHello correctly, including
   omitting the extensions field completely?

--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -3422,16 +3422,14 @@ Cryptographic details:
 
 ## Compatibility with prior versions {#compatibility}
 
-Since there are various versions of TLS (1.0, 1.1, 1.2, 1.3, and any future
-versions) and SSL (2.0 and 3.0), means are needed to negotiate the specific
+Since there are various versions of TLS, endpoints may need to negotiate the specific
 protocol version to use. The TLS protocol provides a built-in mechanism for
 version negotiation so as not to bother other protocol components with the
 complexities of version selection.
 
-TLS 1.x and SSL 3.0 use compatible ClientHello messages, so supporting all
-of them is relatively easy. Similarly, servers can easily handle clients trying
-to use future versions of TLS as long as the ClientHello format remains
-compatible, and the client supports the highest protocol version available
+TLS 1.x and SSL 3.0 use compatible ClientHello messages. Servers can also handle
+clients trying to use future versions of TLS as long as the ClientHello format
+remains compatible, and the client supports the highest protocol version available
 in the server.
 
 ### Negotiating with an older server

--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -963,18 +963,10 @@ type
 : The higher-level protocol used to process the enclosed fragment.
 
 version
-: The version of the protocol currently being employed. This document
-  describes TLS Version 1.3, which uses the version { 3, 4 }. The
-  version value 3.4 is historical, deriving from the use of { 3, 1 }
-  for TLS 1.0. (See {{record-layer-1}}) A client that supports
-  multiple versions of TLS will not know what version will
-  be employed for the connection before it receives the ServerHello.
-  Thus, the ClientHello MUST use the version { 3, 1 } for the
-  record layer version number. (the minium TLS version with which
-  the ClientHello format is compatible) All other record layer version
-  numbers MUST equal the negotiated version number. See
-  {{backward-compatibility}} for more information regarding negotiations
-  with endpoints supporting other versions.
+: The version of the protocol being employed in the current record.
+  For the initial ClientHello this MUST be { 3, 1 }.
+  For the ServerHello and all other TLS records this MUST be equal to the negotiated version.
+  For TLS 1.3 connections, this version is { 3, 4 }.
 
 length
 : The length (in bytes) of the following TLSPlaintext.fragment.  The
@@ -986,8 +978,23 @@ fragment
   specified by the type field.
 {:br }
 
-Implementations MUST NOT send zero-length fragments of Handshake or Alert
-types. Zero-length fragments of Application data MAY
+This document describes TLS Version 1.3, which uses the version { 3, 4 }.
+The version value 3.4 is historical, deriving from the use of { 3, 1 }
+for TLS 1.0 and { 3, 0 } for SSL 3.0. A client that supports
+multiple versions of TLS will not know what version will
+be employed for the connection before it receives the ServerHello.
+In order to maximize backwards compatibility with servers, the
+ClientHello record layer version identifies as simply TLS 1.0
+rather than specifying additional detail.
+Using this fixed value instead of the minimum supported TLS version
+of the client avoids leaking information about the client's support
+for less secure versions of TLS that may be useful for an attacker,
+particularly if the client implements any TLS version fallback logic.
+See {{backward-compatibility}} for more information regarding
+negotiations with endpoints supporting other versions.
+
+Implementations MUST NOT send zero-length fragments of Handshake, Alert, or
+ChangeCipherSpec content types. Zero-length fragments of Application data MAY
 be sent as they are potentially useful as a traffic analysis countermeasure.
 
 
@@ -3473,8 +3480,8 @@ value { 03, XX } as the record layer version number for ClientHello.
 ### Negotiating with buggy servers
 
 Some server implementations are known to implement version negotiation
-incorrectly. For example, there are buggy TLS 1.0 servers that simply close the
-connection when the client offers a version newer than TLS 1.0. Also, it is
+incorrectly. There are buggy TLS servers that simply close the connection
+when a client offers a version newer than it supports. Also, it is
 known that some servers will refuse the connection if any TLS extensions are
 included in ClientHello. Interoperability with such buggy servers is a complex
 topic beyond the scope of this document, and may require multiple connection

--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -3486,6 +3486,10 @@ suites also supported by TLS 1.3 SHOULD be preferred, if available.
 Implementations MUST NOT offer or negotiate RC4 cipher suites for any version.
 [I-D.ietf-tls-prohibiting-rc4]
 
+Old versions of TLS permitted the usage of very low strength ciphers.
+Ciphers with a strength less than 100 bits MUST NOT be offered or
+negotiated for any version.
+
 ### Negotiating with buggy servers
 
 Some server implementations are known to implement version negotiation

--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -3489,7 +3489,7 @@ Implementations MUST NOT offer or negotiate RC4 cipher suites for any version.
 [I-D.ietf-tls-prohibiting-rc4]
 
 Old versions of TLS permitted the usage of very low strength ciphers.
-Ciphers with a strength less than 100 bits MUST NOT be offered or
+Ciphers with a strength less than 112 bits MUST NOT be offered or
 negotiated for any version.
 
 ### Negotiating with buggy servers

--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -965,7 +965,7 @@ type
 
 version
 : The version of the protocol being employed in the current record.
-  For the initial ClientHello this MUST be { 3, 1 }.
+  TLS clients MUST set this version to { 3, 1 } for the initial ClientHello.
   For the ServerHello and all other TLS records this MUST be equal to the negotiated version.
   For TLS 1.3 connections, this version is { 3, 4 }.
 
@@ -991,6 +991,8 @@ Using this fixed value instead of the minimum supported TLS version
 of the client avoids leaking information about the client's support
 for less secure versions of TLS that may be useful for an attacker,
 particularly if the client implements any TLS version fallback logic.
+In order to maximise backwards compatibility with clients,
+TLS servers MUST accept any value { 03, XX } for this version in a ClientHello.
 See {{backward-compatibility}} for more information regarding
 negotiations with endpoints supporting other versions.
 

--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -3476,11 +3476,10 @@ server will proceed with a TLS 1.0 ServerHello. If the server only supports
 versions greater than client_version, it MUST send a "protocol_version"
 alert message and close the connection.
 
-Earlier versions of the TLS specification were not fully clear on what the
-record layer version number (TLSPlaintext.record_version) should contain when sending
-ClientHello (i.e., before it is known which version of the protocol will be
-employed). Thus, TLS servers compliant with this specification MUST accept any
-value { 03, XX } as the record layer version number for ClientHello.
+Note that earlier versions of TLS did not clearly specify the record layer
+version number value in all cases (TLSPlaintext.record_version). Servers
+will receive various TLS 1.x versions in this field, however its value
+MUST always be ignored.
 
 ## Backwards Compatibility Security Restrictions
 


### PR DESCRIPTION
This does the following:
1) Reorganize the backwards compatibility section into subsections for easier readability
2) Freezes the ClientHello record layer version to TLS 1.0 (its effective compatible version)
3) Adds explicit requirement that all other record layer versions match the negotiated version

This plus PR #105 should be sufficient to close issue #54.

The record layer requirements were proposed by Brian Smith on the list.
http://www.ietf.org/mail-archive/web/tls/current/msg14870.html
(also mentioned by him in other discussions)