### PR TITLE
Suggested wording change to Resumption and PSK section.

### DIFF
--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -1767,11 +1767,10 @@ Subsequent Handshake:
 ~~~
 {: #tls-resumption-psk title="Message flow for resumption and PSK"}
 
-Note that the client supplies a ClientKeyShare to the server as well, which
-allows the server to decline resumption and fall back to a full handshake.
-However, because the server is authenticating via a PSK, it does not
+As the server is authenticating via a PSK, it does not
 send a Certificate or a CertificateVerify. PSK-based resumption cannot
-be used to provide a new ServerConfiguration.
+be used to provide a new ServerConfiguration. Note that the client supplies a ClientKeyShare to the server as well, which
+allows the server to decline resumption and fall back to a full handshake. 
 
 The contents and significance of each message will be presented in detail in
 the following sections.


### PR DESCRIPTION
The current wording at the end of the section on resumption and PSK should be changed to indicate that if a server declines resumption then a full handshake, including the server Certificate and CertificateVerify messages, should take place. In its current state, the comment on omission of these messages is not disjoint from the statement regarding the server's rejection of resumption.  