### PR TITLE
use full hello message version field names

### DIFF
--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -3496,10 +3496,10 @@ Implementations MUST NOT send or accept any records with a version less than { 3
 The security of SSL 3.0 {{SSL3}} is considered insufficient for the reasons enumerated
 in [I-D.ietf-tls-sslv3-diediedie], and MUST NOT be negotiated for any reason.
 
-Implementations MUST NOT send a ClientHello.version or ServerHello.version set
-to { 3, 0 } or less. Any endpoint receiving a Hello message with
-ClientHello.version or ServerHello.version set to { 3, 0 } MUST respond with a
-"protocol_version" alert message and close the connection.
+Implementations MUST NOT send a ClientHello.client_version or ServerHello.server_version
+set to { 3, 0 } or less. Any endpoint receiving a Hello message with
+ClientHello.client_version or ServerHello.server_version set to { 3, 0 } MUST respond
+with a "protocol_version" alert message and close the connection.
 
 #  Security Analysis
 


### PR DESCRIPTION
More clear if the exact field names are used properly, instead of the *.version naming that might be confusing.