### PR TITLE
Deprecate alert level

### DIFF
--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -3483,7 +3483,7 @@ with failed connections. All unknown alert types MUST be treated as
 error alerts.
 
 Prior versions of TLS used the "legacy_alert_level" field to indicate the
-severity of the alert. This field should be set to {2} for all alerts,
+severity of the alert. This field MUST be set to a value of 2 for all alerts,
 and MUST be ignored by implementations when receiving alerts.
 
 %%% Alert Messages

--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -3527,7 +3527,7 @@ and MUST be ignored by implementations when receiving alerts.
        } AlertDescription;
 
        struct {
-           uint8 legacy_alert_level = { 2 };
+           uint8 legacy_alert_level = 2;
            AlertDescription description;
        } Alert;
 


### PR DESCRIPTION
After PR #625 all alerts are required to be sent with fatal AlertLevel except for close_notify, end_of_early_data, and user_canceled. Since those three alerts all have separate specified behavior, the AlertLevel field is not serving much purpose, other than providing potential for misuse. We (Facebook) currently receive a number of alerts at incorrect levels from clients (internal_error warning alerts, etc.). I propose deprecating this field to simplify implementations and require that any misuse be ignored.