### PR TITLE
Negotiating 0-RTT means that the server has 1.3 everywhere.

### DIFF
--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -4328,18 +4328,16 @@ MUST always be ignored.
 0-RTT data is not compatible with older servers. An older server will respond
 to the ClientHello with an older ServerHello, but it will not correctly skip
 the 0-RTT data and fail to complete the handshake. This can cause issues when
-a client offers 0-RTT, particularly against multi-server deployments. For
-example, a deployment may deploy TLS 1.3 gradually with some servers
+a client attempts to use 0-RTT, particularly against multi-server deployments. For
+example, a deployment could deploy TLS 1.3 gradually with some servers
 implementing TLS 1.3 and some implementing TLS 1.2, or a TLS 1.3 deployment
-may be downgraded to TLS 1.2.
+could be downgraded to TLS 1.2.
 
-If a client accepts older versions of TLS and receives an older ServerHello
-after sending a ClientHello with 0-RTT data, it MAY retry the connection
-without 0-RTT. It is NOT RECOMMENDED to retry the connection in response to a
-more generic error or advertise lower versions of TLS.
+A client that attempts to send 0-RTT data MUST fail a connection if it receives
+a ServerHello with TLS 1.2 or older.
 
-Multi-server deployments are RECOMMENDED to ensure a stable deployment of TLS
-1.3 without 0-RTT prior to enabling 0-RTT.
+Multi-server deployments therefore MUST ensure a uniform and stable deployment
+of TLS 1.3 without 0-RTT prior to enabling 0-RTT.
 
 ## Backwards Compatibility Security Restrictions
 

--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -4334,10 +4334,12 @@ implementing TLS 1.3 and some implementing TLS 1.2, or a TLS 1.3 deployment
 could be downgraded to TLS 1.2.
 
 A client that attempts to send 0-RTT data MUST fail a connection if it receives
-a ServerHello with TLS 1.2 or older.
+a ServerHello with TLS 1.2 or older.  A client that attempts to repair this
+error SHOULD NOT send a TLS 1.2 ClientHello, but instead send a TLS 1.3
+ClientHello without 0-RTT data.
 
-Multi-server deployments therefore MUST ensure a uniform and stable deployment
-of TLS 1.3 without 0-RTT prior to enabling 0-RTT.
+To avoid this error condition, multi-server deployments SHOULD ensure a uniform
+and stable deployment of TLS 1.3 without 0-RTT prior to enabling 0-RTT.
 
 ## Backwards Compatibility Security Restrictions
 


### PR DESCRIPTION
The text that @davidben proposed that covered 0-RTT and backward
compatibility took the position that a server might not support
TLS 1.3 when it was attempted.  That leads to all sorts of mess,
particularly given that most 1.2 and earlier servers are totally
incapable of handling 0-RTT messages.  In NSS, it's a fatal
error and I would expect others to be similarly strict given the
smackTLS work.

This is a simpler set of rules:
 * If the server advertises support for 0-RTT that means that it
   commits to supporting TLS 1.3 for the duration.
 * If the client attempts 0-RTT, then it should abort if it sees
   a ServerHello with 1.2 or earlier.

This is stricter than what we currently have, but it's crisper.
That is, unless people imagine modifying their TLS 1.2
implementations to be able to ignore 0-RTT data,