### PR TITLE
Remove note about representing integers as opaque vectors.

### DIFF
--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -1108,11 +1108,6 @@ All values, here and elsewhere in the specification, are stored in network byte
 (big-endian) order; the uint32 represented by the hex bytes 01 02 03 04 is
 equivalent to the decimal value 16909060.
 
-Note that in some cases (e.g., DH parameters) it is necessary to represent
-integers as opaque vectors. In such cases, they are represented as unsigned
-integers (i.e., additional leading zero octets are not used even if the most
-significant bit is set).
-
 
 ##  Enumerateds
 


### PR DESCRIPTION
It looks like this is carried over from TLS 1.2---seems I was wrong and
TLS 1.2 did actually say whether there were leading zeros in front of
DHE parameters---but I believe it is no longer used.

Instead our crypto primitives all act on byte strings. Any conversion
between byte strings and the primitive's internal structures is handled
by the primitive itself. (RFC 7748 natively acts on byte strings,
4.2.4.1 specifies how FFDHE is encoded, RSA-PSS comes with a byte string
form, etc.)