### PR TITLE
1rttappdata

### DIFF
--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -1577,7 +1577,8 @@ Exch \  + key_share              -------->
                                             {ServerConfiguration*}  v Params
                                                     {Certificate*}  ^
                                               {CertificateVerify*}  | Auth
-                                 <--------              {Finished}  v
+                                                        {Finished}  v
+                                 <--------     [Application Data*]
      ^ {Certificate*}
 Auth | {CertificateVerify*}
      v {Finished}                -------->
@@ -1715,7 +1716,8 @@ the client will need to restart the handshake with an appropriate
                                               {ServerConfiguration*}
                                                       {Certificate*}
                                                 {CertificateVerify*}
-                                   <--------              {Finished}
+                                                          {Finished}
+                                   <--------     [Application Data*]
          {Certificate*}
          {CertificateVerify*}
          {Finished}                -------->
@@ -1767,7 +1769,8 @@ Data  |  (Finished)
                                               {ServerConfiguration*}
                                                       {Certificate*}
                                                 {CertificateVerify*}
-                                   <--------              {Finished}
+                                                          {Finished}
+                                   <--------     [Application Data*]
          {Certificate*}
          {CertificateVerify*}
          {Finished}                -------->
@@ -1863,7 +1866,8 @@ Initial Handshake:
                                             {ServerConfiguration*}
                                                     {Certificate*}
                                               {CertificateVerify*}
-                                 <--------              {Finished}
+                                                        {Finished}
+                                 <--------     [Application Data*]
        {Certificate*}
        {CertificateVerify*}
        {Finished}                -------->
@@ -1878,7 +1882,8 @@ Subsequent Handshake:
                                                        ServerHello
                                                   + pre_shared_key
                                              {EncryptedExtensions}
-                                 <--------              {Finished}
+                                                        {Finished}
+                                 <--------     [Application Data*]
        {Finished}                -------->
        [Application Data]        <------->      [Application Data]
 ~~~

--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -142,7 +142,7 @@ informative:
          - name: Hal Finney
        date: 2006-08-27
        target: https://www.ietf.org/mail-archive/web/openpgp/current/msg00999.html
-       
+
   GCM:
        title: "Recommendation for Block Cipher Modes of Operation: Galois/Counter Mode (GCM) and GMAC"
        date: 2007-11
@@ -981,7 +981,7 @@ sequence number
   The sequence number is incremented after each record: specifically,
   the first record transmitted under a particular connection state and
   record key MUST use sequence number 0.
-  
+
   Sequence numbers are of type uint64 and MUST NOT exceed 2^64-1.
   Sequence numbers do not wrap.  If a TLS implementation would need to
   wrap a sequence number, it MUST either rekey ({{key-update}}) or
@@ -1554,11 +1554,11 @@ Ephemeral Secret (ES): A secret which is derived from fresh (EC)DHE
 Static Secret (SS): A secret which may be derived from static or
    semi-static keying material, such as a pre-shared key or the
    server's semi-static (EC)DH share.
-   
-Master Secret (MS): A secret derived from both the static 
+
+Master Secret (MS): A secret derived from both the static
    and the ephemeral secret.
 
-In some cases, as with the DH handshake shown in {{tls-full}}, 
+In some cases, as with the DH handshake shown in {{tls-full}},
 the ephemeral and shared
 secrets are the same, but having both allows for a uniform key
 derivation scheme for all cipher modes.
@@ -2979,10 +2979,10 @@ Structure of this Message:
 
 %%% Server Parameters Messages
           enum { (65535) } ConfigurationExtensionType;
-          
+
           enum { client_authentication(1), early_data(2),
                  client_authentication_and_data(3), (255) } EarlyDataType;
-                 
+
           struct {
               ConfigurationExtensionType extension_type;
               opaque extension_data<0..2^16-1>;
@@ -3597,7 +3597,7 @@ the sources from the table above.
                                          "exporter master secret",
                                          handshake_hash, L)
 
-  
+
   Where handshake_hash contains the entire handshake up to
   and including the client's Finished, but not including
   any 0-RTT handshake messages or post-handshake messages.


### PR DESCRIPTION
It would appear, based on the ladder diagrams that the server can't speak after sending its Finished, when it can (unless it doesn't *want* to speak because it is waiting on client auth, that is).  This changes the diagrams to show that.

This is largely editorial discretion stuff.