### PR TITLE
Restructure

### DIFF
--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -240,7 +240,7 @@ informative:
 --- abstract
 
 This document specifies Version 1.3 of the Transport Layer Security
-(TLS) protocol.  The TLS protocol allows client/server applications to
+(TLS) protocol.  TLS allows client/server applications to
 communicate over the Internet in a way that is designed to prevent eavesdropping,
 tampering, and message forgery.
 --- middle
@@ -257,51 +257,50 @@ https://github.com/tlswg/tls13-spec. Instructions are on that page as
 well. Editorial changes can be managed in GitHub, but any substantive
 change should be discussed on the TLS mailing list.
 
-The primary goal of the TLS protocol is to provide privacy and data integrity
-between two communicating peers. The TLS protocol is composed of two layers:
-the TLS Record Protocol and the TLS Handshake Protocol. At the lowest level,
-layered on top of some reliable transport protocol (e.g., TCP {{RFC0793}}), is
-the TLS Record Protocol. The TLS Record Protocol provides connection security
-that has two basic properties:
+The primary goal of TLS is to provide a secure channel
+between two communicating peers. Specifically, the channel should
+provide the following properties.
 
-- The connection is private.  Symmetric cryptography is used for
-  data encryption (e.g., AES {{AES}}).  The keys for
-  this symmetric encryption are generated uniquely for each
-  connection and are based on a secret negotiated by another
-  the TLS Handshake Protocol.
+- Authentication: The server side of the channel is always
+  authenticated; the client side is optionally
+  authenticated. Authentication can happen via asymmetric cryptography
+  (e.g., RSA {{RSA}}, ECDSA {{ECDSA}}) or a pre-shared symmetric key.
 
-- The connection is reliable.  Messages include an authentication
-  tag which protects them against modification.
+- Confidentiality: Data sent over the channel is not visible to
+  attackers.
+  
+- Integrity: Data sent over the channel cannot be modified by attackers.
 
-The TLS Record Protocol is used for encapsulation of various higher-level
-protocols. One such encapsulated protocol, the TLS Handshake Protocol, allows
-the server and client to authenticate each other and to negotiate an encryption
-algorithm and cryptographic keys before the application protocol transmits or
-receives its first byte of data. The TLS Handshake Protocol provides connection
-security that has three basic properties:
+These properties should be true even in the face of an attacker who controls
+the channel, as described in {{RFC3552}}.
+See Section [TODO] for a more formal statement of the relevant security
+properties.
 
+TLS consists of two primary protocol components:
 
-- The peer's identity can be authenticated using asymmetric (public key)
-  cryptography (e.g., RSA {{RSA}}, ECDSA {{ECDSA}}) or a pre-shared
-  symmetric key. The TLS server is always authenticated; client authentication
-  is optional.
+- A handshake protocol which authenticates the communicating parties,
+  negotiates cryptographic modes and parameters, and establishes
+  shared keying material. The handshake protocol is designed to
+  resist tampering; an active attacker should not be able to force
+  the peers to negotiate different parameters than they would
+  if the connection were not under attack.
 
-- The negotiation of a shared secret is secure: the negotiated
-  secret is unavailable to eavesdroppers, and for any authenticated
-  connection the secret cannot be obtained, even by an attacker who
-  can place himself in the middle of the connection.
-
-- The negotiation is reliable: no attacker can modify the
-  negotiation communication without being detected by the parties to
-  the communication.
-
+- A record protocol which uses the parameters established by the
+  handshake protocol to protect traffic between the communicating
+  peers.
 
 One advantage of TLS is that it is application protocol independent.
-Higher-level protocols can layer on top of the TLS protocol transparently. The
-TLS standard, however, does not specify how protocols add security with TLS;
-the decisions on how to initiate TLS handshaking and how to interpret the
-authentication certificates exchanged are left to the judgment of the designers
-and implementors of protocols that run on top of TLS.
+Higher-level protocols can layer on top of TLS transparently. The TLS
+standard, however, does not specify how protocols add security with
+TLS; the decisions on how to initiate TLS handshaking and how to
+interpret the authentication certificates exchanged are left to the
+judgment of the designers and implementors of protocols that run on
+top of TLS.
+
+This document defines TLS version 1.3. While TLS 1.3 is not directly
+compatible with previous versions, all versions of TLS incorporate a
+versioning mechanism which allows clients and servers to interoperably
+negotiate a common version if one is supported.
 
 ##  Conventions and Terminology
 
