### PR TITLE
Flatter Sectioning (for issue #510)

### DIFF
--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -1844,20 +1844,20 @@ The contents and significance of each message will be presented in detail in
 the following sections.
 
 
-##  Handshake Protocol
+#  Messages
 
 The TLS Handshake Protocol messages are presented below in the order they
 MUST be sent; sending handshake messages in an unexpected order
 results in an "unexpected_message" fatal error. Unneeded handshake
 messages can be omitted, however.
 
-### Key Exchange Messages
+## Key Exchange Messages
 
 The key exchange messages are used to exchange security capabilities
 between the client and server and to establish the traffic keys used to protect
 the handshake and the data.
 
-####  Client Hello
+###  Client Hello
 
 When this message will be sent:
 
@@ -1968,7 +1968,7 @@ formats; if not, then it MUST send a fatal "decode_error" alert.
 After sending the ClientHello message, the client waits for a ServerHello
 or HelloRetryRequest message.
 
-####  Server Hello
+###  Server Hello
 
 When this message will be sent:
 
@@ -2054,7 +2054,7 @@ Note: This is an update to TLS 1.2 so in practice many TLS 1.2 clients
 and servers will not behave as specified above.
 
 
-####  Hello Retry Request
+###  Hello Retry Request
 
 When this message will be sent:
 
@@ -2111,7 +2111,7 @@ the selected CipherSuite and NamedGroup match that supplied in
 the HelloRetryRequest. If either of these values differ, the client
 MUST abort the connection with a fatal "handshake_failure" alert.
 
-###  Hello Extensions
+##  Hello Extensions
 
 The extension format is:
 
@@ -2204,7 +2204,7 @@ be taken into account when designing new extensions:
   any major design change.
 
 
-####  Cookie
+###  Cookie
 
 %%% Cookie Extension
 
@@ -2231,7 +2231,7 @@ new ClientHello, the client MUST echo the value of the extension.
 Clients MUST NOT use cookies in subsequent connections.
 
 
-####  Signature Algorithms
+###  Signature Algorithms
 
 The client uses the "signature_algorithms" extension to indicate to the server
 which signature algorithms may be used in digital signatures.
@@ -2357,7 +2357,7 @@ willing to negotiate TLS 1.2 MUST behave in accordance with the requirements of
 * ecdsa_secp256r1_sha256, etc., align with TLS 1.2's ECDSA hash/signature pairs.
   However, the old semantics did not constrain the signing curve.
 
-#### Negotiated Groups
+### Negotiated Groups
 
 When sent by the client, the "supported_groups" extension indicates
 the named groups which the client supports, ordered from most preferred
@@ -2440,7 +2440,7 @@ subsequent connections.
 
 
 
-#### Key Share
+### Key Share
 
 The "key_share" extension contains the endpoint's cryptographic parameters
 for non-PSK key establishment methods (currently DHE or ECDHE).
@@ -2527,7 +2527,7 @@ the server MUST NOT negotiate an (EC)DHE cipher suite.
 [[TODO: Recommendation about what the client offers.
 Presumably which integer DH groups and which curves.]]
 
-#####  Diffie-Hellman Parameters {#ffdhe-param}
+####  Diffie-Hellman Parameters {#ffdhe-param}
 
 Diffie-Hellman {{DH}} parameters for both clients and servers are encoded in
 the opaque key_exchange field of a KeyShareEntry in a KeyShare structure.
@@ -2538,7 +2538,7 @@ encoded as a big-endian integer, padded with zeros to the size of p.
 Note: For a given Diffie-Hellman group, the padding results in all public keys
 having the same length.
 
-##### ECDHE Parameters {#ecdhe-param}
+#### ECDHE Parameters {#ecdhe-param}
 
 ECDHE parameters for both clients and servers are encoded in the
 the opaque key_exchange field of a KeyShareEntry in a KeyShare structure.
@@ -2561,7 +2561,7 @@ Note: Versions of TLS prior to 1.3 permitted point negotiation;
 TLS 1.3 removes this feature in favor of a single point format
 for each curve.
 
-#### Pre-Shared Key Extension
+### Pre-Shared Key Extension
 
 The "pre_shared_key" extension is used to indicate the identity of the
 pre-shared key to be used with a given handshake in association
@@ -2616,7 +2616,7 @@ is returned, the client MUST generate a fatal
 "unknown_psk_identity" alert and close the connection.
 
 
-#### OCSP Status Extensions
+### OCSP Status Extensions
 
 {{!RFC6066}} and {{!RFC6961}} provide extensions to negotiate the server
 sending OCSP responses to the client. In TLS 1.2 and below, the
@@ -2634,7 +2634,7 @@ the existing behavior for SignedCertificateTimestamps {{?RFC6962}},
 and is more easily extensible in the handshake state machine.
 
 
-#### Early Data Indication
+### Early Data Indication
 
 When PSK resumption is used, the client can send application data
 in its first flight of messages. If the client opts to do so, it MUST
@@ -2732,7 +2732,7 @@ an accepted "early_data" extension MUST produce a fatal
 
 [[TODO: How does the client behave if the indication is rejected.]]
 
-##### Processing Order
+#### Processing Order
 
 Clients are permitted to "stream" 0-RTT data until they
 receive the server's Finished, only then sending the "end_of_early_data"
@@ -2741,7 +2741,7 @@ servers MUST process the client's Finished and then immediately
 send the ServerHello, rather than waiting for the client's
 "end_of_early_data" alert.
 
-##### Replay Properties {#replay-time}
+#### Replay Properties {#replay-time}
 
 As noted in {{zero-rtt-data}}, TLS provides only a limited
 inter-connection mechanism for replay protection for data sent by the
@@ -2782,7 +2782,7 @@ is advisable.  However, any allowance also increases the opportunity
 for replay.  In this case, it is better to reject early data than to
 risk greater exposure to replay attacks.
 
-####  Encrypted Extensions
+###  Encrypted Extensions
 
 When this message will be sent:
 
@@ -2820,7 +2820,7 @@ extensions
 : A list of extensions.
 {:br }
 
-####  Certificate Request
+###  Certificate Request
 
 When this message will be sent:
 
@@ -2913,9 +2913,9 @@ certificate_extensions
 Note: It is a fatal "handshake_failure" alert for an anonymous server to request
 client authentication.
 
-### Authentication Messages
+## Authentication Messages
 
-As discussed in {{handshake-protocol-overview}}, TLS uses a common
+As discussed in {{handshake-protocol}}, TLS uses a common
 set of messages for authentication, key confirmation, and handshake
 integrity: Certificate, CertificateVerify, and Finished. These
 messages are always sent as the last messages in their handshake
@@ -2966,7 +2966,7 @@ for each scenario:
 Note: The Handshake Context for the last three rows does not include any 0-RTT
   handshake messages, regardless of whether 0-RTT is used.
 
-####  Certificate
+###  Certificate
 
 When this message will be sent:
 
@@ -3029,7 +3029,7 @@ send an empty certificate list if it does not have an appropriate
 certificate to send in response to the server's authentication
 request.
 
-##### Server Certificate Selection
+#### Server Certificate Selection
 
 The following rules apply to the certificates sent by the server:
 
@@ -3080,7 +3080,7 @@ TLS protocol, they will imply the certificate format and the required encoded
 keying information.
 
 
-##### Client Certificate Selection
+#### Client Certificate Selection
 
 The following rules apply to certificates sent by the client:
 
@@ -3106,7 +3106,7 @@ Note that, as with the server certificate, there are certificates that use
 algorithm combinations that cannot be currently used with TLS.
 
 
-##### Receiving a Certificate Message
+#### Receiving a Certificate Message
 
 In general, detailed certificate validation procedures are out of scope for
 TLS (see {{RFC5280}}). This section provides TLS-specific requirements.
@@ -3137,7 +3137,7 @@ MAY be signed using a different signature algorithm (for instance,
 an RSA key signed with an ECDSA key).
 
 
-####  Certificate Verify
+###  Certificate Verify
 
 When this message will be sent:
 
@@ -3215,7 +3215,7 @@ authentication with pure PSK modes (i.e., those where the
 PSK was not derived from a previous non-PSK handshake).
 
 
-####  Finished
+###  Finished
 
 When this message will be sent:
 
@@ -3272,13 +3272,13 @@ Hash used for the handshake.
 Note: Alerts and any other record types are not handshake messages
 and are not included in the hash computations.
 
-### Post-Handshake Messages
+## Post-Handshake Messages
 
 TLS also allows other messages to be sent after the main handshake.
 These messages use a handshake content type and are encrypted under the application
 traffic key.
 
-#### New Session Ticket Message {#NewSessionTicket}
+### New Session Ticket Message {#NewSessionTicket}
 
 At any time after the server has received the client Finished message, it MAY send
 a NewSessionTicket message. This message creates a pre-shared key
@@ -3379,7 +3379,7 @@ the cipher suite negotiated for this connection. If no flags are set
 that the client recognizes, it MUST ignore the ticket.
 
 
-#### Post-Handshake Authentication
+### Post-Handshake Authentication
 
 The server is permitted to request client authentication at any time
 after the handshake has completed by sending a CertificateRequest
@@ -3398,7 +3398,7 @@ certificate_request_context value allows the server to disambiguate
 the responses).
 
 
