### PR TITLE
Minor fix of syntax for SigAlg enum

### DIFF
--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -2151,13 +2151,13 @@ The "extension_data" field of this extension contains a
            (255)
        } HashAlgorithm;
 
-       enum { 
+       enum {
            anonymous_RESERVED(0),
-           rsa(1), 
-           dsa_RESERVED(2), 
-           ecdsa(3), 
-           (255) }
-         SignatureAlgorithm;
+           rsa(1),
+           dsa_RESERVED(2),
+           ecdsa(3),
+           (255)
+       } SignatureAlgorithm;
 
        struct {
            HashAlgorithm hash;


### PR DESCRIPTION
Missed that when rebasing. sry.