### PR TITLE
Move the downgrade sentinel to the end of server_random.

### DIFF
--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -2123,20 +2123,20 @@ extensions
 {:br }
 
 TLS 1.3 server implementations which respond to a ClientHello with a
-client_version indicating TLS 1.2 or below MUST set the first eight
+client_version indicating TLS 1.2 or below MUST set the last eight
 bytes of their Random value to the bytes:
 
       44 4F 57 4E 47 52 44 01
 
 TLS 1.2 server implementations which respond to a ClientHello with a
-client_version indicating TLS 1.1 or below SHOULD set the first eight
+client_version indicating TLS 1.1 or below SHOULD set the last eight
 bytes of their Random value to the bytes:
 
       44 4F 57 4E 47 52 44 00
 
 
 TLS 1.3 clients receiving a TLS 1.2 or below ServerHello MUST check
-that the top eight octets are not equal to either of these values. TLS
+that the last eight octets are not equal to either of these values. TLS
 1.2 clients SHOULD also perform this check if the ServerHello
 indicates TLS 1.1 or below. If a match is found, the client MUST abort
 the handshake with a fatal "illegal_parameter" alert. This mechanism
@@ -2149,13 +2149,6 @@ when static RSA is used.
 
 Note: This is an update to TLS 1.2 so in practice many TLS 1.2 clients
 and servers will not behave as specified above.
-
-Note: Versions of TLS prior to TLS 1.3 used the top 32 bits of
-the Random value to encode the time since the UNIX epoch. The
-sentinel value above was selected to avoid conflicting with any
-valid TLS 1.2 Random value and to have a low (2^{-64})
-probability of colliding with randomly selected Random
-values.
 
 
 ####  Hello Retry Request


### PR DESCRIPTION
The sentinel value was chosen to avoid conflicting with any valid TLS 1.2
value, but this is not actually desirable. We need to avoid conflicting with
any non-TLS-1.3 server but *still* be a valid TLS 1.2 value. A TLS 1.3 server
must still correctly implement TLS 1.2 to interoperate with existing TLS 1.2
clients.

In particular, placing it at the front clobbers TLS 1.2's server timestamp.
Putting this in the random was silly and 1.3 rightfully removes it, but some
software depends on servers sending a timestamp. The tlsdate program uses this
as a secure-ish time synchronization protocol. Silly as it is, it exists and it
arguably was following the letter of the TLS 1.2 spec, even if we don't like
that timestamp very much...

Move the sentinel to the end so servers may implement this downgrade protection
(which will be needed in the short term given the current version negotiation
as it forces browsers to implement the version fallback again) without breaking
any tlsdate instances which may still exist.