### PR TITLE
fix extensions table in IANA considerations

### DIFF
--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -3875,7 +3875,7 @@ is listed below:
 | signature_algorithms [RFC5246]           |         Yes |    Client |
 | use_srtp [RFC5764]                       |         Yes | Encrypted |
 | heartbeat [RFC6520]                      |         Yes | Encrypted |
-| application_layer_protocol_negotiation[RFC7301] |  Yes | Encrypted |
+| application_layer_protocol_negotiation [RFC7301] | Yes | Encrypted |
 | status_request_v2 [RFC6961]              |         Yes | Encrypted |
 | signed_certificate_timestamp [RFC6962]   |          No | Encrypted |
 | client_certificate_type [RFC7250]        |         Yes | Encrypted |


### PR DESCRIPTION
See the dubiously line-wrapped table here:
https://tools.ietf.org/html/draft-ietf-tls-tls13-11#page-81

The current draft 11 has the last 'd' in the "Recommended" header and all of the last 'd's for all "Encrypted"s bumped to a second line.

The ALPN extension ID name is quite long and results in things not fitting when rendered for tools.ietf.org. This commit adds a space between the name and RFC number/link to (hopefully) let it wrap and have things fit properly.

@martinthomson: Is this spacing fix enough to make the renderer used for that happy enough to wrap this column?

Note also that the cipher suites table also has issues, however I think this will all fit correctly once ChaChaPoly gets an RFC number and its reference can fit properly.