### PR TITLE
fix security considerations

### DIFF
--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -2969,8 +2969,8 @@ are treated as transparent data to the record layer.
 
 #  Security Considerations
 
-Security issues are discussed throughout this memo, especially in Appendices D,
-E, and F.
+Security issues are discussed throughout this memo, especially in Appendices C,
+D, and E.
 
 
 #  IANA Considerations


### PR DESCRIPTION
Removal of the glossary re-assigned the appendix letters, so the ones referenced here are all one earlier.