### PR TITLE
using struct to defined PskBinderEntry.

### DIFF
--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -2211,7 +2211,9 @@ The "extension_data" field of this extension contains a
            uint32 obfuscated_ticket_age;
        } PskIdentity;
 
-       opaque PskBinderEntry<32..255>;
+       struct {
+           opaque binder<32..255>;
+       } PskBinderEntry;
        
        struct {
            select (Handshake.msg_type) {


### PR DESCRIPTION
According our criteria of one-field-struct vs non-struct, this should be a one-field-struct. (My parser warns this.)