### PR TITLE
Remove server_name from the 0-RTT section.

### DIFF
--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -2224,8 +2224,6 @@ connection during which the ticket was established.
 
 - The TLS version number, AEAD algorithm, and the hash for HKDF.
 - The selected ALPN {{!RFC7443}} value, if any.
-- The server_name {{RFC6066}} value provided by the client,
-  if any.
 
 Future extensions MUST define their interaction with 0-RTT.
 


### PR DESCRIPTION
This seems to have just been a mistake? Unlike ALPN, server_name isn't a
value that is selected by the server, so there's no need to match it
against a value stored in the session.

There is the issue of whether sessions are resumable across names or
other application-level contexts (for instance, whether we send client
certificates, different cipher profiles, etc.), but that is a more
complex issue than simply matching on server_name on the server side.
Moreover, any rules there would want to apply to resumption as a whole.
It seems there's no reason to have 0-RTT-specific rules over resumption
ones here.