### PR TITLE
update CHACHA20_POLY1305 cipher suite names

### DIFF
--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -3728,9 +3728,9 @@ A TLS-compliant application SHOULD implement the following cipher suites:
 
 ~~~~
     TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
-    TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305
+    TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256
     TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
-    TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305
+    TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
 ~~~~
 
 ##  MTI Extensions
@@ -3985,21 +3985,21 @@ client-authenticated) cipher suites which are currently available in TLS 1.3:
 
 |              Cipher Suite Name                |    Value    | Specification |
 |:----------------------------------------------|:------------|:--------------|
-|   TLS_DHE_RSA_WITH_AES_128_GCM_SHA256         | {0x00,0x9E} | [RFC5288]     |
-|   TLS_DHE_RSA_WITH_AES_256_GCM_SHA384         | {0x00,0x9F} | [RFC5288]     |
-|   TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256     | {0xC0,0x2B} | [RFC5289]     |
-|   TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384     | {0xC0,0x2C} | [RFC5289]     |
-|   TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256       | {0xC0,0x2F} | [RFC5289]     |
-|   TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384       | {0xC0,0x30} | [RFC5289]     |
-|   TLS_DHE_RSA_WITH_AES_128_CCM                | {0xC0,0x9E} | [RFC6655]     |
-|   TLS_DHE_RSA_WITH_AES_256_CCM                | {0xC0,0x9F} | [RFC6655]     |
-|   TLS_DHE_RSA_WITH_AES_128_CCM_8              | {0xC0,0xA2} | [RFC6655]     |
-|   TLS_DHE_RSA_WITH_AES_256_CCM_8              | {0xC0,0xA3} | [RFC6655]     |
-|   TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305        | {TBD,TBD}   | [I-D.ietf-tls-chacha20-poly1305] |
-|   TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305      | {TBD,TBD}   | [I-D.ietf-tls-chacha20-poly1305] |
-|   TLS_DHE_RSA_WITH_CHACHA20_POLY1305          | {TBD,TBD}   | [I-D.ietf-tls-chacha20-poly1305] |
+| TLS_DHE_RSA_WITH_AES_128_GCM_SHA256           | {0x00,0x9E} | [RFC5288]     |
+| TLS_DHE_RSA_WITH_AES_256_GCM_SHA384           | {0x00,0x9F} | [RFC5288]     |
+| TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256       | {0xC0,0x2B} | [RFC5289]     |
+| TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384       | {0xC0,0x2C} | [RFC5289]     |
+| TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256         | {0xC0,0x2F} | [RFC5289]     |
+| TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384         | {0xC0,0x30} | [RFC5289]     |
+| TLS_DHE_RSA_WITH_AES_128_CCM                  | {0xC0,0x9E} | [RFC6655]     |
+| TLS_DHE_RSA_WITH_AES_256_CCM                  | {0xC0,0x9F} | [RFC6655]     |
+| TLS_DHE_RSA_WITH_AES_128_CCM_8                | {0xC0,0xA2} | [RFC6655]     |
+| TLS_DHE_RSA_WITH_AES_256_CCM_8                | {0xC0,0xA3} | [RFC6655]     |
+| TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256   | {TBD,TBD}   | [I-D.ietf-tls-chacha20-poly1305] |
+| TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256 | {TBD,TBD}   | [I-D.ietf-tls-chacha20-poly1305] |
+| TLS_DHE_RSA_WITH_CHACHA20_POLY1305_SHA256     | {TBD,TBD}   | [I-D.ietf-tls-chacha20-poly1305] |
 
-[[TODO: CHACHA20_POLY1305 cipher suite IDs are TBD.]]
+[[TODO: CHACHA20_POLY1305_SHA256 cipher suite IDs are TBD.]]
 
 Note: ECDHE AES GCM was not yet standards track prior to the publication of
 this specification. This document promotes it to Standards Track.


### PR DESCRIPTION
https://www.ietf.org/rfcdiff?url2=draft-ietf-tls-chacha20-poly1305-04

A new ChaChaPoly draft was just released that changes all the cipher suite names to have an explicitly specified hash. This updates this document with the new names.