### PR TITLE
Allow mk-appendix.py to run on Python 3 system

### DIFF
--- a/mk-appendix.py
+++ b/mk-appendix.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from __future__ import print_function
 import re
 import sys
 
@@ -13,12 +14,12 @@ def print_syntax(val):
     for v in vl:
         if v == "":
             if not last_empty:
-                print
+                print()
             last_empty = True
         else:
             last_empty = False
-            print v
-    print
+            print(v)
+    print()
 
 
 for l in sys.stdin:
@@ -30,16 +31,16 @@ for l in sys.stdin:
             m = re.match('%%(#+|!) (.*)$', l)
             if m is not None:
                 if m.group(1) != '!':
-                    print "%s %s"%(m.group(1), m.group(2))
+                    print("%s %s" % (m.group(1), m.group(2)))
                 print_syntax(APPENDICES[m.group(2)])
                 del APPENDICES[m.group(2)]
-                print
+                print()
             else:
-                print l,
+                print(l, end='')
     else:
         # Strip out everything marked as RESERVED
         if l.find("RESERVED") == -1:
-            print l,
+            print(l, end='')
         m = re.match("\S", l)
         if m is None:
             CURRENT += l
@@ -50,12 +51,7 @@ for l in sys.stdin:
             APPENDICES[IN_APPENDIX] += CURRENT
             CURRENT = ""
             IN_APPENDIX = None
-    
 
 if len(APPENDICES) > 0:
-    sys.stderr.write("Unused figures: " + str(APPENDICES.keys()) + "\n")
+    sys.stderr.write("Unused figures: " + str(list(APPENDICES.keys())) + "\n")
     sys.exit(1)
-
-
-
-    


### PR DESCRIPTION
I also verified that the output for Python 2 and Python 3 are the same.