### PR TITLE
Deprecate old curves, MD5, & SHA-224 (for issue #186)

### DIFF
--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -33,7 +33,6 @@ normative:
   RFC2104:
   RFC2119:
   RFC2434:
-  RFC1321:
   RFC3447:
   RFC5280:
   RFC5288:
@@ -92,6 +91,7 @@ normative:
 
 informative:
   RFC0793:
+  RFC1321:
   RFC1948:
   RFC2246:
   RFC3268:
@@ -309,7 +309,15 @@ server: The endpoint which did not initiate the TLS connection.
 ##  Major Differences from TLS 1.2
 
 
+draft-08
+
+- Remove support for weak and lesser used named curves.
+
+- Remove support for MD5 and SHA-224 hashes with signatures.
+
+
 draft-07
+
 - Integration of semi-ephemeral DH proposal.
 
 - Add initial 0-RTT support
@@ -331,17 +339,12 @@ draft-06
 
 - Remove explicit IV.
 
-- Remove support for weak and lesser used named curves.
-
-- Remove support for MD5 and SHA-224 hashes with signatures.
-
 
 draft-05
 
 - Prohibit SSL negotiation for backwards compatibility.
 
 - Fix which MS is used for exporters.
-
 
 
 draft-04
@@ -357,6 +360,7 @@ draft-04
 - Remove renegotiation.
 
 - Remove point format negotiation.
+
 
 draft-03
 


### PR DESCRIPTION
Not sure if the deprecation cutoff will be at 224 bits (~112 bit security level) or 255 bits (~128 bit security level) yet, so I've just done the former for now.

This drops the old curves under 224 bits, updates the extension example bytes, and deprecates MD5.