### PR TITLE
Remove unused references

### DIFF
--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -88,12 +88,8 @@ normative:
 
 
 informative:
-  RFC0793:
-  RFC1948:
   RFC4086:
   RFC4279:
-  RFC4302:
-  RFC4303:
   RFC4346:
   RFC4366:
   RFC4492:
@@ -106,7 +102,6 @@ informative:
   RFC5116:
   RFC5246:
   RFC5746:
-  RFC5763:
   RFC5764:
   RFC5878:
   RFC5929:


### PR DESCRIPTION
RFC0793, RFC1948, RFC4302, RFC4303 and RFC5763 are not referenced by any text in the body of the current draft. So remove them from the reference section.