@@ -532,34 +531,6 @@ draft-02
 
 -  Remove support for non-AEAD ciphers.
 
-
-#  Goals
-
-The goals of the TLS protocol, in order of priority, are as follows:
-
-1. Cryptographic security: TLS should be used to establish a secure connection
-between two parties.
-
-2. Interoperability: Independent programmers should be able to develop
-applications utilizing TLS that can successfully exchange cryptographic
-parameters without knowledge of one another's code.
-
-3. Extensibility: TLS seeks to provide a framework into which new public key
-and record protection methods can be incorporated as necessary. This will also
-accomplish two sub-goals\: preventing the need to create a new protocol (and
-risking the introduction of possible new weaknesses) and avoiding the need to
-implement an entire new security library.
-
-4. Relative efficiency: Cryptographic operations tend to be highly CPU
-intensive, particularly public key operations. For this reason, the TLS
-protocol has incorporated an optional session caching scheme to reduce the
-number of connections that need to be established from scratch. Additionally,
-care has been taken to reduce network activity.
-
-This document defines TLS version 1.3. While TLS 1.3 is not directly compatible
-with previous versions, all versions of TLS incorporate a versioning mechanism
-which allows clients and servers to interoperably negotiate a common version
-if one is supported.
 
 #  Presentation Language
 

--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -3842,27 +3842,6 @@ in such a way absent explicit configuration or a specific application
 profile.
 
 
-## Changes to RFC 4492
-
-RFC 4492 {{RFC4492}} adds Elliptic Curve cipher suites to TLS. This document
-changes some of the structures used in that document. This section details the
-required changes for implementors of both RFC 4492 and TLS 1.2. Implementors of
-TLS 1.2 who are not implementing RFC 4492 do not need to read this section.
-
-This document adds an "algorithm" field to the digitally-signed
-element in order to identify the signature and digest algorithms used to create
-a signature. This change applies to digital signatures formed using ECDSA as
-well, thus allowing ECDSA signatures to be used with digest algorithms other
-than SHA-1, provided such use is compatible with the certificate and any
-restrictions imposed by future revisions of {{RFC5280}}.
-
-As described in {{server-certificate-selection}}, the restrictions on the signature
-algorithms used to sign certificates are no longer tied to the cipher suite.
-Thus, the restrictions on the algorithm used to sign certificates specified in
-Sections 2 and 3 of RFC 4492 are also relaxed. As in this document, the
-restrictions on the keys in the end-entity certificate remain.
-
-
 # Implementation Notes
 
 The TLS protocol cannot prevent many common security mistakes. This section

--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -1783,18 +1783,20 @@ server_share
 : A single KeyShareEntry value for the negotiated cipher suite.
 {:br }
 
-Servers offer exactly one KeyShareEntry value, which corresponds to the
-key exchange used for the negotiated cipher suite.
+Clients offer an arbitrary number of KeyShareEntry values, each
+representing a single set of key exchange parameters. For instance, a
+client might offer shares for several elliptic curves or multiple
+FFDHE groups.  The key_exchange values for each KeyShareEntry MUST by
+generated independently.  Clients MUST NOT offer multiple
+KeyShareEntry values for the same group.  Clients and MUST NOT offer
+any KeyShareEntry values for groups not listed in the client's
+"supported_groups" extension.
 
