### PR TITLE
legacy_session_id: SHOULD -> MUST

### DIFF
--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -1514,7 +1514,7 @@ legacy_session_id
   feature which has been merged with Pre-Shared Keys in this version
   (see {{resumption-and-psk}}).
   This field MUST be ignored by a server negotiating TLS 1.3 and
-  SHOULD be set as a zero length vector (i.e., a single zero byte
+  MUST be set as a zero length vector (i.e., a single zero byte
   length field) by clients which do not have a cached session ID
   set by a pre-TLS 1.3 server.
 


### PR DESCRIPTION
All other fields deprecated by this spec use "MUST be set to ...", such as ClientHello.legacy_version, ClientHello.legacy_compression_methods, TLSPlaintext.legacy_record_version. Only ClientHello.legacy_session_id "SHOULD be set as [...]" So I suggest changing this to "MUST" as well.