### PR TITLE
relax certificate_list ordering requirements to match current practice

### DIFF
--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -2665,10 +2665,13 @@ Note: Prior to TLS 1.3, "certificate_list" ordering was required to be strict,
 however some implementations already allowed for some flexibility. For maximum
 compatibility, all implementations SHOULD be prepared to handle potentially
 extraneous certificates and arbitrary orderings from any TLS version (with
-the exception of the sender's certificate, which is expected to be first). Some
-servers are configured to send both a current and deprecated intermediate for
-transitional purposes, and others were simply configured incorrectly, but these
-cases can nonetheless can be validated properly by clients capable of doing so.
+the exception of the sender's certificate). Some servers are configured to send
+both a current and deprecated intermediate for transitional purposes, and others
+are simply configured incorrectly, but these cases can nonetheless be validated
+properly by clients capable of doing so. Whilst the chain MAY be ordered in a
+variety of ways, the peer's end-entity certificate MUST be the first element in
+the vector, and implementations MUST abort with a fatal "bad_certificate" alert
+in the event that this is not the case.
 
 The same message type and structure will be used for the client's response to a
 certificate request message. Note that a client MAY send no certificates if it

--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -2649,15 +2649,24 @@ Structure of this message:
        } Certificate;
 
 certificate_list
-: This is a sequence (chain) of certificates.  The server's
-  certificate MUST come first in the list.  Each following
-  certificate MUST directly certify the one preceding it.  Because
-  certificate validation requires that root keys be distributed
-  independently, the self-signed certificate that specifies the root
-  certification authority (CA) MAY be omitted from the chain, under the
-  assumption that the client must already possess it in order to
-  validate it in any case.
+: This is a sequence (chain) of certificates. The sender's
+  certificate MUST come first in the list. Each following
+  certificate SHOULD directly certify one preceding it. Because
+  certificate validation requires that trust anchors be distributed
+  independently, a self-signed certificate that specifies a
+  trust anchor MAY be omitted from the chain, provided that
+  supported peers are known to possess any omitted certificates
+  they may require.
 {:br }
+
+Note: Prior to TLS 1.3, "certificate_list" ordering was required to be strict,
+however some implementations already allowed for some flexibility. For maximum
+compatibility, all implementations SHOULD be prepared to handle potentially
+extraneous certificates and arbitrary orderings from any TLS version (with
+the exception of the sender's certificate, which is expected to be first). Some
+servers are configured to send both a current and deprecated intermediate for
+transitional purposes, and others were simply configured incorrectly, but these
+cases can nonetheless can be validated properly by clients capable of doing so.
 
 The same message type and structure will be used for the client's response to a
 certificate request message. Note that a client MAY send no certificates if it

--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -321,6 +321,8 @@ draft-08
  
 - Reduce maximum permitted record expansion for AEAD from 2048 to 256 octets.
 
+- Relax certificate_list ordering requirement to match current practice.
+
 
 draft-07
 
@@ -3704,6 +3706,10 @@ that negotiate the use of TLS 1.0-1.2 SHOULD set the record layer
 version number to the negotiated version for the ServerHello and all
 records thereafter.
 
+For maximum compatibility with previously non-standard behavior and misconfigured
+deployments, all implementations SHOULD support validation of certificate chains
+based on the expectations in this document, even when handling prior TLS versions'
+handshakes. (see {{server-certificate}})
 
 ## Negotiating with an older server
 


### PR DESCRIPTION
Current client implementations allow more flexible certificate ordering than the spec allows and some server implementations send certificates in orders that the spec says "MUST" not be done. Relaxing the language here to a "SHOULD" is appropriate so implementers following this spec know that such situations need to be handled. Enforcing this more strictly would cause interop problems for no practical gain.

The modified language here is based on the mailing list discussion.