-Clients offer an arbitrary number of KeyShareEntry values, each representing
-a single set of key exchange parameters. For instance, a client might
-offer shares for several elliptic curves or multiple FFDHE groups.
-The key_exchange values for each KeyShareEntry MUST by generated independently.
-Clients MUST NOT offer multiple KeyShareEntry values for the same group.
-Clients and servers MUST NOT offer any KeyShareEntry values for
-groups not listed in the client's "supported_groups" extension.
-Servers MUST NOT offer a KeyShareEntry value for a group not offered by the
-client in its corresponding KeyShare.
+Servers offer exactly one KeyShareEntry value, which corresponds to
+the key exchange used for the negotiated cipher suite.  Servers MUST
+NOT offer a KeyShareEntry value for a group not offered by the client
+in its corresponding KeyShare or "supported_groups" extension.
+
 Implementations MAY check for violations of these rules and
 and MAY abort the connection with a fatal "illegal_parameter" alert
 if one is violated.

--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -2271,8 +2271,8 @@ Meaning of this message:
 
 > This message conveys the endpoint's certificate chain to the peer.
 
-> The certificate MUST be appropriate for the negotiated cipher suite's key
-exchange algorithm and any negotiated extensions.
+> The certificate MUST be appropriate for the negotiated cipher suite's
+authentication algorithm and any negotiated extensions.
 
 Structure of this message:
 
@@ -2288,8 +2288,7 @@ Structure of this message:
 certificate_request_context:
 : If this message is in response to a CertificateRequest, the
   value of certificate_request_context in that message. Otherwise,
-  in the case of server authentication or client authentication
-  in 0-RTT, this field SHALL be zero length.
+  in the case of server authentication this field SHALL be zero length.
 
 certificate_list
 : This is a sequence (chain) of certificates. The sender's
@@ -2323,13 +2322,8 @@ The following rules apply to the certificates sent by the server:
   otherwise (e.g., {{RFC5081}}).
 
 - The server's end-entity certificate's public key (and associated
-  restrictions) MUST be compatible with the selected key exchange
-  algorithm.
-
-| Key Exchange Alg.    | Certificate Key Type       |
-|----------------------|----------------------------|
-| DHE_RSA or ECDHE_RSA | RSA public key             |
-| ECDHE_ECDSA          | ECDSA or EdDSA public key  |
+  restrictions) MUST be compatible with the selected authentication
+  algorithm (currently RSA or ECDSA).
 
 - The certificate MUST allow the key to be used for signing (i.e., the
   digitalSignature bit MUST be set if the Key Usage extension is present) with
@@ -2379,10 +2373,10 @@ In particular:
   message was non-empty, one of the certificates in the certificate
   chain SHOULD be issued by one of the listed CAs.
 
-- The certificates MUST be signed using an acceptable hash/
-  signature algorithm pair, as described in {{certificate-request}}.  Note
-  that this relaxes the constraints on certificate-signing
-  algorithms found in prior versions of TLS.
+- The certificates MUST be signed using an acceptable signature
+  algorithm, as described in {{certificate-request}}.  Note that this
+  relaxes the constraints on certificate-signing algorithms found in
+  prior versions of TLS.
 
 - If the certificate_extensions list in the certificate request message
   was non-empty, the end-entity certificate MUST match the extension OIDs
@@ -2409,11 +2403,7 @@ handshake (considering the client unauthenticated) or send a fatal alert.
 
 Any endpoint receiving any certificate signed using any signature algorithm
 using an MD5 hash MUST send a "bad_certificate" alert message and close
-the connection.
-
-SHA-1 is deprecated and therefore NOT RECOMMENDED.
-Endpoints that reject certification paths due to use of a deprecated hash MUST send
-a fatal "bad_certificate" alert message before closing the connection.
+the connection. SHA-1 is deprecated and therefore NOT RECOMMENDED.
 All endpoints are RECOMMENDED to transition to SHA-256 or better as soon
 as possible to maintain interoperability with implementations
 currently in the process of phasing out SHA-1 support.
@@ -2421,6 +2411,10 @@ currently in the process of phasing out SHA-1 support.
 Note that a certificate containing a key for one signature algorithm
 MAY be signed using a different signature algorithm (for instance,
 an RSA key signed with an ECDSA key).
+
+Endpoints that reject certification paths due to use of a deprecated
+hash MUST send a fatal "bad_certificate" alert message before closing
+the connection.
 
 
 ###  Certificate Verify
