### PR TITLE
Clarify what to do when TLSPlaintext.length is too large

### DIFF
--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -3228,7 +3228,9 @@ legacy_record_version
 
 length
 : The length (in bytes) of the following TLSPlaintext.fragment. The
-  length MUST NOT exceed 2^14.
+  length MUST NOT exceed 2^14. An endpoint that receives a record
+  that exceeds this length MUST terminate the connection with a
+  “record_overflow” alert.
 
 fragment
 : The data being transmitted. This value transparent and treated as an

--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -3230,7 +3230,7 @@ length
 : The length (in bytes) of the following TLSPlaintext.fragment. The
   length MUST NOT exceed 2^14. An endpoint that receives a record
   that exceeds this length MUST terminate the connection with a
-  “record_overflow” alert.
+  "record_overflow" alert.
 
 fragment
 : The data being transmitted. This value transparent and treated as an


### PR DESCRIPTION
Before record protection is established, if an endpoint receives a TLSPlaintext structure whose "length" field is too large (>2^14), should it send a "record_overflow" alert?