### PR TITLE
update RFC refs

### DIFF
--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -4,7 +4,7 @@ abbrev: TLS
 docname: draft-ietf-tls-tls13-latest
 category: std
 updates: 4492
-obsoletes: 3268, 4346, 4366, 5246, 5077
+obsoletes: 5077, 5246
 
 ipr: pre5378Trust200902
 area: General

--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -94,7 +94,6 @@ informative:
   RFC0793:
   RFC1948:
   RFC2246:
-  RFC3268:
   RFC4086:
   RFC4279:
   RFC4302:
@@ -2950,10 +2949,9 @@ Structure of this message:
 The verify_data value is computed as follows:
 
 verify_data
-:      HMAC(finished_secret, finished_label + '\0' + handshake_hash)
-       where HMAC uses the Hash algorithm for the handshake.
-       See {{the-handshake-hash}} for the definition of
-       handshake_hash.
+: HMAC(finished_secret, finished_label + '\0' + handshake_hash)
+  where HMAC {{RFC2104}} uses the Hash algorithm for the handshake.
+  See {{the-handshake-hash}} for the definition of handshake_hash.
 
 finished_label
 : For Finished messages sent by the client, the string
@@ -3154,7 +3152,7 @@ These shared secret values are used to generate cryptographic keys as
 shown below. 
 
 The derivation process is as follows, where L denotes the length of
-the underlying hash function for HKDF.
+the underlying hash function for HKDF {{RFC5869}}.
 
 ~~~
   HKDF-Expand-Label(Secret, Label, HashValue, Length) =


### PR DESCRIPTION
Use refs for HKDF & HMAC in the document and drop the unused AES CBC RFC ref in favor of the AES GCM RFCs (refs already in use).

Caught via Travis warnings that they were all unused. It also notes that RFC 2246 (TLS 1.0) isn't referenced directly and RFC 5705 isn't used, either.

@ekr: You probably wanted to reference RFC 5705 somewhere in your recent work, but it's not currently used. Travis also complains about I-D.ietf-tls-session-hash, though that is referenced in the credits. It probably should be referenced somewhere too.