### PR TITLE
Require the CertificateRequest context to be empty in the handshake.

### DIFF
--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -2275,7 +2275,7 @@ certificate_request_context
   which will be echoed in the client's Certificate message. The
   certificate_request_context MUST be unique within the scope
   of this connection (thus preventing replay of client
-  CertificateVerify messages).
+  CertificateVerify messages). Within the handshake, this field MUST be empty.
 
 supported_signature_algorithms
 : A list of the signature algorithms that the server is


### PR DESCRIPTION
It's only useful during the handshake, so avoid forcing the client save
that field for the in-handshake version.