### PR TITLE
Make a cookie have a minimum size

### DIFF
--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -1792,7 +1792,7 @@ even if they would otherwise be incompatible.
 %%% Cookie Extension
 
        struct {
-           opaque cookie<0..2^16-1>;
+           opaque cookie<1..2^16-1>;
        } Cookie;
 
 Cookies serve two primary purposes:


### PR DESCRIPTION
The spec requires that a cookie (or key_share) be present in HRR, but it's possible to send an empty cookie.  That's just inviting errors.