### PR TITLE
Control SHA-1 with signature_algorithms

### DIFF
--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -2255,11 +2255,13 @@ hash
   and SHA-512 {{SHS}}, respectively. The "none" value is provided for
   future extensibility, in case of a signature algorithm which does
   not require hashing before signing.  Previous versions of TLS
-  supported MD5 and SHA-1. These algorithms are now deprecated and
-  MUST NOT be offered by TLS 1.3 implementations.  SHA-1 SHOULD NOT be
-  offered, however clients willing to negotiate use of TLS 1.2 MAY
-  offer support for SHA-1 for backwards compatibility with old
-  servers.
+  supported MD5 and SHA-1.  These algorithms are now deprecated.
+  MD5 MUST NOT be offered by TLS 1.3 implementations; SHA-1 SHOULD
+  NOT be offered.
+
+  Clients MAY offer support for SHA-1 for backwards compatibility,
+  either with TLS 1.2 servers or for servers that have certificate
+  chains with signatures based on SHA-1.
 
 signature
 : This field indicates the signature algorithm that may be used.
@@ -2279,7 +2281,7 @@ suite indicates permissible signature algorithms but not hash algorithms.
 {{server-certificate-selection}} and {{key-share}} describe the
 appropriate rules.
 
-Clients offering support for SHA-1 for TLS 1.2 servers MUST do so by listing
+Clients offering support for SHA-1 for backwards compatibility MUST do so by listing
 those hash/signature pairs as the lowest priority (listed after all other
 pairs in the supported_signature_algorithms vector). TLS 1.3 servers MUST NOT
 offer a SHA-1 signed certificate unless no valid certificate chain can be
@@ -3183,7 +3185,8 @@ If the server cannot produce a certificate chain that is signed only via the
 indicated supported pairs, then it SHOULD continue the handshake by sending
 the client a certificate chain of its choice that may include algorithms
 that are not known to be supported by the client. This fallback chain MAY
-use the deprecated SHA-1 hash algorithm.
+use the deprecated SHA-1 hash algorithm only if the "signature_algorithms"
+extension provided by the client permits it.
 If the client cannot construct an acceptable chain using the provided
 certificates and decides to abort the handshake, then it MUST send an
 "unsupported_certificate" alert message and close the connection.

--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -2262,8 +2262,8 @@ hash
   NOT be offered.
 
   Clients MAY offer support for SHA-1 for backwards compatibility,
-  either with TLS 1.2 servers or for servers that have certificate
-  chains with signatures based on SHA-1.
+  either with TLS 1.2 servers or for servers that have certification
+  paths with signatures based on SHA-1.
 
 signature
 : This field indicates the signature algorithm that may be used.
@@ -2290,8 +2290,9 @@ offer a SHA-1 signed certificate unless no valid certificate chain can be
 produced without it (see {{server-certificate-selection}}).
 
 The signatures on certificates that are self-signed or certificates that are
-trust anchors are not validated.  Thus, a self-signed certificate or trust
-anchor MAY use a hash or signature algorithm that is not advertised as being
+trust anchors are not validated since they begin a certification path (see
+{{RFC5280}}, Section 3.2).  A certificate that begins a certification
+path MAY use a hash or signature algorithm that is not advertised as being
 supported in the signature_algorithms extension.
 
 Note: TLS 1.3 servers MAY receive TLS 1.2 ClientHellos which do not contain
@@ -2846,7 +2847,7 @@ using an MD5 hash MUST send a "bad_certificate" alert message and close
 the connection.
 
 As SHA-1 and SHA-224 are deprecated, support for them is NOT RECOMMENDED.
-Endpoints that reject chains due to use of a deprecated hash MUST send
+Endpoints that reject certification paths due to use of a deprecated hash MUST send
 a fatal "bad_certificate" alert message before closing the connection.
 All servers are RECOMMENDED to transition to SHA-256 or better as soon
 as possible to maintain interoperability with implementations
@@ -3258,7 +3259,7 @@ using an MD5 hash MUST send a "bad_certificate" alert message and close
 the connection.
 
 SHA-1 is deprecated and therefore NOT RECOMMENDED.
-Endpoints that reject chains due to use of a deprecated hash MUST send
+Endpoints that reject certification paths due to use of a deprecated hash MUST send
 a fatal "bad_certificate" alert message before closing the connection.
 All endpoints are RECOMMENDED to transition to SHA-256 or better as soon
 as possible to maintain interoperability with implementations
