### PR TITLE
Clarify that the key changes immediately at Finished.

### DIFF
--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -2719,6 +2719,10 @@ Hash used for the handshake.
 Note: Alerts and any other record types are not handshake messages
 and are not included in the hash computations.
 
+Any records following a 1-RTT Finished message MUST be encrypted under the
+application traffic key. In particular, this includes any alerts sent by the
+server in response to client Certificate and CertificateVerify messages.
+
 ## Post-Handshake Messages
 
 TLS also allows other messages to be sent after the main handshake.


### PR DESCRIPTION
(My impression from the list is that we're not doing post-handshake key separation. If I'm wrong and we are, this will need to be slightly tweaked. Anyway, the current state of the world is we don't do it, so I've worded it accordingly.)

---

As the Finished message is an implicit ChangeCipherSpec, it's worth
clarifying that this is the point at which the cipher state changes.

Should an implementation not send half-RTT data, it may defer switching
traffic keys until both Finished messages have been exchanged. This will
not work well, as alerts sent in response to a bad client certificate
will be unreadable. The outgoing traffic keys must be switched early.