### PR TITLE
add/tweak some references

### DIFF
--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -3979,7 +3979,7 @@ all exporter computations.
 In the absence of an application profile standard specifying otherwise, a
 TLS-compliant application MUST implement the TLS_AES_128_GCM_SHA256
 cipher suite and SHOULD implement the TLS_AES_256_GCM_SHA384 and
-TLS_CHACHA20_POLY1305_SHA256 cipher suites.
+TLS_CHACHA20_POLY1305_SHA256 cipher suites. (see {{cipher-suites}})
 
 A TLS-compliant application MUST support digital signatures with
 rsa_pkcs1_sha256 (for certificates), rsa_pss_sha256 (for
@@ -3993,11 +3993,11 @@ In the absence of an application profile standard specifying otherwise, a
 TLS-compliant application MUST implement the following TLS extensions:
 
   * Supported Versions ("supported_versions"; {{supported-versions}})
+  * Cookie ("cookie"; {{cookie}})
   * Signature Algorithms ("signature_algorithms"; {{signature-algorithms}})
   * Negotiated Groups ("supported_groups"; {{negotiated-groups}})
   * Key Share ("key_share"; {{key-share}})
   * Pre-Shared Key ("pre_shared_key"; {{pre-shared-key-extension}})
-  * Cookie ("cookie"; {{cookie}})
   * Server Name Indication ("server_name"; Section 3 of {{RFC6066}})
 
 All implementations MUST send and use these extensions when offering
@@ -4030,10 +4030,11 @@ Servers requiring this extension SHOULD respond to a ClientHello
 lacking a "server_name" extension by terminating the connection with a
 "missing_extension" alert.
 
+
 #  Security Considerations
 
-Security issues are discussed throughout this memo, especially in Appendices B,
-C, and D.
+Security issues are discussed throughout this memo, especially in
+{{implementation-notes}}, {{backward-compatibility}}, and {{security-analysis}}.
 
 
 #  IANA Considerations


### PR DESCRIPTION
Just noticed that the MTI suites section didn't link to the suites, so here's a minor PR with some reference fiddling for this section:
* Add a link in MTI suites to the suites section, now that they're defined in this document.
* Nitpick ordering of extensions in MTI extensions to have them in same order as sections (so numbers in links are consistient).
* Change plaintext reference to appendices in Security Considerations to actual references.