### PR TITLE
promote RFC 6066 to normative reference

### DIFF
--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -38,6 +38,7 @@ normative:
   RFC5288:
   RFC5289:
   RFC5869:
+  RFC6066:
   RFC6209:
   RFC6367:
   RFC6655:
@@ -113,7 +114,6 @@ informative:
   RFC5246:
   RFC5705:
   RFC5763:
-  RFC6066:
   RFC6176:
   RFC7465:
   RFC7507:


### PR DESCRIPTION
SNI is now MTI (all MUST support; clients SHOULD send when applicable; servers MAY require it)

Thus, RFC 6066 in which it is defined is now a normative reference, not informative.

https://www.ietf.org/iesg/statement/normative-informative.html