### PR TITLE
Clarify g,p are predefined

### DIFF
--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -2099,7 +2099,8 @@ the opaque key_exchange field of a KeyShareEntry in a KeyShare structure.
 The opaque value contains the
 Diffie-Hellman public value (Y = g^X mod p),
 encoded as a big-endian integer, padded with zeros to the size of p in
-bytes.
+bytes. The values of g and p are predefined, and are specified in {{RFC7919}}
+Appendix A.
 
 Note: For a given Diffie-Hellman group, the padding results in all public keys
 having the same length.


### PR DESCRIPTION
I think the current spec doesn't explicitly say what the values of g and p (for finite field DHE) are. So I want to add a link to RFC 7919 in Diffie-Hellman Parameters section to make it clear.