### PR TITLE
update changelog for PR #641

### DIFF
--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -428,6 +428,11 @@ server: The endpoint which did not initiate the TLS connection.
 (*) indicates changes to the wire protocol which may require implementations
     to update.
 
+draft-16
+
+- Change RSASSA-PSS and EdDSA SignatureScheme codepoints for better backwards compatibility (*)
+
+
 draft-15
 
 - New negotiation syntax as discussed in Berlin (*)


### PR DESCRIPTION
PR #641 changed enum values which would need updating by any experimental implementations that were actually using them. Even if this doesn't come up in practice, it should be listed in the changelog.