### PR TITLE
specify what to do when receive wrong fragments

### DIFF
--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -3186,6 +3186,8 @@ not preserved in the record layer (i.e., multiple messages of the same
 ContentType MAY be coalesced into a single TLSPlaintext record, or a single
 message MAY be fragmented across several records).
 Alert messages ({{alert-protocol}}) MUST NOT be fragmented across records.
+An endpoint that receives a fragmented alert message MUST terminate the
+connection with a "decode_error" alert.
 
 %%% Record Layer
 
@@ -3232,9 +3234,10 @@ Endpoints supporting other versions negotiate the version to use
 by following the procedure and requirements in {{backward-compatibility}}.
 
 Implementations MUST NOT send zero-length fragments of Handshake or
-Alert types, even if those fragments contain padding. Zero-length
-fragments of Application Data MAY be sent as they are potentially
-useful as a traffic analysis countermeasure.
+Alert types, even if those fragments contain padding. An endpoint that
+receives such a fragment MUST terminate the connection with a
+"decode_error" alert. Zero-length fragments of Application Data MAY
+be sent as they are potentially useful as a traffic analysis countermeasure.
 
 When record protection has not yet been engaged, TLSPlaintext
 structures are written directly onto the wire. Once record protection


### PR DESCRIPTION
This clarifies what to do when an endpoint receives a zero-length fragment of Handshake or Alert type, or a fragmented Alert message [1]. This addresses the issue that @tomato42 posted on list [2].

[1] https://www.ietf.org/mail-archive/web/tls/current/msg21631.html.
[2] https://www.ietf.org/mail-archive/web/tls/current/msg21629.html
