### PR TITLE
Fix code block display issues

### DIFF
--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -971,6 +971,7 @@ server random
 These parameters are defined in the presentation language as:
 
 %%% Security Parameters
+
        enum { server, client } ConnectionEnd;
 
        enum { tls_kdf_sha256, tls_kdf_sha384 } KDFAlgorithm;
@@ -1047,6 +1048,7 @@ message MAY be fragmented across several records).
 Alert messages ({{alert-protocol}}) MUST NOT be fragmented across records.
 
 %%% Record Layer
+
        struct {
            uint8 major;
            uint8 minor;
@@ -1119,6 +1121,7 @@ of {{RFC5116}}. The key is either the client_write_key or the server_write_key
 and in TLS 1.3 the additional data input is empty (zero length).
 
 %%% Record Layer
+
        struct {
            ContentType opaque_type = application_data(23); /* see fragment.type */
            ProtocolVersion record_version = { 3, 1 };    /* TLS v1.x */
@@ -1302,6 +1305,7 @@ connections. Like other messages, alert messages are encrypted
 as specified by the current connection state.
 
 %%% Alert Messages
+
        enum { warning(1), fatal(2), (255) } AlertLevel;
 
        enum {
@@ -1908,6 +1912,7 @@ they are encapsulated within one or more TLSPlaintext or TLSCiphertext structure
 processed and transmitted as specified by the current active session state.
 
 %%% Handshake Protocol
+
        enum {
            hello_request_RESERVED(0),
            client_hello(1),
@@ -2081,6 +2086,7 @@ acceptable by the server, it will respond with a "handshake_failure" fatal alert
 Structure of this message:
 
 %%% Key Exchange Messages
+
        struct {
            ProtocolVersion server_version;
            Random random;
@@ -2172,6 +2178,7 @@ fatal "handshake_failure" alert.
 Structure of this message:
 
 %%% Key Exchange Messages
+
        struct {
            ProtocolVersion server_version;
            CipherSuite cipher_suite;
@@ -2219,6 +2226,7 @@ MUST abort the connection with a fatal "handshake_failure" alert.
 The extension format is:
 
 %%% Key Exchange Messages
+
        struct {
            ExtensionType extension_type;
            opaque extension_data<0..2^16-1>;
@@ -2310,6 +2318,7 @@ be taken into account when designing new extensions:
 ####  Cookie
 
 %%% Cookie Extension
+
        struct {
            opaque cookie<0..2^16-1>;
        } Cookie;
@@ -2348,6 +2357,7 @@ The "extension_data" field of this extension contains a
 "supported_signature_algorithms" value:
 
 %%% Signature Algorithm Extension
+
        enum {
            /* RSASSA-PKCS-v1_5 algorithms */
            rsa_pkcs1_sha1 (0x0201),
@@ -2486,6 +2496,7 @@ The "extension_data" field of this extension contains a
 "NamedGroupList" value:
 
 %%% Named Group Extension
+
        enum {
            /* Elliptic Curve Groups (ECDHE) */
            obsolete_RESERVED (1..22),
@@ -2557,6 +2568,7 @@ group selection from the server at the cost of an additional round trip.
 (see {{hello-retry-request}})
 
 %%% Key Exchange Messages
+
        struct {
            NamedGroup group;
            opaque key_exchange<1..2^16-1>;
@@ -2579,6 +2591,7 @@ The "extension_data" field of this extension contains a
 "KeyShare" value:
 
 %%% Key Exchange Messages
+
        struct {
            select (role) {
                case client:
@@ -2742,6 +2755,7 @@ The "extension_data" field of this extension contains an
 "EarlyDataIndication" value:
 
 %%% Key Exchange Messages
+
        struct {
            select (Role) {
                case client:
@@ -2868,6 +2882,7 @@ risk greater exposure to replay attacks.
 #### Ticket Age
 
 %%% Key Exchange Messages
+
        struct {
            uint32 ticket_age;
        } TicketAge;
@@ -2920,6 +2935,7 @@ in the IANA registry can be sent in the client's EncryptedExtensions.
 Structure of this message:
 
 %%% Server Parameters Messages
+
        struct {
            Extension extensions<0..2^16-1>;
        } EncryptedExtensions;
@@ -2939,6 +2955,7 @@ follow EncryptedExtensions.
 Structure of this message:
 
 %%% Server Parameters Messages
+
        opaque DistinguishedName<1..2^16-1>;
 
        struct {
@@ -3098,6 +3115,7 @@ exchange algorithm and any negotiated extensions.
 Structure of this message:
 
 %%% Authentication Messages
+
        opaque ASN1Cert<1..2^24-1>;
 
        struct {
@@ -3261,6 +3279,7 @@ message.
 Structure of this message:
 
 %%% Authentication Messages
+
        struct {
             digitally-signed struct {
                opaque hashed_data[hash_length];


### PR DESCRIPTION
Editorial: Indented code blocks do not render correctly until after the first blank line. Added initial blank lines where appropriate to fix the appearance of affected code blocks.