### PR TITLE
fix Presentation Language sectioning

### DIFF
--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -1252,7 +1252,7 @@ Fields and variables may be assigned a fixed value using "=", as in:
            T2 f2;
        } T;
 
-###  Variants
+##  Variants
 
 Defined structures may have variants based on some knowledge that is available
 within the environment. The selector must be an enumerated type that defines


### PR DESCRIPTION
Variants is not a subsection of Constants; just have them all be subsections of same depth within Presentation Language

https://tools.ietf.org/html/draft-ietf-tls-tls13-17#section-3.7