### PR TITLE
Revise signature algorithm negotiation.

### DIFF
--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -2316,20 +2316,20 @@ The "extension_data" field of this extension contains a
 %%% Signature Algorithm Extension
        enum {
            // RSASSA-PKCS-v1_5 algorithms.
-           rsa_pkcs1_sha1 (0x0101),
-           rsa_pkcs1_sha256 (0x0301),
-           rsa_pkcs1_sha384 (0x0401),
+           rsa_pkcs1_sha1 (0x0201),
+           rsa_pkcs1_sha256 (0x0401),
+           rsa_pkcs1_sha384 (0x0501),
            rsa_pkcs1_sha512 (0x0601),
 
            // DSA algorithms (deprecated).
-           dsa_sha1 (0x0102),
-           dsa_sha256 (0x0302),
-           dsa_sha384 (0x0402),
+           dsa_sha1 (0x0202),
+           dsa_sha256 (0x0402),
+           dsa_sha384 (0x0502),
            dsa_sha512 (0x0602),
 
            // ECDSA algorithms.
-           ecdsa_secp256r1_sha256 (0x0303),
-           ecdsa_secp384r1_sha384 (0x0403),
+           ecdsa_secp256r1_sha256 (0x0403),
+           ecdsa_secp384r1_sha384 (0x0503),
            ecdsa_secp521r1_sha512 (0x0603),
 
            // RSASSA-PSS algorithms.
@@ -2342,10 +2342,10 @@ The "extension_data" field of this extension contains a
            ed448 (0x0704),
 
            // Reserved Code Points.
-           obsolete_RESERVED (0x0000..0x0100),
-           obsolete_RESERVED (0x0103..0x0300),
-           obsolete_RESERVED (0x0304..0x0400),
-           obsolete_RESERVED (0x0404..0x0600),
+           obsolete_RESERVED (0x0000..0x0200),
+           obsolete_RESERVED (0x0203..0x0400),
+           obsolete_RESERVED (0x0404..0x0500),
+           obsolete_RESERVED (0x0504..0x0600),
            obsolete_RESERVED (0x0604..0x06FF),
            private_use (0xFE00..0xFFFF),
            (0xFFFF)

--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -2429,9 +2429,10 @@ willing to negotiate TLS 1.2 MUST behave in accordance with the requirements of
 
 * In TLS 1.2, the extension contained hash/signature pairs. The pairs are
   encoded in two octets, so SignatureAlgorithm values have been allocated to
-  align with TLS 1.2's encoding. Unallocated pairs are deprecated as of TLS
-  1.3. These values MUST NOT be offered or negotiated by any implementation.
-  Note that accepting MD5 hashes, in particular, has security concerns {{SLOTH}}.
+  align with TLS 1.2's encoding. Some legacy pairs are left unallocated. These
+  algorithms are deprecated as of TLS 1.3. They MUST NOT be offered or
+  negotiated by any implementation. In particular, MD5 {{SLOTH}} and SHA-224
+  MUST NOT be used.
 
 * ecdsa_secp256r1_sha256, etc., align with TLS 1.2's ECDSA hash/signature pairs.
   However, the old semantics did not constrain the signing curve.


### PR DESCRIPTION
This PR contains proposed specification text for the mailing list thread here:
https://www.ietf.org/mail-archive/web/tls/current/msg19060.html

SignatureAlgorithm and HashAlgorithm are merged into a single u16 value. Fold signing curves into it as well. This is wire-compatible with TLS 1.2, generalizes better to Ed25519 which combines all parameters into a single algorithm, and allows the server to report signature curve preferences to the client.

Per discussion, there are only three ECDSA values, one per curve, so mismatching curve and hash is no longer allowed. They use the same values as the old TLS 1.2 ECDSA code points. (If the WG decides differently here, that can be tweaked.)

Otherwise, I tried to keep SHOULD NOTs and MUST NOTs the same. MUST NOT values (MD5 and SHA-224) are unallocated and remain at MUST NOT. DSA and SHA-1 remain allocated as they're merely SHOULD NOT.

Note: SHA-1 values are limited to rsa_pkcs1_sha1 (formerly {sha1, rsa}) and dsa_sha1 (formerly {sha1, dsa}). TLS 1.2's {sha1, ecdsa} does not have a corresponding TLS 1.3 value due to the curve/hash matching. (Thus it implicitly falls in the unallocated pair MUST NOT bucket.)

Finally, with NamedGroups limited to (EC)DH, this also removes the 'ecdh_' prefix on ecdh_x25519 and ecdh_x448. X25519 and X448 already refer exclusively to Diffie-Hellman primitives and now there is no need to disambiguate between signing curves anyway.