### PR TITLE
fix HkdfLabel.label min length

### DIFF
--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -3320,7 +3320,7 @@ in some cases, the extracted xSS and xES will not.
   struct HkdfLabel {
     uint16 length;
     opaque hash_value<0..255>;
-    opaque label<8..255>;
+    opaque label<9..255>;
   };
 
   Where:


### PR DESCRIPTION
The current min size of HkdfLabel.label is impossible. Here's a PR for a trivial fix by increasing it.

HkdfLabel.label = "TLS 1.3, " + Label
("TLS 1.3, ").length = 9
if Label.length >=1 then
HkdfLabel.label.length >= 10

It can never be 8 or 9 bytes long.

next power of two is 16, so might as well do:
opaque label<16..255>;
which has 9 bytes for version prefix & a minimum of 7 for the label (current shortest is 15 bytes)