### PR TITLE
Dual keying ladders, plus limit number of KeyUpdates.

### DIFF
--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -2956,7 +2956,7 @@ the responses).
 
 
 ### Key and IV Update {#key-update}
-     enum { update_not_requested(0), update_requested(2), (255)
+     enum { update_not_requested(0), update_requested(1), (255)
      } KeyUpdateRequest;
 
      struct {

--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -3625,7 +3625,9 @@ operation.
                  |
                  v
               Handshake
-               Secret -----> Derive-Secret(., "client handshake traffic secret",
+               Secret
+                 |
+                 +---------> Derive-Secret(., "client handshake traffic secret",
                  |                         ClientHello...ServerHello)
                  |                         = client_handshake_traffic_secret
                  |

--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -2494,7 +2494,7 @@ for each scenario:
 
 | Mode | Handshake Context | Base Key |
 |------|-------------------|----------|
-| 0-RTT | ClientHello | early_traffic_secret|
+| 0-RTT | ClientHello | client_early_traffic_secret|
 | 1-RTT (Server) | ClientHello ... later of EncryptedExtensions/CertificateRequest | [sender]_handshake_traffic_secret |
 | 1-RTT (Client) | ClientHello ... ServerFinished     | [sender]_handshake_traffic_secret |
 | Post-Handshake | ClientHello ... ClientFinished + CertificateRequest | [sender]_traffic_secret_N |
@@ -3605,7 +3605,7 @@ In this diagram, the following formatting conventions apply:
   from the left.
 - Derive-Secret's Secret argument is indicated by the arrow coming in
   from the left. For instance, the Early Secret is the Secret for
-  generating the early_traffic_secret.
+  generating the client_early_traffic_secret.
 
 Note that the 0-RTT Finished message is not included in the Derive-Secret
 operation.
@@ -3617,9 +3617,9 @@ operation.
    PSK ->  HKDF-Extract
                  |
                  v
-           Early Secret ---> Derive-Secret(., "early traffic secret",
+           Early Secret ---> Derive-Secret(., "client early traffic secret",
                  |                         ClientHello)
-                 |                         = early_traffic_secret
+                 |                         = client_early_traffic_secret
                  v
 (EC)DHE -> HKDF-Extract
                  |
@@ -3716,8 +3716,8 @@ each class of traffic keys:
 
 | Record Type | Secret | Phase |
 |:------------|--------|-------|
-| 0-RTT Handshake   | early_traffic_secret | "early handshake key expansion" |
-| 0-RTT Application | early_traffic_secret | "early application data key expansion" |
+| 0-RTT Handshake   | client_early_traffic_secret | "early handshake key expansion" |
+| 0-RTT Application | client_early_traffic_secret | "early application data key expansion" |
 | Handshake         | [sender]_handshake_traffic_secret | "handshake key expansion" |
 | Application Data  | [sender]_traffic_secret_N | "application data key expansion" |
 

--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -2956,14 +2956,14 @@ the responses).
 
 
 ### Key and IV Update {#key-update}
-
-     enum { true(1), false(2) (255) } Boolean;
+     enum { update_not_requested(0), update_requested(2), (255)
+     } KeyUpdateRequest;
 
      struct {
-         Boolean requestUpdate;
+         KeyUpdateRequest request_update;
      } KeyUpdate;
 
-requestUpdate
+request_update
 : Indicates that the recipient of the KeyUpdate should respond with its
 own KeyUpdate.
 {:br }
@@ -2979,23 +2979,20 @@ next generation of keys, computed as described in
 {{updating-traffic-keys}}. Upon receiving a KeyUpdate, the receiver
 MUST update its receiving keys.
 
-If the requestUpdate field is set to "true" then the receiver MUST
-send a KeyUpdate of its own with requestUpdate set to "false" prior
+If the requestUpdate field is set to "update_requested" then the receiver MUST
+send a KeyUpdate of its own with requestUpdate set to "update_not_requested" prior
 to sending its next application data record. This mechanism allows either side to force an update to the
 entire connection, but causes an implementation which
 receives multiple KeyUpdates while it is silent to respond with
 a single update. Note that implementations may receive an arbitrary
 number of messages between sending a KeyUpdate and receiving the
 peer's KeyUpdate because those messages may already be in flight.
-The side which sends its KeyUpdate first needs to retain
-its receive traffic keys (though not the traffic secret) for the previous
-generation of keys until it receives the KeyUpdate from the other
-side. Because send and receive keys are derived from independent
+However, because send and receive keys are derived from independent
 traffic secrets, retaining the receive traffic secret does not threaten
 the forward secrecy of data sent before the sender changed keys.
 
 If implementations independently send their own KeyUpdates with
-requestUpdate set to true, and they cross in flight, then each side
+requestUpdate set to "update_requested", and they cross in flight, then each side
 will also send a response, with the result that each side increments
 by two generations.
 
@@ -3627,8 +3624,7 @@ operation.
 (EC)DHE -> HKDF-Extract
                  |
                  v
-              Handshake
-               Secret
+         Handshake Secret
                  |
                  +---------> Derive-Secret(., "client handshake traffic secret",
                  |                         ClientHello...ServerHello)
@@ -3731,8 +3727,8 @@ following table indicates the purpose values for each type of key:
 
 | Key Type         | Purpose            |
 |:-----------------|:-------------------|
-| write_key | "write key" |
-| write_iv  | "write iv"  |
+| key | "key" |
+| iv  | "iv"  |
 
 All the traffic keying material is recomputed whenever the
 underlying Secret changes (e.g., when changing from the handshake to

--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -2970,7 +2970,7 @@ next generation of keys, computed as described in
 {{updating-traffic-keys}}. Upon receiving a KeyUpdate, the receiver
 MUST update its receiving keys.
 
-Each implementation MUST receive a min_send_generation counter that
+Each implementation MUST maintain a min_send_generation counter that
 is initialized to 0 at the time the traffic keys are installed.
 Upon receiving a KeyUpdate, if the receiver has sent any data records since receiving the
 last KeyUpdate it MUST also increment its min_send_generation value


### PR DESCRIPTION
The idea here is that you can be silently receiving, receive a pile
of KeyUpdates, and then respond with just one. Because there are
dual ladders, this doesn't cause PFS problem.


@davidben PTAL