### PR TITLE
draft-ietf-tls-cached-info is now RFC 7924

### DIFF
--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -771,7 +771,7 @@ Certificate.
   server is not authenticating with a certificate (i.e.,
   with PSK or (EC)DHE-PSK cipher suites). Note that if raw public keys
   {{RFC7250}} or the cached information extension
-  {{?I-D.ietf-tls-cached-info}} are in use, then this message
+  {{?RFC7924}} are in use, then this message
   will not contain a certificate but rather some other value
   corresponding to the server's long-term key.
   [{{certificate}}]


### PR DESCRIPTION
draft-ietf-tls-cached-info is now [RFC 7924](https://tools.ietf.org/html/rfc7924). Update the reference.