### PR TITLE
Tweak NewSessionTicket lower bounds.

### DIFF
--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -2773,8 +2773,8 @@ Hash.Length zeroes.
          uint32 ticket_lifetime;
          uint32 flags;
          uint32 ticket_age_add;
-         TicketExtension extensions<2..2^16-2>;
-         opaque ticket<0..2^16-1>;
+         TicketExtension extensions<0..2^16-2>;
+         opaque ticket<1..2^16-1>;
      } NewSessionTicket;
 
 


### PR DESCRIPTION
In TLS 1.2, empty tickets were used for the server to change its mind
about sending a ticket after committing to it in ServerHello:

> If the server determines that it does not want to include a
> ticket after it has included the SessionTicket extension in the
> ServerHello, then it sends a zero-length ticket in the
> NewSessionTicket handshake message.

This is not useful in TLS 1.3 where a server could decline to send a
ticket at all, so don't allow 0. (Fields tend to specify whether empty
values are allowed.)

Also lower the minimum NewSessionTicket.extensions size from 2 to 0.
Since we haven't defined any TicketExtensionTypes at all, it probably
should be allowed to be empty.