### PR TITLE
revise HelloRetryRequest

### DIFF
--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -2066,12 +2066,11 @@ extensions
 
 When this message will be sent:
 
-> Servers send this message in response to a ClientHello
-message when it was able to find an acceptable set of algorithms and
-groups that are mutually supported, but
-the client's ClientKeyShare did not contain an acceptable
-value. If it cannot find such a match, it will respond with a fatal
-"handshake_failure" alert.
+> Servers send this message in response to a ClientHello message when it
+was able to find an acceptable set of algorithms and groups that are
+mutually supported, but the client's ClientKeyShare did not contain an
+acceptable value. If it cannot find such a match, it will respond with a
+fatal "handshake_failure" alert.
 
 Structure of this message:
 
@@ -2089,35 +2088,40 @@ selected_group
 : The group which the client MUST use for its new ClientHello.
 {:br }
 
-The server_version, cipher_suite, and extensions fields have the
-same meanings as their corresponding values in the ServerHello. The
-server SHOULD send only the extensions necessary for the client to
-generate a correct ClientHello pair. As with a ServerHello, only
-extensions first offered by the client can appear in a HelloRetryRequest.
+The server_version, cipher_suite, and extensions fields have the same
+meanings as their corresponding values in the ServerHello. The server
+SHOULD send only the extensions necessary for the client to generate a
+correct ClientHello pair. As with a ServerHello, only extensions first
+offered by the client can appear in a HelloRetryRequest.
 
-Upon receipt of a HelloRetryRequest, the client MUST first verify
-that the selected_group was offered in its "supported_groups" extension and
-that no ClientKeyShareOffer for the selected_group was offered in its "client_key_share"
-extension. If either of these conditions are detected, then the client
-MUST abort the handshake with a fatal "handshake_failure"
-alert. Clients SHOULD also abort with an "handshake_failure" alert in response to any second
-HelloRetryRequest which is sent on the same connection (i.e.,
-where the ClientHello was itself in response to a HelloRetryRequest).
+Upon receipt of a HelloRetryRequest, the client MUST first verify that
+the selected_group was offered in its "supported_groups" extension and
+that no ClientKeyShareOffer for the selected_group was offered in its
+"client_key_share" extension. If either of these conditions are detected,
+then the client MUST abort the handshake with a fatal "handshake_failure"
+alert.
 
-If the HelloRetryRequest is verified as acceptable, the client MUST send a new
-ClientHello with an updated ClientKeyShare extension to the server. This ClientKeyShare MUST contain
-the exact previous set of offered keys with a new ClientKeyShareOffer value for the server's selected_group
-appended to the end of the list (or a new extension with exactly one value, if none was provided initially).
-All other fields in this new ClientHello MUST match the first attempt.
-Note that omitting any information previously included in the initial ClientHello
-introduces the risk of downgrade attack, as this retry exchange is unauthenticated.
+Clients SHOULD also abort with an "handshake_failure" alert in response
+to any second HelloRetryRequest which is sent on the same connection
+(i.e., where the ClientHello was itself in response to a
+HelloRetryRequest).
+
+If the HelloRetryRequest is verified as acceptable, the client MUST send
+a new ClientHello with an updated ClientKeyShare extension to the server.
+This ClientKeyShare MUST contain the exact previous set of offered keys
+with a new ClientKeyShareOffer value for the server's selected_group
+appended to the end of the list (or a new extension with exactly one
+value, if none was provided initially). All other fields in this new
+ClientHello MUST match the first attempt. Note that omitting any
+information previously included in the initial ClientHello introduces
+the risk of downgrade attack, as this retry exchange is unauthenticated.
 
 After sending the new ClientHello and receiving a new ServerHello,
 the client MUST verify that the same ProtocolVersion, CipherSuite, and
 NamedGroup specified in the server's HelloRetryRequest are selected in the
-server's new ServerHello/ServerKeyShare. If any of these values
-differ, the client MUST abort the connection with a fatal
-"handshake_failure" alert.
+server's new ServerHello/ServerKeyShare. If any of these values differ,
+the client MUST abort the connection with a fatal "handshake_failure"
+alert.
 
 [[OPEN ISSUE: https://github.com/tlswg/tls13-spec/issues/104]]
 

--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -2068,8 +2068,8 @@ When this message will be sent:
 
 > Servers send this message in response to a ClientHello message when it
 was able to find an acceptable set of algorithms and groups that are
-mutually supported, but the client's ClientKeyShare did not contain an
-acceptable value. If it cannot find such a match, it will respond with a
+mutually supported, but the client's ClientKeyShare offer did not contain an
+acceptable value. If it cannot find such a match, it MUST respond with a
 fatal "handshake_failure" alert.
 
 Structure of this message:
@@ -2117,8 +2117,8 @@ information previously included in the initial ClientHello introduces
 the risk of downgrade attack, as this retry exchange is unauthenticated.
 
 After sending the new ClientHello and receiving a new ServerHello,
-the client MUST verify that the same ProtocolVersion, CipherSuite, and
-NamedGroup specified in the server's HelloRetryRequest are selected in the
+the client MUST verify that the same server_version, cipher_suite, and
+selected_group specified in the server's HelloRetryRequest are selected in the
 server's new ServerHello/ServerKeyShare. If any of these values differ,
 the client MUST abort the connection with a fatal "handshake_failure"
 alert.


### PR DESCRIPTION
This is the commit with the HelloRetryRequest changes from PR #268 backported to the current master. It's mostly just editorial, with a few important fixes. There was one part with a double negative that was supposed to be a triple negative and made no sense. As I was interacting with this area in merging the DH key share methods together, I ended up rewriting this somewhat to make it easier to follow and fix the various issues. Aside from being more verbose and explicit about how to handle errors, this doesn't change any of the design in the current draft spec.

It also makes note of, but does not alter the current state of, issue #104.