@@ -2494,7 +2488,7 @@ If sent by a server, the signature algorithm MUST be one offered in the
 client's "signature_algorithms" extension unless no valid certificate chain can be
 produced without unsupported algorithms (see {{signature-algorithms}}). Note that
 there is a possibility for inconsistencies here. For instance, the client might
-offer ECDHE_ECDSA key exchange but omit any ECDSA and EdDSA values from its
+offer an ECDHE_ECDSA cipher suite but omit any ECDSA and EdDSA values from its
 "signature_algorithms" extension. In order to negotiate correctly, the server
 MUST check any candidate cipher suites against the "signature_algorithms"
 extension before selecting them. This is somewhat inelegant but is a compromise

--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -723,7 +723,7 @@ send the client a PSK identity which corresponds to a key derived from
 the initial handshake (See {{NewSessionTicket}}). The client
 can then use that PSK identity in future handshakes to negotiate use
 of the PSK; if the server accepts it, then the security context of the
-original connection is tied to the new connection. In TLS 1.2 and
+new connection is tied to the original connection. In TLS 1.2 and
 below, this functionality was provided by "session resumption" and
 "session tickets" {{RFC5077}}. Both mechanisms are obsoleted in TLS
 1.3.
@@ -1154,9 +1154,15 @@ ClientHello as its first message. The client will also send a
 ClientHello when the server has responded to its ClientHello with a
 ServerHello that selects cryptographic parameters that don't match the
 client's "key_share" extension. In that case, the client MUST send the same
-ClientHello (without modification) except including a new KeyShareEntry
-as the lowest priority share (i.e., appended to the list of shares in
-the "key_share" extension). If a server receives a ClientHello at any other time, it MUST send
+ClientHello (without modification) except:
+
+- Including a new KeyShareEntry as the lowest priority share
+  (i.e., appended to the list of shares in the "key_share" extension).
+
+- Removing the EarlyDataIndication {{early-data-indication}} extension
+  if one was present. Early data is not permitted after HelloRetryRequest.
+  
+If a server receives a ClientHello at any other time, it MUST send
 a fatal "unexpected_message" alert and close the connection.
 
 Structure of this message:

--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -2650,7 +2650,7 @@ ticket_lifetime
   ticket_lifetime.
 
 ticket_age_add
-: A randomly 32-bit value that is used to obscure the age of the ticket that the
+: A randomly generated 32-bit value that is used to obscure the age of the ticket that the
   client includes in the "early_data" extension.  The actual ticket age is
   added to this value modulo 2^32 to obtain the value that is transmitted by
   the client.
@@ -2889,7 +2889,8 @@ The traffic keying material is generated from the following input values:
 The keying material is computed using:
 
        key = HKDF-Expand-Label(Secret,
-                               phase + ", " + purpose, "",
+                               phase + ", " + purpose,
+                               "",
                                key_length)
 
 The following table describes the inputs to the key calculation for

--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -2553,7 +2553,7 @@ Structure of this message:
 %%% Authentication Messages
 
        struct {
-           opaque verify_data[verify_data_length];
+           opaque verify_data[Hash.length];
        } Finished;
 
 
@@ -2561,10 +2561,13 @@ The verify_data value is computed as follows:
 
        verify_data =
            HMAC(finished_key, Hash(
-                  Handshake Context + Certificate* + CertificateVerify*
-               ) + Hash(resumption_context)
-               )
-
+                                   Handshake Context +
+                                   Certificate* +
+                                   CertificateVerify*
+                              ) +
+                              Hash(resumption_context)
+           )
+ 
        * Only included if present.
 
 Where HMAC {{RFC2104}} uses the Hash algorithm for the handshake.

--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -672,23 +672,6 @@ Finished message. Note that while the server may send application data
 prior to receiving the client's Authentication messages, any data sent at
 that point is, of course, being sent to an unauthenticated peer.
 