-#### Key and IV Update {#key-update}
+### Key and IV Update {#key-update}
 
      struct {} KeyUpdate;
 

--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -1468,7 +1468,7 @@ unknown_psk_identity
 New Alert values are assigned by IANA as described in {{iana-considerations}}.
 
 
-##  Handshake Protocol Overview
+##  Handshake Protocol
 
 The cryptographic parameters of the session state are produced by the
 TLS Handshake Protocol, which operates on top of the TLS record
@@ -1476,6 +1476,43 @@ layer. When a TLS client and server first start communicating, they
 agree on a protocol version, select cryptographic algorithms,
 optionally authenticate each other, and establish shared secret keying
 material.
+
+%%% Handshake Protocol
+
+       enum {
+           hello_request_RESERVED(0),
+           client_hello(1),
+           server_hello(2),
+           new_session_ticket(4),
+           hello_retry_request(6),
+           encrypted_extensions(8),
+           certificate(11),
+           server_key_exchange_RESERVED(12),
+           certificate_request(13),
+           server_hello_done_RESERVED(14),
+           certificate_verify(15),
+           client_key_exchange_RESERVED(16),
+           finished(20),
+           key_update(24),
+           (255)
+       } HandshakeType;
+
+       struct {
+           HandshakeType msg_type;    /* handshake type */
+           uint24 length;             /* bytes in message */
+           select (HandshakeType) {
+               case client_hello:          ClientHello;
+               case server_hello:          ServerHello;
+               case hello_retry_request:   HelloRetryRequest;
+               case encrypted_extensions:  EncryptedExtensions;
+               case certificate_request:   CertificateRequest;
+               case certificate:           Certificate;
+               case certificate_verify:    CertificateVerify;
+               case finished:              Finished;
+               case new_session_ticket:    NewSessionTicket;
+               case key_update:            KeyUpdate;
+           } body;
+       } Handshake;
 
 TLS supports three basic key exchange modes:
 
