### PR TITLE
minor followup to PR #459

### DIFF
--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -4151,7 +4151,7 @@ TLS protocol issues:
   (see {{backward-compatibility}})
 
 -  Do you handle TLS extensions in ClientHello correctly, including
-  unknown extensions?
+  unknown extensions or omitting the extensions field completely?
 
 -  When the server has requested a client certificate, but no
   suitable certificate is available, do you correctly send an empty


### PR DESCRIPTION
Here's a quick followup to PR #459. Both the new and old issue are applicable. Whilst TLS 1.3 will always have extensions, servers will need to be able to handle hellos from older clients that don't send any extensions without choking. "Correctly" in this case is just a matter of parsing and rejecting or replying as TLS 1.2, but it's nonetheless still applicable for interop.