### PR TITLE
Renumber new SignatureSchemes.

### DIFF
--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -3994,13 +3994,14 @@ by IANA
 -  TLS SignatureScheme Registry: Values with the first byte in the range
   0-254 (decimal) are assigned via Specification Required {{RFC2434}}.
   Values with the first byte 255 (decimal) are reserved for Private
-  Use {{RFC2434}}. This registry SHALL have a "Recommended" column.
+  Use {{RFC2434}}. Values with the first byte in the range 0-6 or with the
+  second byte in the range 0-3 that are not currently allocated are reserved for
+  backwards compatibility.
+  This registry SHALL have a "Recommended" column.
   The registry [shall be/ has been] initially populated with the values described in
   {{signature-algorithms}}. The following values SHALL be marked as
   "Recommended": ecdsa_secp256r1_sha256, ecdsa_secp384r1_sha384,
   rsa_pss_sha256, rsa_pss_sha384, rsa_pss_sha512, ed25519.
-
-  [[TODO: How to denote that values ending in 0x00 through 0x03 are also reserved?]]
 
 Finally, this document obsoletes the TLS HashAlgorithm Registry and the TLS
 SignatureAlgorithm Registry, both originally created in {{RFC5246}}.  IANA

--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -1771,13 +1771,13 @@ The "extension_data" field of this extension in a ClientHello contains a
            ecdsa_secp521r1_sha512 (0x0603),
 
            /* RSASSA-PSS algorithms */
-           rsa_pss_sha256 (0x0700),
-           rsa_pss_sha384 (0x0701),
-           rsa_pss_sha512 (0x0702),
+           rsa_pss_sha256 (0x0804),
+           rsa_pss_sha384 (0x0805),
+           rsa_pss_sha512 (0x0806),
 
            /* EdDSA algorithms */
-           ed25519 (0x0703),
-           ed448 (0x0704),
+           ed25519 (0x0807),
+           ed448 (0x0808),
 
            /* Reserved Code Points */
            dsa_sha1_RESERVED (0x0202),
@@ -4000,8 +4000,13 @@ by IANA
   "Recommended": ecdsa_secp256r1_sha256, ecdsa_secp384r1_sha384,
   rsa_pss_sha256, rsa_pss_sha384, rsa_pss_sha512, ed25519.
 
-Finally, this document obsoletes a registry originally created in {{RFC5246}}.
-IANA [shall/has] updated it to list values 7-223 as "Reserved".
+  [[TODO: How to denote that values ending in 0x00 through 0x03 are also reserved?]]
+
+Finally, this document obsoletes the TLS HashAlgorithm Registry and the TLS
+SignatureAlgorithm Registry, both originally created in {{RFC5246}}.  IANA
+[shall/has] update the TLS HashAlgorithm Registry to list values 7-223 as
+"Reserved" and the TLS SignatureAlgorithm Registry to list values 4-233 as
+"Reserved".
 
 --- back
 


### PR DESCRIPTION
Avoid both starting with an existing hash AND ending with an existing
SignatureAlgorithm. In principle, this should not be necessary, but TLS
1.2 says:

>   signature
>      This field indicates the signature algorithm that may be used.
>      The values indicate anonymous signatures, RSASSA-PKCS1-v1_5
>      [PKCS1] and DSA [DSS], and ECDSA [ECDSA], respectively.  The
>      "anonymous" value is meaningless in this context but used in
>      Section 7.4.3.  It MUST NOT appear in this extension.

Bouncy Castle appears to have been enforcing this, causing interop
issues. As this was a straight-up MUST NOT, it seems prudent to
renumber. And if we're renumbering anyway, may as well avoid all the old
SignatureAlgorithms and avoid confusing tools like Wireshark.