### PR TITLE
Remove server missing_extension requirements.

### DIFF
--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -1652,8 +1652,6 @@ which signature algorithms may be used in digital signatures.
 
 Clients which offer one or more cipher suites which use certificate authentication
 (i.e., any non-PSK cipher suite) MUST send the "signature_algorithms" extension.
-If this extension is not provided and no alternative cipher suite is available,
-the server MUST close the connection with a fatal "missing_extension" alert.
 (see {{mti-extensions}})
 
 The "extension_data" field of this extension contains a
@@ -1785,8 +1783,6 @@ ECDSA curves. Signature algorithms are now negotiated independently (see
 Clients which offer one or more (EC)DHE cipher suites MUST send at least one
 supported NamedGroup value and servers MUST NOT negotiate any of these
 cipher suites unless a supported value was provided.
-If this extension is not provided and no alternative cipher suite is available,
-the server MUST close the connection with a fatal "missing_extension" alert.
 (see {{mti-extensions}})
 If the extension is provided, but no compatible group is offered, the
 server MUST NOT negotiate a cipher suite of the relevant type. For
@@ -1858,8 +1854,8 @@ Clients which offer one or more (EC)DHE cipher suites MUST send this
 extension and SHOULD send at least one supported KeyShareEntry value.
 Servers MUST NOT negotiate any of these cipher suites unless a supported
 value was provided.
-If this extension is not provided in a ServerHello or ClientHello,
-and the peer is offering (EC)DHE cipher suites, then the endpoint MUST close
+If this extension is not provided in a ServerHello,
+and the client selected an (EC)DHE cipher suite, then the client MUST close
 the connection with a fatal "missing_extension" alert.
 (see {{mti-extensions}})
 Clients MAY send an empty client_shares vector in order to request
@@ -1989,8 +1985,6 @@ Clients which offer one or more PSK cipher suites
 MUST send at least one supported psk_identity value and
 servers MUST NOT negotiate any of these cipher suites unless a supported
 value was provided.
-If this extension is not provided and no alternative cipher suite is available,
-the server MUST close the connection with a fatal "missing_extension" alert.
 (see {{mti-extensions}})
 
 The "extension_data" field of this extension contains a
@@ -2030,6 +2024,8 @@ suite, if available.
 
 If the server selects a PSK cipher suite, it MUST send a
 "pre_shared_key" extension with the identity that it selected.
+If this extension is not provided, the client MUST close the connection with a
+fatal "missing_extension" alert.
 The client MUST verify that the server's selected_identity
 is within the range supplied by the client. If the server supplies an
 "early_data" extension, the client MUST verify that the server selected the


### PR DESCRIPTION
(This is orthogonal to whether alerts should be MUST or SHOULD. I've
left them as MUST for now.)

While the client can reasonably send missing_extension in response to a
ServerHello which, say, selected an ECDHE cipher without key_share, the
server is in no such position. Such a requirement is unhelpful as a
natural implementation would have the same behavior (connection failed)
anyway.

Since servers already must account for some ciphers requiring ECDHE and
some not, a server may implement logic such as:

    ecdheOk := tryToSelectAGroup(myList, clientList)
    for cipher in serverCiphers {
        if cipher not in clientCiphers {
            continue
        }
        if isECDHE(cipher) and not ecdheOk {
            continue
        }
        ... other checks, etc. ...
        yay, I found a cipher
    }
    if no cipher was found {
        send handshake_failure and close connection
    }

There is no reason to ask a server to distinguish between the following
cases, all of which will fail anyway:

- The client sent only ECDHE ciphers I know about but did not send
  key_share.
- The client sent only ECDHE ciphers I know about but only key_shares I
  don't implement.
- The client sent only ECDHE ciphers, some of which I don't know about,
  and did not send key_share.
- The client sent ECDHE ciphers I know about and some PSK ciphers I
  don't know about and did not send key_share.
- The client sent only ECDHE ciphers, none of which I know about, and
  did not send key_share.

Notably, the some cases are not even distinguishable, even though the
old text mandates different alerts for them. The only case we can
reasonably send missing_extension for is the first, but this is an
unhelpful special-case to mandate. It only adds complexity (the
connection will fail anyway), thus risking bugs.