-[[TODO: Move this elsewhere?
-Note that higher layers should not be overly reliant on whether TLS always
-negotiates the strongest possible connection between two endpoints. There are a
-number of ways in which a man-in-the-middle attacker can attempt to make two
-entities drop down to the least secure method they support
-(i.e., perform a downgrade attack). The TLS protocol has
-been designed to minimize this risk, but there are still attacks available: for
-example, an attacker could block access to the port a secure service runs on,
-or attempt to get the peers to negotiate an unauthenticated connection. The
-fundamental rule is that higher levels must be cognizant of what their security
-requirements are and never transmit information over a channel less secure than
-what they require. The TLS protocol is secure in that any cipher suite offers
-its promised level of security: if you negotiate AES-GCM {{GCM}} with
-a 255-bit ECDHE key exchange with a host whose certificate
-chain you have verified, you can expect that to be reasonably "secure"
-against algorithmic attacks, at least in the year 2015.]]
-
 ## Incorrect DHE Share
 
 If the client has not provided an appropriate "key_share" extension (e.g. it

--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -1904,7 +1904,7 @@ generate a fatal "unknown_psk_identity" alert and close the connection.
 
 Note that although 0-RTT data is encrypted with the first PSK identity, the
 server may fall back to 1-RTT and select a different PSK identity if multiple
-are offered.
+identities are offered.
 
 
 ### OCSP Status Extensions
@@ -2029,9 +2029,8 @@ send the ServerHello, rather than waiting for the client's
 
 #### Replay Properties {#replay-time}
 
-As noted in {{zero-rtt-data}}, TLS provides only a limited
-inter-connection mechanism for replay protection for data sent by the
-client in the first flight.
+As noted in {{zero-rtt-data}}, TLS provides a limited mechanism for
+replay protection for data sent by the client in the first flight.
 
 The "obfuscated_ticket_age" parameter in the client's "early_data" extension SHOULD be used by
 servers to limit the time over which the first flight might be
@@ -2050,9 +2049,10 @@ time prior to sending the NewSessionTicket message and account for
 that in the value it saves.
 
 To properly validate the ticket age, a server needs to save at least two items:
-* The time that the server generated the session ticket and the estimated round
+
+- The time that the server generated the session ticket and the estimated round
   trip time can be added together to form a baseline time.
-* The "ticket_age_add" parameter from the NewSessionTicket is needed to recover
+- The "ticket_age_add" parameter from the NewSessionTicket is needed to recover
   the ticket age from the "obfuscated_ticket_age" parameter.
 
 There are several potential sources of error that make an exact

--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -1721,10 +1721,6 @@ completed handshake to change what groups they offer to a server in
 subsequent connections.
 
 
-[[TODO: IANA Considerations.]]
-
-
-
 ### Key Share
 
 The "key_share" extension contains the endpoint's cryptographic parameters

--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -1371,35 +1371,7 @@ padding selection algorithms, or define a padding policy request
 mechanism through TLS extensions or some other means.
 
 
-#  The TLS Handshaking Protocols
-
-TLS has two subprotocols that are used to allow peers to agree upon security
-parameters for the record layer, to authenticate themselves, to instantiate
-negotiated security parameters, and to report error conditions to each other.
-
-The TLS Handshake Protocol is responsible for negotiating a session, which consists
-of the following items:
-
-peer certificate
-: X509v3 {{RFC5280}} certificate of the peer.  This element of the state
-  may be null.
-
-cipher spec
-: Specifies the authentication and key establishment algorithms,
-  the hash for use with HKDF to generate keying
-  material, and the record protection algorithm
-
-resumption master secret
-: a secret shared between the client and server that can be used
-  as a pre-shared symmetric key (PSK) in future connections.
-{:br }
-
-These items are then used to create security parameters for use by the record
-layer when protecting application data. Many connections can be instantiated
-using the same session using a PSK established in an initial handshake.
-
-
-##  Alert Protocol
+#  Alert Protocol
 
 One of the content types supported by the TLS record layer is the alert type.
 Alert messages convey the severity of the message (warning or fatal) and a
@@ -1456,7 +1428,7 @@ as specified by the current connection state.
            AlertDescription description;
        } Alert;
 
