### PR TITLE
Adding elapsed_time protection for early data

### DIFF
--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -2741,9 +2741,9 @@ configuration_id
 elapsed_time
 
 : The time elapsed since the client learned about the server
-  configuration that it is using, in seconds.  This value can be used
-  by the server to limit the time over which early data can be
-  replayed.  See {{replay-time}} for details.
+  configuration that it is using, in milliseconds.  This value can
+  be used by the server to limit the time over which early data can
+  be replayed.  See {{replay-time}} for details.
 
 cipher_suite
 : The cipher suite which the client is using to encrypt the early data.


### PR DESCRIPTION
This isn't perfect yet, but I think that it's a good mitigation.

The biggest shortcoming I see is the absence of a recommended allowance for error.  That will take some measurements to determine, I think.