### PR TITLE
Make pre_shared_key explicit in 0-RTT diagram

### DIFF
--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -1803,8 +1803,8 @@ Initial Handshake:
 
 Subsequent Handshake:
        ClientHello
-         + key_share
-         + pre_shared_key        -------->
+         + pre_shared_key
+         + key_share*            -------->
                                                        ServerHello
                                                   + pre_shared_key
                                                       + key_share*
@@ -1838,6 +1838,7 @@ in the first flight, the rest of the handshake uses the same messages.
 
          ClientHello
            + early_data
+           + pre_shared_key
            + key_share*
          (EncryptedExtensions)
          (Finished)
@@ -1845,7 +1846,8 @@ in the first flight, the rest of the handshake uses the same messages.
          (end_of_early_data)        -------->
                                                          ServerHello
                                                         + early_data
-                                                         + key_share
+                                                    + pre_shared_key
+                                                        + key_share*
                                                {EncryptedExtensions}
                                                {CertificateRequest*}
                                                           {Finished}


### PR DESCRIPTION
A 0-RTT is always a PSK handshake, so it requires a pre_shared_key, make it explicit in the diagram.

Also, in 0-RTT the key_share is only sent by the server for (EC)DHE, mark it optional.

Finally, the client key_share in PSK is a SHOULD, so mark it optional.