-###  Closure Alerts
+##  Closure Alerts
 
 The client and the server must share knowledge that the connection is ending in
 order to avoid a truncation attack. Failure to properly close a connection does
@@ -1508,7 +1480,7 @@ manages its data transport, including when connections are opened or closed.
 Note: It is assumed that closing a connection reliably delivers pending data
 before destroying the transport.
 
-###  Error Alerts
+##  Error Alerts
 
 Error handling in the TLS Handshake Protocol is very simple. When an error is
 detected, the detecting party sends a message to its peer. Upon
@@ -1673,7 +1645,7 @@ unknown_psk_identity
 New Alert values are assigned by IANA as described in {{iana-considerations}}.
 
 
-##  Handshake Protocol
+#  Handshake Protocol
 
 The TLS Handshake Protocol is one of the defined higher-level clients of the
 TLS Record Protocol. This protocol is used to negotiate the secure attributes
@@ -1726,13 +1698,13 @@ messages can be omitted, however.
 New handshake message types are assigned by IANA as described in
 {{iana-considerations}}.
 
-### Key Exchange Messages
+## Key Exchange Messages
 
 The key exchange messages are used to exchange security capabilities
 between the client and server and to establish the traffic keys used to protect
 the handshake and the data.
 
-####  Client Hello
+###  Client Hello
 
 When this message will be sent:
 
@@ -1843,7 +1815,7 @@ formats; if not, then it MUST send a fatal "decode_error" alert.
 After sending the ClientHello message, the client waits for a ServerHello
 or HelloRetryRequest message.
 
-####  Server Hello
+###  Server Hello
 
 When this message will be sent:
 
@@ -1929,7 +1901,7 @@ Note: This is an update to TLS 1.2 so in practice many TLS 1.2 clients
 and servers will not behave as specified above.
 
 
-####  Hello Retry Request
+###  Hello Retry Request
 
 When this message will be sent:
 
@@ -1986,7 +1958,7 @@ the selected CipherSuite and NamedGroup match that supplied in
 the HelloRetryRequest. If either of these values differ, the client
 MUST abort the connection with a fatal "handshake_failure" alert.
 
-###  Hello Extensions
+##  Hello Extensions
 
 The extension format is:
 
@@ -2079,7 +2051,7 @@ be taken into account when designing new extensions:
   any major design change.
 
 
-####  Cookie
+###  Cookie
 
 %%% Cookie Extension
 
@@ -2106,7 +2078,7 @@ new ClientHello, the client MUST echo the value of the extension.
 Clients MUST NOT use cookies in subsequent connections.
 
 
-####  Signature Algorithms
+###  Signature Algorithms
 
 The client uses the "signature_algorithms" extension to indicate to the server
 which signature algorithms may be used in digital signatures.
@@ -2231,7 +2203,7 @@ willing to negotiate TLS 1.2 MUST behave in accordance with the requirements of
 * ecdsa_secp256r1_sha256, etc., align with TLS 1.2's ECDSA hash/signature pairs.
   However, the old semantics did not constrain the signing curve.
 
-#### Negotiated Groups
+### Negotiated Groups
 
 When sent by the client, the "supported_groups" extension indicates
 the named groups which the client supports, ordered from most preferred
@@ -2314,7 +2286,7 @@ subsequent connections.
 
 
 
-#### Key Share
+### Key Share
 
 The "key_share" extension contains the endpoint's cryptographic parameters
 for non-PSK key establishment methods (currently DHE or ECDHE).
@@ -2402,7 +2374,7 @@ the server MUST NOT negotiate an (EC)DHE cipher suite.
 [[TODO: Recommendation about what the client offers.
 Presumably which integer DH groups and which curves.]]
 
-#####  Diffie-Hellman Parameters {#ffdhe-param}
+####  Diffie-Hellman Parameters {#ffdhe-param}
 
 Diffie-Hellman {{DH}} parameters for both clients and servers are encoded in
 the opaque key_exchange field of a KeyShareEntry in a KeyShare structure.
