### PR TITLE
spell-out first occurances of PSK

### DIFF
--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -1241,7 +1241,7 @@ cipher spec
 
 resumption master secret
 : a secret shared between the client and server that can be used
-  as a PSK in future connections.
+  as a pre-shared symmetric key (PSK) in future connections.
 {:br }
 
 These items are then used to create security parameters for use by the record
@@ -1825,7 +1825,7 @@ is compromised and client authentication is used, then the attacker
 can impersonate the client on subsequent connections.
 
 
-### Resumption and PSK
+### Resumption and Pre-Shared Key (PSK)
 
 Finally, TLS provides a pre-shared key (PSK) mode which allows a
 client and server who share an existing secret (e.g., a key

--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -2062,7 +2062,7 @@ random
 legacy_session_id
 : Versions of TLS before TLS 1.3 supported a session resumption
   feature which has been merged with Pre-Shared Keys in this version
-  (see {{resumption-and-psk}}).
+  (see {{resumption-and-pre-shared-key-psk}}).
   This field MUST be ignored by a server negotiating TLS 1.3 and
   SHOULD be set as a zero length vector (i.e., a single zero byte
   length field) by clients which do not have a cached session ID


### PR DESCRIPTION
the PSK acronym occurs first in the TOC, and later in S 6 without being spelled-out -- these modest changes fix that. 

[ this is also a small test to see if I have the tlswg+github process figured out ]
