### PR TITLE
drop obsolete recommendation of 1024-bit DHE as secure

### DIFF
--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -3336,10 +3336,10 @@ Users should be able to view information about the certificate and root CA.
 TLS supports a range of key sizes and security levels, including some that
 provide no or minimal security. A proper implementation will probably not
 support many cipher suites. For instance, anonymous Diffie-Hellman is strongly
-discouraged because it cannot prevent man- in-the-middle attacks. Applications
+discouraged because it cannot prevent man-in-the-middle attacks. Applications
 should also enforce minimum and maximum key sizes. For example, certificate
-chains containing 512- bit RSA keys or signatures are not appropriate for
-high-security applications.
+chains containing keys or signatures weaker than 2048-bit RSA are not appropriate
+for secure applications.
 
 ## Implementation Pitfalls
 

--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -1413,15 +1413,12 @@ Note that higher layers should not be overly reliant on whether TLS always
 negotiates the strongest possible connection between two peers. There are a
 number of ways in which a man-in-the-middle attacker can attempt to make two
 entities drop down to the least secure method they support. The protocol has
-been designed to minimize this risk, but there are still attacks available: for
-example, an attacker could block access to the port a secure service runs on,
+been designed to minimize this risk, but there are still attacks available. For
+example, an attacker could block access to the port a secure service runs on
 or attempt to get the peers to negotiate an unauthenticated connection. The
 fundamental rule is that higher levels must be cognizant of what their security
 requirements are and never transmit information over a channel less secure than
-what they require. The TLS protocol is secure in that any cipher suite offers
-its promised level of security: if you negotiate AES-GCM {{GCM}} with
-a 1024-bit DHE key exchange with a host whose certificate you have
-verified, you can expect to be that secure.
+what they require.
 
 These goals are achieved by the handshake protocol, which can be
 summarized as follows: The client sends a ClientHello message which

--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -1418,7 +1418,13 @@ example, an attacker could block access to the port a secure service runs on
 or attempt to get the peers to negotiate an unauthenticated connection. The
 fundamental rule is that higher levels must be cognizant of what their security
 requirements are and never transmit information over a channel less secure than
-what they require.
+what they require. The TLS protocol is secure in that any cipher suite offers
+its promised level of security: if you negotiate AES-GCM {{GCM}} with
+a 255-bit ECDHE or 3072-bit DHE key exchange with a host whose certificate
+chain you have verified, you can expect that to be reasonably secure.
+
+[[TODO: Cite Curve25519 TLS I-D/RFC when available, or whatever other
+curve at the ~128-bit security level is decided to be TLS 1.3 MTI. ]]
 
 These goals are achieved by the handshake protocol, which can be
 summarized as follows: The client sends a ClientHello message which

--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -1420,11 +1420,8 @@ fundamental rule is that higher levels must be cognizant of what their security
 requirements are and never transmit information over a channel less secure than
 what they require. The TLS protocol is secure in that any cipher suite offers
 its promised level of security: if you negotiate AES-GCM {{GCM}} with
-a 255-bit ECDHE or 3072-bit DHE key exchange with a host whose certificate
+a 255-bit ECDHE key exchange with a host whose certificate
 chain you have verified, you can expect that to be reasonably secure.
-
-[[TODO: Cite Curve25519 TLS I-D/RFC when available, or whatever other
-curve at the ~128-bit security level is decided to be TLS 1.3 MTI. ]]
 
 These goals are achieved by the handshake protocol, which can be
 summarized as follows: The client sends a ClientHello message which
@@ -3344,8 +3341,8 @@ provide no or minimal security. A proper implementation will probably not
 support many cipher suites. For instance, anonymous Diffie-Hellman is strongly
 discouraged because it cannot prevent man-in-the-middle attacks. Applications
 should also enforce minimum and maximum key sizes. For example, certificate
-chains containing keys or signatures weaker than 2048-bit RSA are not appropriate
-for secure applications.
+chains containing keys or signatures weaker than 2048-bit RSA or 224-bit ECDSA
+are not appropriate for secure applications.
 
 ## Implementation Pitfalls
 


### PR DESCRIPTION
A newer recommendation could be put in as a replacement, however I don't think the sentence adds anything to the explanation, nor do I expect whatever could be recommended to hold up forever.

Also fix some punctuation in the same paragraph.