@@ -4012,7 +4013,7 @@ Users should be able to view information about the certificate and root CA.
 TLS supports a range of key sizes and security levels, including some that
 provide no or minimal security. A proper implementation will probably not
 support many cipher suites. Applications SHOULD also enforce minimum and
-maximum key sizes. For example, certificate chains containing keys or
+maximum key sizes. For example, certification paths containing keys or
 signatures weaker than 2048-bit RSA or 224-bit ECDSA are not appropriate
 for secure applications.
 See also {{backwards-compatibility-security-restrictions}}.
@@ -4099,7 +4100,7 @@ version number to the negotiated version for the ServerHello and all
 records thereafter.
 
 For maximum compatibility with previously non-standard behavior and misconfigured
-deployments, all implementations SHOULD support validation of certificate chains
+deployments, all implementations SHOULD support validation of certification paths
 based on the expectations in this document, even when handling prior TLS versions'
 handshakes. (see {{server-certificate-selection}})
 

--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -2257,7 +2257,7 @@ hash
   not require hashing before signing.
 
   Previous versions of TLS
-  supported MD5, SHA-1 and SHA-224.  These algorithms are now deprecated.
+  supported MD5, SHA-1, and SHA-224.  These algorithms are now deprecated.
   MD5 and SHA-224 MUST NOT be offered by TLS 1.3 implementations; SHA-1 SHOULD
   NOT be offered.
 
@@ -3248,7 +3248,7 @@ Any endpoint receiving any certificate signed using any signature algorithm
 using an MD5 hash MUST send a "bad_certificate" alert message and close
 the connection.
 
-As SHA-1 is deprecated, support for them is NOT RECOMMENDED.
+SHA-1 is deprecated and therefore NOT RECOMMENDED.
 Endpoints that reject chains due to use of a deprecated hash MUST send
 a fatal "bad_certificate" alert message before closing the connection.
 All endpoints are RECOMMENDED to transition to SHA-256 or better as soon

--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -2846,7 +2846,7 @@ Any endpoint receiving any certificate signed using any signature algorithm
 using an MD5 hash MUST send a "bad_certificate" alert message and close
 the connection.
 
-As SHA-1 and SHA-224 are deprecated, support for them is NOT RECOMMENDED.
+SHA-1 is deprecated and therefore NOT RECOMMENDED.
 Endpoints that reject certification paths due to use of a deprecated hash MUST send
 a fatal "bad_certificate" alert message before closing the connection.
 All servers are RECOMMENDED to transition to SHA-256 or better as soon

--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -3363,6 +3363,8 @@ Where:
 
 HMAC
 : HMAC {{RFC2104}} using the Hash algorithm for the handshake.
+As noted above: the HMAC input can generally be implemented by a running
+hash.
 
 finished_label
 : For Finished messages sent by the client, the string
@@ -3372,10 +3374,8 @@ finished_label
   sending the messages in?]]
 {: br}
 
-As noted above: the HMAC input can generally be implemented by a running
-hash.
 
-> In previous versions of TLS, the verify_data was always 12 octets long. In
+In previous versions of TLS, the verify_data was always 12 octets long. In
 the current version of TLS, it is the size of the HMAC output for the
 Hash used for the handshake.
 

--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -3441,7 +3441,10 @@ MUST send an empty Certificate message followed by Finished.
 Note: because there may already be application data messages in
 flight, the server MUST be prepared to receive an arbitrary number
 of such messages before receiving the Authentication messages.
