### PR TITLE
prohibit use of renegotiation to negotiate TLSv1.3

### DIFF
--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -1370,6 +1370,12 @@ ClientHello (without modification) except:
 If a server receives a ClientHello at any other time, it MUST send
 a fatal "unexpected_message" alert and close the connection.
 
+If a server established a TLS session at a previous version of the protocol
+and receives a TLS 1.3 ClientHello in a renegotiation, it MUST retain the
+previous protocol version. In particular, it MUST NOT negotiate TLS 1.3.
+A client that receives a TLS 1.3 ServerHello in an established session MUST
+send a fatal "protocol_version" alert and close the connection.
+
 Structure of this message:
 
 %%% Key Exchange Messages


### PR DESCRIPTION
the renegotiation mechanism from TLSv1.2 and earlier is
deprecated, that deprecation extends to the ability to
renegotiate existing TLSv1.2 (or earlier) session to TLSv1.3