### PR TITLE
Tighten and clarify KeyShareEntry ordering.

### DIFF
--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -2026,8 +2026,10 @@ The "extension_data" field of this extension contains a
 client_shares
 : A list of offered KeyShareEntry values in descending order of client preference.
   This vector MAY be empty if the client is requesting a HelloRetryRequest.
-  The ordering of values here SHOULD match that of the ordering of offered support
-  in the "supported_groups" extension.
+  Each KeyShareEntry value MUST correspond to a group offered in the
+  "supported_groups" extension and MUST appear in the same order.  However, the
+  values MAY be a non-contiguous subset of the "supported_groups" extension and
+  MAY omit the most preferred groups.
 
 selected_group
 : The mutually supported group the server intends to negotiate and


### PR DESCRIPTION
The text already says that both supported_groups and key_shares are in
order of "client preference". Supposing "client preference" is a
well-defined notion, we are already requiring the order match.

The SHOULD was also unclear on whether the list may be a general
subsequence. Clarify that this is allowed. This may be useful if, say,
we define some very large NamedGroup (post-quantum?) in the future that
is still preferable over the existing options. Clients would likely wish
to NOT offer it initially because it would be a waste of bandwidth for
the vast majority of servers which don't support it. (Not to mention
intolerance problems.)

In that scenario, a client would likely not predict a key_share by
default and instead use some kind of server info cache (either caching
what the server chose or using the full server supported_groups list).
But that client would still wish to advertise the new group first.