@@ -2413,7 +2385,7 @@ encoded as a big-endian integer, padded with zeros to the size of p.
 Note: For a given Diffie-Hellman group, the padding results in all public keys
 having the same length.
 
-##### ECDHE Parameters {#ecdhe-param}
+#### ECDHE Parameters {#ecdhe-param}
 
 ECDHE parameters for both clients and servers are encoded in the
 the opaque key_exchange field of a KeyShareEntry in a KeyShare structure.
@@ -2436,7 +2408,7 @@ Note: Versions of TLS prior to 1.3 permitted point negotiation;
 TLS 1.3 removes this feature in favor of a single point format
 for each curve.
 
-#### Pre-Shared Key Extension
+### Pre-Shared Key Extension
 
 The "pre_shared_key" extension is used to indicate the identity of the
 pre-shared key to be used with a given handshake in association
@@ -2498,7 +2470,7 @@ server may fall back to 1-RTT and select a different PSK identity if multiple
 are offered.
 
 
-#### OCSP Status Extensions
+### OCSP Status Extensions
 
 {{!RFC6066}} and {{!RFC6961}} provide extensions to negotiate the server
 sending OCSP responses to the client. In TLS 1.2 and below, the
@@ -2516,7 +2488,7 @@ the existing behavior for SignedCertificateTimestamps {{?RFC6962}},
 and is more easily extensible in the handshake state machine.
 
 
-#### Early Data Indication
+### Early Data Indication
 
 When PSK resumption is used, the client can send application data
 in its first flight of messages. If the client opts to do so, it MUST
@@ -2609,7 +2581,7 @@ an accepted "early_data" extension MUST produce a fatal
 
 [[TODO: How does the client behave if the indication is rejected.]]
 
-##### Processing Order
+#### Processing Order
 
 Clients are permitted to "stream" 0-RTT data until they
 receive the server's Finished, only then sending the "end_of_early_data"
@@ -2618,7 +2590,7 @@ servers MUST process the client's Finished and then immediately
 send the ServerHello, rather than waiting for the client's
 "end_of_early_data" alert.
 
-##### Replay Properties {#replay-time}
+#### Replay Properties {#replay-time}
 
 As noted in {{zero-rtt-data}}, TLS provides only a limited
 inter-connection mechanism for replay protection for data sent by the
@@ -2659,7 +2631,7 @@ is advisable.  However, any allowance also increases the opportunity
 for replay.  In this case, it is better to reject early data than to
 risk greater exposure to replay attacks.
 
-####  Encrypted Extensions
+###  Encrypted Extensions
 
 When this message will be sent:
 
@@ -2697,7 +2669,7 @@ extensions
 : A list of extensions.
 {:br }
 
-####  Certificate Request
+###  Certificate Request
 
 When this message will be sent:
 
@@ -2790,7 +2762,7 @@ certificate_extensions
 Note: It is a fatal "handshake_failure" alert for an anonymous server to request
 client authentication.
 
-### Authentication Messages
+## Authentication Messages
 
 As discussed in {{protocol-overview}}, TLS uses a common
 set of messages for authentication, key confirmation, and handshake
@@ -2843,7 +2815,7 @@ for each scenario:
 Note: The Handshake Context for the last three rows does not include any 0-RTT
   handshake messages, regardless of whether 0-RTT is used.
 
-####  Certificate
+###  Certificate
 
 When this message will be sent:
 
@@ -2906,7 +2878,7 @@ send an empty certificate list if it does not have an appropriate
 certificate to send in response to the server's authentication
 request.
 
-##### Server Certificate Selection
+#### Server Certificate Selection
 
 The following rules apply to the certificates sent by the server:
 
@@ -2957,7 +2929,7 @@ TLS protocol, they will imply the certificate format and the required encoded
 keying information.
 
 
-##### Client Certificate Selection
+#### Client Certificate Selection
 
 The following rules apply to certificates sent by the client:
 
@@ -2983,7 +2955,7 @@ Note that, as with the server certificate, there are certificates that use
 algorithm combinations that cannot be currently used with TLS.
 
 
