### PR TITLE
Forbid post-handshake handshake/application interleave.

### DIFF
--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -2729,9 +2729,9 @@ TLS also allows other messages to be sent after the main handshake.
 These messages use a handshake content type and are encrypted under the application
 traffic key.
 
-Handshake messages sent after the handshake MUST NOT be interleaved with
-application data. That is, if a message is split over two or more handshake
-records, there MUST NOT be any application data records between them.
+Handshake messages sent after the handshake MUST NOT be interleaved with other
+record types. That is, if a message is split over two or more handshake
+records, there MUST NOT be any other records between them.
 
 ### New Session Ticket Message {#NewSessionTicket}
 

--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -2729,6 +2729,10 @@ TLS also allows other messages to be sent after the main handshake.
 These messages use a handshake content type and are encrypted under the application
 traffic key.
 
+Handshake messages sent after the handshake MUST NOT be interleaved with
+application data. That is, if a message is split over two or more handshake
+records, there MUST NOT be any application data records between them.
+
 ### New Session Ticket Message {#NewSessionTicket}
 
 At any time after the server has received the client Finished message, it MAY send


### PR DESCRIPTION
No sender could possibly need to send half of a message interleaved with
application data in TLS, so forbid this. This cuts down on the
state-space a receiver needs to worry about.

This also means one cannot force the peer to buffer all but one byte of
a giant post-handshake message, and then never complete it for the
lifetime of the connection. (Although it does not remove all
steady state buffering DoS-type concerns.)