### PR TITLE
Editorial: Select on Handshake.msg_type

### DIFF
--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -1269,7 +1269,7 @@ processed and transmitted as specified by the current active session state.
        struct {
            HandshakeType msg_type;    /* handshake type */
            uint24 length;             /* bytes in message */
-           select (HandshakeType) {
+           select (Handshake.msg_type) {
                case client_hello:          ClientHello;
                case server_hello:          ServerHello;
                case hello_retry_request:   HelloRetryRequest;


### PR DESCRIPTION
The select statement in Handshake should be based on Handshake.msg_type since the field is already defined and the select statement is unnamed and does not define its own field.