-##### Receiving a Certificate Message
+#### Receiving a Certificate Message
 
 In general, detailed certificate validation procedures are out of scope for
 TLS (see {{RFC5280}}). This section provides TLS-specific requirements.
@@ -3014,7 +2986,7 @@ MAY be signed using a different signature algorithm (for instance,
 an RSA key signed with an ECDSA key).
 
 
-####  Certificate Verify
+###  Certificate Verify
 
 When this message will be sent:
 
@@ -3118,7 +3090,7 @@ authentication with pure PSK modes (i.e., those where the
 PSK was not derived from a previous non-PSK handshake).
 
 
-####  Finished
+###  Finished
 
 When this message will be sent:
 
@@ -3175,13 +3147,13 @@ Hash used for the handshake.
 Note: Alerts and any other record types are not handshake messages
 and are not included in the hash computations.
 
-### Post-Handshake Messages
+## Post-Handshake Messages
 
 TLS also allows other messages to be sent after the main handshake.
 These messages use a handshake content type and are encrypted under the application
 traffic key.
 
-#### New Session Ticket Message {#NewSessionTicket}
+### New Session Ticket Message {#NewSessionTicket}
 
 At any time after the server has received the client Finished message, it MAY send
 a NewSessionTicket message. This message creates a pre-shared key
@@ -3282,7 +3254,7 @@ the cipher suite negotiated for this connection. If no flags are set
 that the client recognizes, it MUST ignore the ticket.
 
 
-#### Post-Handshake Authentication
+### Post-Handshake Authentication
 
 The server is permitted to request client authentication at any time
 after the handshake has completed by sending a CertificateRequest
@@ -3301,7 +3273,7 @@ certificate_request_context value allows the server to disambiguate
 the responses).
 
 
-#### Key and IV Update {#key-update}
+### Key and IV Update {#key-update}
 
      struct {} KeyUpdate;
 

--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -1378,7 +1378,8 @@ selected_group
 The server_version, cipher_suite, and extensions fields have the
 same meanings as their corresponding values in the ServerHello. The
 server SHOULD send only the extensions necessary for the client to
-generate a correct ClientHello pair. As with ServerHello, a
+generate a correct ClientHello pair (currently no such extensions
+exist.) As with ServerHello, a
 HelloRetryRequest MUST NOT contain any extensions that were not first
 offered by the client in its ClientHello.
 
@@ -1455,10 +1456,10 @@ ServerHello messages, the extensions MAY appear in any order. There MUST NOT be
 more than one extension of the same type.
 
 Finally, note that extensions can be sent both when starting a new session and
-when requesting session resumption or 0-RTT mode. Indeed, a client that requests session
+when in resumption-PSK mode. Indeed, a client that requests session
 resumption does not in general know whether the server will accept this
-request, and therefore it SHOULD send the same extensions as it would send if
-it were not attempting resumption.
+request, and therefore it SHOULD send the same extensions as it would send
+normally.
 
 In general, the specification of each extension type needs to describe the
 effect of the extension both during full handshake and session resumption. Most
@@ -1488,15 +1489,6 @@ be taken into account when designing new extensions:
   Designers and implementors should be aware of the fact that until the
   handshake has been authenticated, active attackers can modify messages and
   insert, remove, or replace extensions.
-
-- It would be technically possible to use extensions to change major aspects
-  of the design of TLS; for example, the design of cipher suite negotiation.
-  This is not recommended; it would be more appropriate to define a new version
-  of TLS --- particularly since the TLS handshake algorithms have specific
-  protection against version rollback attacks based on the version number, and
-  the possibility of version rollback should be a significant consideration in
-  any major design change.
-
 
 ###  Cookie
 


### PR DESCRIPTION
This is a lot of editorial work. Specifically:

- Removing redundant text
- Reordering things so that the handshake appears first and making the handshake and alert section A heds
- Harmonize a bunch of text
- Remove the obsolete Security Analysis text in preparation for providing a real Security Analysis section.

This is my first cut and I will make another pass later today to catch mistakes/things that still need to be updated.

@davegarrett @martinthomson you may want to take a look at this pre-merge.