### PR TITLE
Preserve leading zeros in Diffie-Hellman secrets.

### DIFF
--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -3672,9 +3672,12 @@ hashed.]]
 ###  Diffie-Hellman
 
 A conventional Diffie-Hellman computation is performed. The negotiated key (Z)
-is used as the shared secret, and is used in the key schedule as
-specified above. Leading bytes of Z that contain all zero bits are stripped
-before it is used as the input to HKDF.
+is converted to byte string by encoding in big-endian, padded with zeros up to
+the size of the prime. This byte string is used as the shared secret, and is
+used in the key schedule as specified above.
+
+Note that this construction differs from previous versions of TLS which remove
+leading zeros.
 
 ### Elliptic Curve Diffie-Hellman
 
@@ -4180,8 +4183,8 @@ Cryptographic details:
   (see {{cryptographic-attributes}})? Do you verify that the RSA padding
   doesn't have additional data after the hash value? {{FI06}}
 
--  When using Diffie-Hellman key exchange, do you correctly strip
-  leading zero bytes from the negotiated key (see {{diffie-hellman}})?
+-  When using Diffie-Hellman key exchange, do you correctly preserve
+  leading zero bytes in the negotiated key (see {{diffie-hellman}})?
 
 -  Does your TLS client check that the Diffie-Hellman parameters sent
   by the server are acceptable (see


### PR DESCRIPTION
Every other use of Diffie-Hellman preserves leading zeros. See PKCS #3 section
8.3, RFC 2631 section 2.1.2, and SP 800-56A section C.1. I assume X9.42 says
something similar to RFC 2631, but I do not have a copy of it. This discrepancy
has caused sporadic interoperability issues in TLS 1.2's DHE construction, so
clearly it's confusing.

Moreover, having variable-length secrets is generally dubious. It exposes an
unnecessary side channel.

Since TLS 1.2's server-fiat DHE and TLS 1.3's negotiated DHE are already very
different animals (1.3 DHE is more like 1.2 ECDHE than anything else), change
it to the more reasonable scheme going forward. This is not compatible with 1.2
and does risk a different set of sporadic interop issues if implementations do
not realize this changed, but we already have those with 1.2 implementations
today.