### PR TITLE
extension name is "Supported Groups", not "Named Group"

### DIFF
--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -1798,7 +1798,7 @@ fatal "handshake_failure" alert.
 The "extension_data" field of this extension contains a
 "NamedGroupList" value:
 
-%%% Named Group Extension
+%%% Supported Groups Extension
 
        enum {
            /* Elliptic Curve Groups (ECDHE) */
@@ -3842,7 +3842,7 @@ might receive them from older TLS implementations.
 %%### Key Exchange Messages
 %%#### Cookie Extension
 %%#### Signature Algorithm Extension
-%%#### Named Group Extension
+%%#### Supported Groups Extension
 
 Values within "obsolete_RESERVED" ranges were used in previous versions
 of TLS and MUST NOT be offered or negotiated by TLS 1.3 implementations.


### PR DESCRIPTION
We have a registry called "supported groups", and the extension is
"supported groups"; but each element is called a "named group" and the
data passed in the extension is a "named group list".  be consistent
in our terminology.