### PR TITLE
Explicitly saying that a case can have multiple fields. (#700)

### DIFF
--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -1248,7 +1248,7 @@ element of the enumeration declared in the select. Case arms have limited
 fall-through: if two case arms follow in immediate succession with no fields in
 between, then they both contain the same fields. Thus, in the example below,
 "orange" and "banana" both contain V2. Note that this piece of syntax was added
-in TLS 1.2 {{RFC5246}}.
+in TLS 1.2 {{RFC5246}}. Each case arm can have one or more fields.
 
 The body of the variant structure may be given a label for reference. The
 mechanism by which the variant is selected at runtime is not prescribed by the
@@ -1261,7 +1261,8 @@ presentation language.
            Tn fn;
            select (E) {
                case e1: Te1;
-               case e2: Te2;
+               case e2: Te21;
+                        Te22;
                case e3: case e4: Te3;
                ....
                case en: Ten;


### PR DESCRIPTION
This patch clarifies the presentation language to fix issue 700.