### PR TITLE
Allow empty TicketExtensions.

### DIFF
--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -2973,7 +2973,7 @@ to that negotiated connection where the ticket was established.
 
        struct {
            TicketExtensionType extension_type;
-           opaque extension_data<1..2^16-1>;
+           opaque extension_data<0..2^16-1>;
        } TicketExtension;
 
        struct {


### PR DESCRIPTION
Other extensions are allowed to be empty. We may end up needing to
merely store an indicator someday.