### PR TITLE
Fix typo in key schedule.

### DIFF
--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -3508,7 +3508,7 @@ In this diagram, the following formatting conventions apply:
                  v
               Handshake
                Secret -----> Derive-Secret(., "handshake traffic secret",
-                 |                         ClientHello + ServerHello)
+                 |                         ClientHello...ServerHello)
                  |                         = handshake_traffic_secret
                  v
       0 -> HKDF-Extract


### PR DESCRIPTION
There may be messages between ClientHello and ServerHello
(HelloRetryRequest and the second ClientHello), so use ... rather than
+.