### PR TITLE
fix broken reference link

### DIFF
--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -3601,7 +3601,7 @@ The following extensions are no longer applicable to TLS 1.3, although
 TLS 1.3 clients MAY send them if they are willing to negotiate them
 with prior versions of TLS. TLS 1.3 servers MUST ignore these
 extensions if they are negotiating TLS 1.3: 
- max_fragment_length {{RFC6066},
+max_fragment_length {{RFC6066}},
 truncated_hmac {{RFC6066}},
 srp {{RFC5054}},
 encrypt_then_mac {{RFC7366}},


### PR DESCRIPTION
Fix another missing brace breaking a link.

Also drops a leading space for that line; markdown doesn't seem to need it and generates a space there anyway, just as it does for all the other lines.