### PR TITLE
Specify whether DHE public keys are zero-padded.

### DIFF
--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -2625,7 +2625,10 @@ Diffie-Hellman {{DH}} parameters for both clients and servers are encoded in
 the opaque key_exchange field of a KeyShareEntry in a KeyShare structure.
 The opaque value contains the
 Diffie-Hellman public value (dh_Y = g^X mod p),
-encoded as a big-endian integer.
+encoded as a big-endian integer, padded with zeros to the size of p.
+
+Note: For a given Diffie-Hellman group, the padding results in all public keys
+having the same length.
 
 %%% Key Exchange Messages
        opaque dh_Y<1..2^16-1>;
@@ -4179,6 +4182,9 @@ Cryptographic details:
 - Do you use a strong and, most importantly, properly seeded random number
   generator (see {{random-number-generation-and-seeding}}) Diffie-Hellman
   private values, the ECDSA "k" parameter, and other security-critical values?
+
+- Do you zero-pad Diffie-Hellman public key values to the group size (see
+  {{ffdhe-param}})?
 
 
 # Backward Compatibility


### PR DESCRIPTION
TLS 1.2 did not specify this and some implementations have sporadic interoperability issues as a result. Specify that, in TLS 1.3, public keys should be zero-padded. This is believed to be the more compatible TLS 1.2 variant, and having cryptographic messages be fixed-width fields where possible (not that it matters for public keys) seems preferable to saving one byte 1/256 of the time.