### PR TITLE
fix misnamed handshake_hash in text

### DIFF
--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -3048,7 +3048,7 @@ Structure of this message:
             };
        } CertificateVerify;
 
-> Where session_hash is as described in {{the-handshake-hash}} and
+> Where handshake_hash is as described in {{the-handshake-hash}} and
 includes the messages sent or received, starting at ClientHello and up
 to, but not including, this message, including the type and length
 fields of the handshake messages. This is a digest of the


### PR DESCRIPTION
The struct contains a value named handshake_hash, not session_hash.

I apparently had fixed this in PR #189. Pulling it out separately to get it in now, as it hasn't even been decided for sure if we're doing that.