### PR TITLE
Fixing #630

### DIFF
--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -2261,13 +2261,15 @@ The "extension_data" field of this extension contains an
 
 %%% Key Exchange Messages
 
+       struct {} None;
+
        struct {
            select (Handshake.msg_type) {
                case client_hello:
                    uint32 obfuscated_ticket_age;
 
                case server_hello:
-                   struct {};
+                   None;
            };
        } EarlyDataIndication;
 

--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -1173,6 +1173,7 @@ numerical information may be omitted.
 
        enum { low, medium, high } Amount;
 
+For numerical values, the notation \<floor..ceiling\> is also allowed.
 
 ##  Constructed Types
 


### PR DESCRIPTION
This patches ensure that the described syntax and examples are consistent. In other words, parsers implementing Section 3 can parse all examples.