### PR TITLE
append "_RESERVED" to DSA SignatureScheme value names

### DIFF
--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -2349,11 +2349,10 @@ The "extension_data" field of this extension contains a
            rsa_pkcs1_sha384 (0x0501),
            rsa_pkcs1_sha512 (0x0601),
 
-           // DSA algorithms (deprecated).
-           dsa_sha1 (0x0202),
-           dsa_sha256 (0x0402),
-           dsa_sha384 (0x0502),
-           dsa_sha512 (0x0602),
+           dsa_sha1_RESERVED (0x0202),
+           dsa_sha256_RESERVED (0x0402),
+           dsa_sha384_RESERVED (0x0502),
+           dsa_sha512_RESERVED (0x0602),
 
            // ECDSA algorithms.
            ecdsa_secp256r1_sha256 (0x0403),


### PR DESCRIPTION
This appends a "_RESERVED" to each name for the DSA values in the SignatureScheme enum to have them hidden up top and only shown in the appendix, as they're obsolete and their full description was removed in a prior changeset (https://github.com/tlswg/tls13-spec/commit/bed72816a2cbcb2695718c3936c44b78498e07da).

The alternative would be to remove them completely and expand the obsolete_RESERVED ranges to encompass them (these ranges are already hidden up top). I think keeping them as separate reserved values in the appendix is a bit better.

Note that I have to delete this block's header comment as well, as the auto-pruning won't catch that.