### PR TITLE
helloretryrequest fixups

### DIFF
--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -2419,14 +2419,16 @@ must consider the supported groups in both cases.
 The "key_share" extension contains the endpoint's cryptographic parameters
 for non-PSK key establishment methods (currently DHE or ECDHE).
 
-Clients which offer one or more (EC)DHE cipher suites
-MUST send at least one supported KeyShare value and
-servers MUST NOT negotiate any of these cipher suites unless a supported
+Clients which offer one or more (EC)DHE cipher suites MUST send this
+extension and SHOULD send at least one supported KeyShareEntry value.
+Servers MUST NOT negotiate any of these cipher suites unless a supported
 value was provided.
-If this extension is not provided in a ServerHello or retried ClientHello,
+If this extension is not provided in a ServerHello or ClientHello,
 and the peer is offering (EC)DHE cipher suites, then the endpoint MUST close
 the connection with a fatal "missing_extension" alert.
 (see {{mti-extensions}})
+Clients MAY send an empty client_shares vector in order to request
+group selection from the server at the cost of an additional round trip.
 
 %%% Key Exchange Messages
        struct {
@@ -2465,8 +2467,8 @@ The "extension_data" field of this extension contains a
 
 client_shares
 : A list of offered KeyShareEntry values in descending order of client preference.
-  This vector MUST NOT be empty. Clients not providing a KeyShare MUST instead
-  omit this extension from the ClientHello.
+  Servers MUST NOT negotiate any connection if this vector is empty and instead
+  MUST respond with a HelloRetryRequest (see {{hello-retry-request}}).
 
 server_share
 : A single KeyShareEntry value for the negotiated cipher suite.  Servers
@@ -2481,11 +2483,11 @@ a single set of key exchange parameters. For instance, a client might
 offer shares for several elliptic curves or multiple integer DH groups.
 The key_exchange values for each KeyShareEntry MUST by generated independently.
 Clients MUST NOT offer multiple KeyShareEntry values for the same parameters.
-Clients MAY omit this extension from the ClientHello, and in response to this,
-servers MUST send a HelloRetryRequest requesting use of one of the
-groups the client offered support for in its "supported_groups"
-extension. If no common supported group is available, the server MUST
-produce a fatal "handshake_failure" alert. (see {{hello-retry-request}})
+Clients and servers MUST NOT offer any KeyShareEntry values for groups not
+listed in the client's "supported_groups" extension.
+If the client provides a non-empty client_shares vector and
+no common supported group is available, the server MUST abort the connection
+with a fatal "handshake_failure" alert.
 
 [[TODO: Recommendation about what the client offers.
 Presumably which integer DH groups and which curves.]]

--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -2488,6 +2488,8 @@ Clients and servers MUST NOT offer any KeyShareEntry values for groups not
 listed in the client's "supported_groups" extension.
 Servers MUST NOT offer a KeyShareEntry value for a group not offered by the
 client in its corresponding KeyShare.
+Implementations receiving any KeyShare containing any of these prohibited
+values MUST abort the connection with a fatal "illegal_parameter" alert.
 
 If no mutually supported group is available between the two endpoints' KeyShare
 offers, yet there is a mutually supported group that can be found via the

--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -2094,7 +2094,7 @@ message when it was able to find an acceptable set of algorithms and
 groups that are mutually supported, but
 the client's KeyShare did not contain an acceptable
 offer. If it cannot find such a match, it will respond with a
-"handshake_failure" alert.
+fatal "handshake_failure" alert.
 
 Structure of this message:
 
@@ -2109,18 +2109,21 @@ Structure of this message:
 [[OPEN ISSUE: Merge in DTLS Cookies?]]
 
 selected_group
-: The group which the client MUST use for its new ClientHello.
+: The mutually supported group the server intends to negotiate and
+  is requesting a retried ClientHello/KeyShare for.
 {:br }
 
-The "server_version", "cipher_suite" and "extensions" fields have the
+The server_version, cipher_suite, and extensions fields have the
 same meanings as their corresponding values in the ServerHello. The
 server SHOULD send only the extensions necessary for the client to
-generate a correct ClientHello pair.
+generate a correct ClientHello pair. As with ServerHello, a
+HelloRetryRequest MUST NOT contain any extensions that were not first
+offered by the client in its ClientHello.
 
 Upon receipt of a HelloRetryRequest, the client MUST first verify that
-the "selected_group" field corresponds to a group which was provided
+the selected_group field corresponds to a group which was provided
 in the "supported_groups" extension in the original ClientHello.  It
-MUST then verify that the "selected_group" field does not correspond
+MUST then verify that the selected_group field does not correspond
 to a group which was provided in the "key_share" extension in the
 original ClientHello. If either of these checks fails, then the client
 MUST abort the handshake with a fatal "handshake_failure"
@@ -2129,15 +2132,16 @@ to any second HelloRetryRequest which was sent in the same connection
 (i.e., where the ClientHello was itself in response to a
 HelloRetryRequest).
 
-Otherwise, the client MUST send a ClientHello with a new KeyShare
+Otherwise, the client MUST send a ClientHello with an updated KeyShare
 extension to the server. The client MUST append a new KeyShareEntry
-list which is consistent with the "selected_group" field to the groups
+for the group indicated in the selected_group field to the groups
 in its original KeyShare.
 
 Upon re-sending the ClientHello and receiving the
 server's ServerHello/KeyShare, the client MUST verify that
 the selected CipherSuite and NamedGroup match that supplied in
-the HelloRetryRequest.
+the HelloRetryRequest. If either of these values differ, the client
+MUST abort the connection with a fatal "handshake_failure" alert.
 
 [[OPEN ISSUE: https://github.com/tlswg/tls13-spec/issues/104]]
 


### PR DESCRIPTION
@ekr: You addressed the main ambiguity in https://github.com/tlswg/tls13-spec/commit/74c4c7da1bf5bcea4f75cfc38c1aedb406098d3d#diff-9d84740dcc569a0a5a359d0fba461a05L2097 . This fixes a few remaining issues. An itemized list:
* "handshake_failure" alert is fatal
* note it must be appended, not just "used", in the selected_group description (just using instead of appending creates a downgrade attack due to lack of authentication for this message, as discussed previously)
* clean up styling of variable names; the dominant style uses no quotes around variable names, but quotes around enum values (granted, this may not be the ideal style, but it is more or less consistently the case elsewhere in the document)
* note that the same rule as ServerHello applies: no extensions the client did not offer first
* update text to deal with possibility of omitted extension
* minor wording simplification
* specify error to use if "MUST" fails (could be a "SHOULD" error, here)