### PR TITLE
remove errant "--- back" line

### DIFF
--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -3040,7 +3040,6 @@ In addition, this document defines two new registries to be maintained by IANA:
   inclusive are assigned via Specification Required {{RFC2434}}.
   Values from 224-255 (decimal) inclusive are reserved for Private
   Use {{RFC2434}}.
---- back
 
 
 # Protocol Data Structures and Constant Values


### PR DESCRIPTION
There's a line at the end of the "IANA Considerations" section that just has the content "--- back". It's seemingly not valid markup for anything. It looks like it was introduced in the initial conversion to markdown, but has been left in there ever since. I'm pretty sure it's some accidental cruft added from the conversion, but I'm not 100% sure. (copy/paste from an editor?)

It doesn't seem to have a purpose, though of course, please correct me if I'm wrong. Here's a PR to just delete the line.