### PR TITLE
Fix typo in cipher suite naming convention.

### DIFF
--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -3949,7 +3949,7 @@ function to be used with HKDF. Cipher suites follow the naming convention:
 Cipher suite names follow the naming convention:
 
 ~~~
-   CipherSuite TLS13_CIPHER_HASH = VALUE;
+   CipherSuite TLS_CIPHER_HASH = VALUE;
 ~~~
 
 | Component | Contents |


### PR DESCRIPTION
One 'TLS13_' prefix snuck by.