### PR TITLE
EncryptedExtensions is mandatory

### DIFF
--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -2679,7 +2679,7 @@ identifier in this case.
 
 When this message will be sent:
 
-> If this message is sent, it MUST be sent immediately after the
+> The EncryptedExtensions message MUST be sent immediately after the
 ServerHello message. This is the first message that is encrypted
 under keys derived from ES.
 


### PR DESCRIPTION
I think that the decision was to make this mandatory, since present-but-empty is harder to screw up.

Closes #323.