### PR TITLE
Rename HandshakeType.session_ticket to HandshakeType.new_session_ticket.

### DIFF
--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -1943,9 +1943,6 @@ processed and transmitted as specified by the current active session state.
            } body;
        } Handshake;
 
-[[TODO: Add IANA Considerations to rename the 'NewSessionTicket' HandshakeType
-value to 'new_session_ticket'.]]
-
 The TLS Handshake Protocol messages are presented below in the order they
 MUST be sent; sending handshake messages in an unexpected order
 results in an "unexpected_message" fatal error. Unneeded handshake
@@ -3856,7 +3853,8 @@ and their allocation policies are below:
   Action {{RFC2434}}.
 
 -  TLS HandshakeType Registry: Future values are allocated via
-  Standards Action {{RFC2434}}.
+  Standards Action {{RFC2434}}. IANA [SHALL update/has updated] this registry
+  to rename item 4 from "NewSessionTicket" to "new_session_ticket".
 
 This document also uses a registry originally created in {{RFC4366}}. IANA has
 updated it to reference this document. The registry and its allocation policy

--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -1912,7 +1912,7 @@ processed and transmitted as specified by the current active session state.
            hello_request_RESERVED(0),
            client_hello(1),
            server_hello(2),
-           session_ticket(4),
+           new_session_ticket(4),
            hello_retry_request(6),
            encrypted_extensions(8),
            certificate(11),
@@ -1938,10 +1938,13 @@ processed and transmitted as specified by the current active session state.
                case certificate:           Certificate;
                case certificate_verify:    CertificateVerify;
                case finished:              Finished;
-               case session_ticket:        NewSessionTicket;
+               case new_session_ticket:    NewSessionTicket;
                case key_update:            KeyUpdate;
            } body;
        } Handshake;
+
+[[TODO: Add IANA Considerations to rename the 'NewSessionTicket' HandshakeType
+value to 'new_session_ticket'.]]
 
 The TLS Handshake Protocol messages are presented below in the order they
 MUST be sent; sending handshake messages in an unexpected order


### PR DESCRIPTION
This is purely aesthetic, but apparently no one realizes the name is different, not even IANA, so we may as well go fix it.

(I don't know how to write IANA considerations, so I've left it a TODO. But if you give me text, I'll update this PR to include it.)

---
For consistency. At a glance, it seems most TLS implementations did not realize
the HandshakeType value was actually named session_ticket and assumed it was
named new_session_ticket anyway. Moreover, the IANA entry was named neither and
actually named NewSessionTicket since RFC 4507's IANA considerations used the
wrong name.