### PR TITLE
Codify receiver obligations on epoch changes.

### DIFF
--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -1387,6 +1387,10 @@ formats; if not, then it MUST send a fatal "decode_error" alert.
 After sending the ClientHello message, the client waits for a ServerHello
 or HelloRetryRequest message.
 
+The next message the client sends will be under a different key, so the server
+MUST check that the end of the ClientHello message aligns with a record
+boundary.
+
 ###  Server Hello
 
 When this message will be sent:
@@ -1472,6 +1476,9 @@ when static RSA is used.
 
 Note: This is an update to TLS 1.2 so in practice many TLS 1.2 clients
 and servers will not behave as specified above.
+
+ServerHello signals a key change, so the client MUST check that the end of the
+ServerHello message aligns with a record boundary.
 
 
 ###  Hello Retry Request
@@ -2721,7 +2728,9 @@ and are not included in the hash computations.
 
 Any records following a 1-RTT Finished message MUST be encrypted under the
 application traffic key. In particular, this includes any alerts sent by the
-server in response to client Certificate and CertificateVerify messages.
+server in response to client Certificate and CertificateVerify messages. The
+receiver MUST check that the end of the Finished message aligns with a record
+boundary.
 
 ## Post-Handshake Messages
 
@@ -2888,6 +2897,9 @@ messages with the old keys. Additionally, both sides MUST enforce that
 a KeyUpdate with the old key is received before accepting any messages
 encrypted with the new key. Failure to do so may allow message truncation
 attacks.
+
+KeyUpdate signals a key change, so the receiver MUST check that the end of the
+KeyUpdate message aligns with a record boundary.
 
 
 #  Record Protocol

--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -1389,7 +1389,7 @@ or HelloRetryRequest message.
 
 The next message the client sends will be under a different key, so the server
 MUST check that the end of the ClientHello message aligns with a record
-boundary.
+boundary; if not, then it MUST send a fatal "unexpected_message" alert.
 
 ###  Server Hello
 
@@ -1478,7 +1478,8 @@ Note: This is an update to TLS 1.2 so in practice many TLS 1.2 clients
 and servers will not behave as specified above.
 
 ServerHello signals a key change, so the client MUST check that the end of the
-ServerHello message aligns with a record boundary.
+ServerHello message aligns with a record boundary; if not, then it MUST send a
+fatal "unexpected_message" alert.
 
 
 ###  Hello Retry Request
@@ -2728,9 +2729,10 @@ and are not included in the hash computations.
 
 Any records following a 1-RTT Finished message MUST be encrypted under the
 application traffic key. In particular, this includes any alerts sent by the
-server in response to client Certificate and CertificateVerify messages. The
-receiver MUST check that the end of the Finished message aligns with a record
-boundary.
+server in response to client Certificate and CertificateVerify messages.
+
+The receiver MUST check that the end of the Finished message aligns with a
+record boundary; if not, then it MUST send a fatal "unexpected_message" alert.
 
 ## Post-Handshake Messages
 
@@ -2899,7 +2901,8 @@ encrypted with the new key. Failure to do so may allow message truncation
 attacks.
 
 KeyUpdate signals a key change, so the receiver MUST check that the end of the
-KeyUpdate message aligns with a record boundary.
+KeyUpdate message aligns with a record boundary; if not, then it MUST send a
+fatal "unexpected_message" alert.
 
 
 #  Record Protocol


### PR DESCRIPTION
TLS is stuck with the legacy of a layer of indirection between messages
and records. This means that message boundaries and record boundaries
need not be correlated at all, which has historically been the cause of
bugs.

Among other problems, correlating messages with key changes is subtle.
Receivers MUST ensure that there is no buffered handshake data cross
record boundaries. Otherwise one can inject prefixes authenticated under
one epoch into another. Write down these rules.

Note: the spelling of these rules is very TLS-centric. DTLS will need a
very different spelling of the rules. (It's not as straight-forward as
record boundaries. One must make sure there is no partial message data
beyond the current message.) Since DTLS 1.3 does not exist yet, I've
left that alone. We should extract a common "transport" or "dispatch"
layer interface between DTLS/TLS for the protocol to sit on top of for
that.