-
+[[TODO: We need to add a context value here to allow the server
+to ensure freshness of the signature and to correlate requests
+and responses. See:
+https://github.com/tlswg/tls13-spec/issues/262.]]
 
 #  Cryptographic Computations
 

--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -1496,10 +1496,10 @@ The basic TLS Handshake for DH is shown in {{tls-full}}:
 ~~~
        Client                                               Server
   
-Key  ^ ClientHello                                                  
-Exch v  + KeyShare               -------->                           
-                                                       ServerHello  ^ Key
-                                                        + KeyShare  v Exch
+Key  / ClientHello                                                  
+Exch \  + KeyShare               -------->                           
+                                                       ServerHello  \ Key
+                                                        + KeyShare  / Exch
                                              {EncryptedExtensions}  ^ 
                                             {ServerConfiguration*}  | Server
                                              {CertificateRequest*}  v Params
@@ -1588,7 +1588,7 @@ CertificateVerify
 
 Finished
 : a MAC over the entire handshake. This message provides key confirmation, binds the endpoint's identity
-  to the exchanged keys, and in some modes (see {{zero-rtt-exchange}}) 
+  to the exchanged keys, and in some modes (0-RTT and PSK) 
   also authenticates the handshake using the the Static Secret. [{{finished}}]
 {:br }
 

--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -1,4 +1,4 @@
- ---
+---
 title: The Transport Layer Security (TLS) Protocol Version 1.3
 abbrev: TLS
 docname: draft-ietf-tls-tls13-latest
@@ -3370,7 +3370,7 @@ finished_label
   the string "server finished" [[OPEN ISSUE: Do we still need these?
   labels? Should we expand them to indicate which phase we are
   sending the messages in?]]
-~~~
+{: br}
 
 As noted above: the HMAC input can generally be implemented by a running
 hash.

--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -2289,6 +2289,11 @@ pairs in the supported_signature_algorithms vector). TLS 1.3 servers MUST NOT
 offer a SHA-1 signed certificate unless no valid certificate chain can be
 produced without it (see {{server-certificate-selection}}).
 
+The signatures on certificates that are self-signed or certificates that are
+trust anchors are not validated.  Thus, a self-signed certificate or trust
+anchor MAY use a hash or signature algorithm that is not advertised as being
+supported in the signature_algorithms extension.
+
 Note: TLS 1.3 servers MAY receive TLS 1.2 ClientHellos which do not contain
 this extension. If those servers are willing to negotiate TLS 1.2, they MUST
 behave in accordance with the requirements of {{RFC5246}} when negotiating
@@ -2822,12 +2827,16 @@ The following rules apply to the certificates sent by the server:
 All certificates provided by the server MUST be signed by a
 hash/signature algorithm pair that appears in the "signature_algorithms"
 extension provided by the client, if they are able to provide such
-a chain (see {{signature-algorithms}}).
+a chain (see {{signature-algorithms}}).  Certificates that are self-signed
+or certificates that are expected to be trust anchors are not validated as
+part of the chain and therefore MAY be signed with any algorithm.
+
 If the server cannot produce a certificate chain that is signed only via the
 indicated supported pairs, then it SHOULD continue the handshake by sending
 the client a certificate chain of its choice that may include algorithms
 that are not known to be supported by the client. This fallback chain MAY
 use the deprecated SHA-1 hash algorithm.
+
 If the client cannot construct an acceptable chain using the provided
 certificates and decides to abort the handshake, then it MUST send an
 "unsupported_certificate" alert message and close the connection.

--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -2254,9 +2254,11 @@ hash
   values indicate support for unhashed data, SHA-1, SHA-256, SHA-384,
   and SHA-512 {{SHS}}, respectively. The "none" value is provided for
   future extensibility, in case of a signature algorithm which does
-  not require hashing before signing.  Previous versions of TLS
-  supported MD5 and SHA-1.  These algorithms are now deprecated.
-  MD5 MUST NOT be offered by TLS 1.3 implementations; SHA-1 SHOULD
+  not require hashing before signing.
+
+  Previous versions of TLS
+  supported MD5, SHA-1 and SHA-224.  These algorithms are now deprecated.
+  MD5 and SHA-224 MUST NOT be offered by TLS 1.3 implementations; SHA-1 SHOULD
   NOT be offered.
 
   Clients MAY offer support for SHA-1 for backwards compatibility,
@@ -3246,7 +3248,7 @@ Any endpoint receiving any certificate signed using any signature algorithm
 using an MD5 hash MUST send a "bad_certificate" alert message and close
 the connection.
 
-As SHA-1 and SHA-224 are deprecated, support for them is NOT RECOMMENDED.
+As SHA-1 is deprecated, support for them is NOT RECOMMENDED.
 Endpoints that reject chains due to use of a deprecated hash MUST send
 a fatal "bad_certificate" alert message before closing the connection.
 All endpoints are RECOMMENDED to transition to SHA-256 or better as soon


### PR DESCRIPTION
The current draft permits the use of SHA-1 in the certificate chain, which gives SHA-1 a free pass indefinitely.  Since we expressly forbid the use of SHA-1 for signing in TLS itself, we can just permit clients to include it in "signature_algorithms" and use that to determine whether SHA-1 is acceptable.

That means that clients that want to disable SHA-1 (real soon now, we promise), can signal that preference cleanly.

This is built on top of #316 to avoid a nasty rebase when that merges.  Just look at the final commit.