@@ -1621,6 +1658,9 @@ its promised level of security: if you negotiate AES-GCM {{GCM}} with
 a 255-bit ECDHE key exchange with a host whose certificate
 chain you have verified, you can expect that to be reasonably "secure"
 against algorithmic attacks, at least in the year 2015.]]
+
+New handshake message types are assigned by IANA as described in
+{{iana-considerations}}.
 
 ### Incorrect DHE Share
 
@@ -1806,56 +1846,10 @@ the following sections.
 
 ##  Handshake Protocol
 
-The TLS Handshake Protocol is one of the defined higher-level clients of the
-TLS Record Protocol. This protocol is used to negotiate the secure attributes
-of a session. Handshake messages are supplied to the TLS record layer, where
-they are encapsulated within one or more TLSPlaintext or TLSCiphertext structures, which are
-processed and transmitted as specified by the current active session state.
-
-%%% Handshake Protocol
-
-       enum {
-           hello_request_RESERVED(0),
-           client_hello(1),
-           server_hello(2),
-           new_session_ticket(4),
-           hello_retry_request(6),
-           encrypted_extensions(8),
-           certificate(11),
-           server_key_exchange_RESERVED(12),
-           certificate_request(13),
-           server_hello_done_RESERVED(14),
-           certificate_verify(15),
-           client_key_exchange_RESERVED(16),
-           finished(20),
-           key_update(24),
-           (255)
-       } HandshakeType;
-
-       struct {
-           HandshakeType msg_type;    /* handshake type */
-           uint24 length;             /* bytes in message */
-           select (HandshakeType) {
-               case client_hello:          ClientHello;
-               case server_hello:          ServerHello;
-               case hello_retry_request:   HelloRetryRequest;
-               case encrypted_extensions:  EncryptedExtensions;
-               case certificate_request:   CertificateRequest;
-               case certificate:           Certificate;
-               case certificate_verify:    CertificateVerify;
-               case finished:              Finished;
-               case new_session_ticket:    NewSessionTicket;
-               case key_update:            KeyUpdate;
-           } body;
-       } Handshake;
-
 The TLS Handshake Protocol messages are presented below in the order they
 MUST be sent; sending handshake messages in an unexpected order
 results in an "unexpected_message" fatal error. Unneeded handshake
 messages can be omitted, however.
-
-New handshake message types are assigned by IANA as described in
-{{iana-considerations}}.
 
 ### Key Exchange Messages
 


### PR DESCRIPTION
This is a PR for the section flattening scheme I noted in issue #510. The handshake structs are a little awkwardly positioned, but other than that, this is pretty straightforward. A little bit of excessive redundant text is also cut here. The reasons to do this are:
1) The TOC will actually list all the messages and extensions by name, which is fairly important information, and should make browsing the document easier.
2) No more 5 part subsection ID silliness.
3) The relevant handshake enum and struct are now defined before all the stuff that mentions them.