### PR TITLE
Fix error in NamedGroupList

### DIFF
--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -1907,7 +1907,7 @@ The "extension_data" field of this extension contains a
        } NamedGroup;
 
        struct {
-           NamedGroup named_group_list<1..2^16-1>;
+           NamedGroup named_group_list<2..2^16-1>;
        } NamedGroupList;
 
 Elliptic Curve Groups (ECDHE)


### PR DESCRIPTION
Each value in NamedGroup enum has 2 bytes. So the lower limit for named_group_list should be 2. Similar as [Errata 4633](https://www.rfc-editor.org/errata_search.php?eid=4633).