### PR TITLE
fixing the mismatch of ASN1Cert and ASN1CertData.

### DIFF
--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -2647,7 +2647,7 @@ Structure of this message:
        opaque ASN1Cert<1..2^24-1>;
 
        struct {
-           ASN1CertData cert_data;
+           ASN1Cert cert_data;
            Extension extensions<0..2^16-1>;
        } CertificateEntry;
 


### PR DESCRIPTION
832b864f78784b7d06e300148c478877a4398d6e introduced this syntax error.