### PR TITLE
Clarify verification requirements of KeyUpdate

### DIFF
--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -3542,6 +3542,12 @@ the traffic keys (though not the traffic secret) for the previous
 generation of keys until it receives the KeyUpdate from the other
 side.
 
+Both sender and receiver must encrypt their KeyUpdate 
+messages with the old keys. Additionaly, both sides MUST enforce that 
+a KeyUpdate with the old key is received before accepting any messages
+encrypted with the new key. Failure to do so may allow message truncation
+attacks.
+
 
 #  Cryptographic Computations
 

--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -3543,7 +3543,7 @@ generation of keys until it receives the KeyUpdate from the other
 side.
 
 Both sender and receiver must encrypt their KeyUpdate 
-messages with the old keys. Additionaly, both sides MUST enforce that 
+messages with the old keys. Additionally, both sides MUST enforce that 
 a KeyUpdate with the old key is received before accepting any messages
 encrypted with the new key. Failure to do so may allow message truncation
 attacks.


### PR DESCRIPTION
The current wording of KeyUpdate a bit ambiguous, and leaves out certain areas needed for enforcement and might result in a security issue if not implemented correctly

A sender of the keyupdate has no choice of which key to encrypt the keyupdate with, however the recipient does. 
It has 2 choices:
a. Use old key and reset the sequence number after acking the keyupdate
b. Use the new key for the key update and reset the sequence number before acking the keyupdate.

This distinction is very important for security. If a client uses option b), this causes a security vuln. Because the sequence numbers are reset after a key update, an attacker could truncate (application data) records from the old stream, wait for the key update from the client, and then let new packets through. The client or server has no way of figuring out this has happened. 

If a receiver verifies that the KeyUpdate is received with the old key before accepting messages encrypted with the new key, then this attack is prevented.