### PR TITLE
always require key_share extension with (EC)DHE suites

### DIFF
--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -2419,14 +2419,16 @@ must consider the supported groups in both cases.
 The "key_share" extension contains the endpoint's cryptographic parameters
 for non-PSK key establishment methods (currently DHE or ECDHE).
 
-Clients which offer one or more (EC)DHE cipher suites
-MUST send at least one supported KeyShare value and
-servers MUST NOT negotiate any of these cipher suites unless a supported
+Clients which offer one or more (EC)DHE cipher suites MUST send this
+extension and SHOULD send at least one supported KeyShareEntry value.
+Servers MUST NOT negotiate any of these cipher suites unless a supported
 value was provided.
-If this extension is not provided in a ServerHello or retried ClientHello,
+If this extension is not provided in a ServerHello or ClientHello,
 and the peer is offering (EC)DHE cipher suites, then the endpoint MUST close
 the connection with a fatal "missing_extension" alert.
 (see {{mti-extensions}})
+Clients MAY send an empty client_shares vector in order to request
+group selection from the server at the cost of an additional round trip.
 
 %%% Key Exchange Messages
        struct {
@@ -2465,8 +2467,8 @@ The "extension_data" field of this extension contains a
 
 client_shares
 : A list of offered KeyShareEntry values in descending order of client preference.
-  This vector MUST NOT be empty. Clients not providing a KeyShare MUST instead
-  omit this extension from the ClientHello.
+  Servers MUST NOT negotiate any connection if this vector is empty and instead
+  MUST respond with a HelloRetryRequest (see {{hello-retry-request}}).
 
 server_share
 : A single KeyShareEntry value for the negotiated cipher suite.  Servers
@@ -2481,11 +2483,11 @@ a single set of key exchange parameters. For instance, a client might
 offer shares for several elliptic curves or multiple integer DH groups.
 The key_exchange values for each KeyShareEntry MUST by generated independently.
 Clients MUST NOT offer multiple KeyShareEntry values for the same parameters.
-Clients MAY omit this extension from the ClientHello, and in response to this,
-servers MUST send a HelloRetryRequest requesting use of one of the
-groups the client offered support for in its "supported_groups"
-extension. If no common supported group is available, the server MUST
-produce a fatal "handshake_failure" alert. (see {{hello-retry-request}})
+Clients and servers MUST NOT offer any KeyShareEntry values for groups not
+listed in the client's "supported_groups" extension.
+If the client provides a non-empty client_shares vector and
+no common supported group is available, the server MUST abort the connection
+with a fatal "handshake_failure" alert.
 
 [[TODO: Recommendation about what the client offers.
 Presumably which integer DH groups and which curves.]]

--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -2488,6 +2488,8 @@ Clients and servers MUST NOT offer any KeyShareEntry values for groups not
 listed in the client's "supported_groups" extension.
 Servers MUST NOT offer a KeyShareEntry value for a group not offered by the
 client in its corresponding KeyShare.
+Implementations receiving any KeyShare containing any of these prohibited
+values MUST abort the connection with a fatal "illegal_parameter" alert.
 
 If no mutually supported group is available between the two endpoints' KeyShare
 offers, yet there is a mutually supported group that can be found via the


### PR DESCRIPTION
The current text is a mix of omitting and sending empty, as pointed out by Ilari on the mailing list. This fixes things and switches to an always-send model.