### PR TITLE
purpose should be lowercase

### DIFF
--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -3668,8 +3668,8 @@ The following table indicates the purpose values for each type of key:
 |:-----------------|:-------------------|
 | Client Write Key | "client write key" |
 | Server Write Key | "server write key" |
-| Client Write IV  | "client write IV"  |
-| Server Write IV  | "server write IV"  |
+| Client Write IV  | "client write iv"  |
+| Server Write IV  | "server write iv"  |
 
 All the traffic keying material is recomputed whenever the
 underlying Secret changes (e.g., when changing from the handshake to


### PR DESCRIPTION
It seems that both Karthik and I misinterpreted this "IV" to be uppercase, but it should be lowercase... Thus fixing this table so that others won't make the very same mistake..
