### PR TITLE
Copy edit certificate_list changes

### DIFF
--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -2728,20 +2728,20 @@ certificate_list
   certificate MUST come first in the list. Each following
   certificate SHOULD directly certify one preceding it. Because
   certificate validation requires that trust anchors be distributed
-  independently, a self-signed certificate that specifies a
+  independently, a certificate that specifies a
   trust anchor MAY be omitted from the chain, provided that
-  supported peers are known to possess any omitted certificates
-  they may require.
+  supported peers are known to possess any omitted certificates.
 {:br }
 
-Note: Prior to TLS 1.3, "certificate_list" ordering was required to be strict,
-however some implementations already allowed for some flexibility. For maximum
+Note: Prior to TLS 1.3, "certificate_list" ordering required each certificate
+to certify the one immediately preceding it.
+However some implementations allowed some flexibility, since some servers send
+both a current and deprecated intermediate for transitional purposes, and others
+are simply configured incorrectly, but could nonetheless be validated
+properly. For maximum
 compatibility, all implementations SHOULD be prepared to handle potentially
 extraneous certificates and arbitrary orderings from any TLS version (with
-the exception of the sender's certificate). Some servers are configured to send
-both a current and deprecated intermediate for transitional purposes, and others
-are simply configured incorrectly, but these cases can nonetheless be validated
-properly by clients capable of doing so. Although the chain MAY be ordered in a
+the exception of the sender's certificate).  Although the chain MAY be ordered in a
 variety of ways, the peer's end-entity certificate MUST be the first element in
 the vector.
 

--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -2735,7 +2735,7 @@ certificate_list
 
 Note: Prior to TLS 1.3, "certificate_list" ordering required each certificate
 to certify the one immediately preceding it.
-However some implementations allowed some flexibility, since some servers send
+However some implementations allowed some flexibility since some servers send
 both a current and deprecated intermediate for transitional purposes, and others
 are simply configured incorrectly, but could nonetheless be validated
 properly. For maximum


### PR DESCRIPTION
Remove self-signed, since the key point is that it's a trust anchor that was independently distributed.  Note here that some trust anchors are signed, though that usually indicates a reason for it to be included, the signing might persist for longer than the actual need for it.

Also the explanation had more words than it needed.

n.b., I only loosely wrapped this stuff, if you want a proper wrapping of lines, name a preferred wrap column, because I couldn't work out what to do here.