### PR TITLE
Use correct pronoun for "client" and "attacker"

### DIFF
--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -1582,7 +1582,7 @@ Finished
   the Static Secret. [{{server-finished}}]
 {:br }
 
-Upon receiving the server's messages, the client responds with his final
+Upon receiving the server's messages, the client responds with its final
 flight of messages:
 
 Certificate
@@ -4074,7 +4074,7 @@ TLS is susceptible to a number of denial-of-service (DoS) attacks. In
 particular, an attacker who initiates a large number of TCP connections can
 cause a server to consume large amounts of CPU doing asymmetric crypto
 operations. However, because TLS is generally used over TCP, it is difficult for the
-attacker to hide his point of origin if proper TCP SYN randomization is used
+attacker to hide their point of origin if proper TCP SYN randomization is used
 {{RFC1948}} by the TCP stack.
 
 Because TLS runs over TCP, it is also susceptible to a number of DoS attacks on


### PR DESCRIPTION
The spec always uses the gender-neutral possessive pronoun "its" for "client", so I think we should definitely fix that occurrence.

Also, it seems that throughout the document we try to not use gender-specific pronouns for "attacker". I'm not sure about "their" though, as it looks like we usually try to avoid that by restructuring sentences, but I may be mistaken. We could also refer to multiple attackers?