### PR TITLE
drop unused references

### DIFF
--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -36,18 +36,11 @@ normative:
   RFC2434:
   RFC3447:
   RFC5280:
-  RFC5288:
-  RFC5289:
-  RFC5487:
   RFC5869:
   RFC6066:
-  RFC6209:
-  RFC6367:
   RFC6655:
-  RFC7251:
   RFC7539:
   RFC7748:
-  RFC7905:
   I-D.irtf-cfrg-eddsa:
 
   AES:
@@ -88,12 +81,8 @@ normative:
 
 
 informative:
-  RFC0793:
-  RFC1948:
   RFC4086:
   RFC4279:
-  RFC4302:
-  RFC4303:
   RFC4346:
   RFC4366:
   RFC4492:
@@ -106,7 +95,6 @@ informative:
   RFC5116:
   RFC5246:
   RFC5746:
-  RFC5763:
   RFC5764:
   RFC5878:
   RFC5929:


### PR DESCRIPTION
I went through and did a check of our current references usage. There's quite a few that need to be cleaned up. The 7 normative refs this PR drops are for cipher suites that are no longer applicable to TLS 1.3 in the new negotiation. (for the replaced ones, we cite the algorithm RFC rather than the cipher RFC, now) There's also 5 informative refs we just don't cite anymore.

Beyond those currently in this changeset, we also have the GCM, PKCS6, & PKCS7 refs which are currently unused as well. Not sure if we want to drop them too or stick them in where appropriate now.