### PR TITLE
Editorial: Fix syntax errors

### DIFF
--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -3051,7 +3051,7 @@ Alert messages ({{alert-protocol}}) MUST NOT be fragmented across records.
            change_cipher_spec_RESERVED(20),
            alert(21),
            handshake(22),
-           application_data(23)
+           application_data(23),
            (255)
        } ContentType;
 


### PR DESCRIPTION
According to the Section 3.5. Enumerateds there must be a comma before the
width definition (I found this mistake by writing an source-to-source compiler
for the presentation language).