### PR TITLE
trivial formatting fix

### DIFF
--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -337,6 +337,7 @@ server: The endpoint which did not initiate the TLS connection.
 ##  Major Differences from TLS 1.2
 
 draft-14
+
 - Allow cookies to be longer.
 
 
@@ -388,6 +389,7 @@ draft-12
 
 - Editorial cleanup
 
+
 draft-11
 
 - Port the CFRG curves & signatures work from RFC4492bis.
@@ -407,6 +409,7 @@ draft-11
   an alert.
 
 - Reset sequence number upon key change (as proposed by Fournet et al.)
+
 
 draft-10
 


### PR DESCRIPTION
Lack of a blank line after "draft-14" but before the bullet point causes it to render all on one line:
https://tlswg.github.io/tls13-spec/

This is just a quick patch to make the spacing consistent because apparently Markdown (or, at least whatever is interpreting it there) can be picky. ;)

This is just a whitespace fix.