### PR TITLE
Downgrade a SHA-1 ordering requirement from MUST to SHOULD.

### DIFF
--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -1817,8 +1817,8 @@ EdDSA algorithms
 {:br }
 
 rsa_pkcs1_sha1, dsa_sha1, and ecdsa_sha1 SHOULD NOT be offered. Clients
-offering these values for backwards compatibility MUST list them as the lowest
-priority (listed after all other algorithms in the
+offering these values for backwards compatibility SHOULD list them as the
+lowest priority (listed after all other algorithms in the
 supported_signature_algorithms vector). TLS 1.3 servers MUST NOT offer a SHA-1
 signed certificate unless no valid certificate chain can be produced without it
 (see {{server-certificate-selection}}).


### PR DESCRIPTION
Alas, it turns out that not only are there plenty of servers incapable
of signing anything but SHA-1, but there are bugs in signature algorithm
processing. Specifically, older versions of NSS have the following bug:

   https://bugzilla.mozilla.org/show_bug.cgi?id=1119983

Affected versions will:

a) Refuse to sign anything but SHA-1. (Type mismatch between
   HashAlgorithm and internal OID identifier.)

b) Require that the SHA-1-based algorithm appear in the first N sigalg
   entries, where N is the number of sigalg entries that begin with a
   HashAlgorithm that NSS knows how to parse. (Mistake in appending to
   an array.)

The upshot is, with SHA-1 at the end, advertising new algorithms like
rsa_pss_sha256 or ed25519 will break those servers. This bug does not
appear very common (I found 35 hosts in a probe of the Alexa top 1m
list), but it is difficult to predict these things ahead of time. At
least one affected piece of software targets enterprise customers (it
bundles a copy of NSS), where outdated software is prevalent and
visibility nil.

To avoid tying our hands should we need ugly workarounds, downgrade MUST
to SHOULD. RSASSA-PKCS1-v1_5 is forbidden in TLS 1.3 anyway, so while
advertising rsa_pkcs1_* at the front would be poor, it shouldn't have
serious adverse effects.

(Note that version-intolerance is many orders magnitude higher, so this
will not save us from the fallback on its own. Nonetheless, even with a
fallback, it is simpler if the signature algorithms list could
eventually be kept constant between TLS 1.2 and TLS 1.3.)