### PR TITLE
Make RFC7919 a normative reference

### DIFF
--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -48,6 +48,7 @@ normative:
   RFC7539:
   RFC7748:
   RFC7905:
+  RFC7919:
   I-D.irtf-cfrg-eddsa:
 
   AES:
@@ -121,7 +122,6 @@ informative:
   RFC7568:
   RFC7627:
   RFC7685:
-  RFC7919:
 
   DSS:
        title: "Digital Signature Standard, version 4"


### PR DESCRIPTION
According to the IESG statement [1]:
> Normative references specify documents that must be read to understand or implement the technology in the new RFC.
> Even references that are relevant only for optional features must be classified as normative if they meet the above conditions for normative references. 

So I think it is better to categorize RFC 7919 as normative rather than informative, because it is a must-read to implement [section 4.2.5.1](https://tlswg.github.io/tls13-spec/#ffdhe-param) Diffie-Hellman Parameters.

[1] https://www.ietf.org/iesg/statement/normative-informative.html