### PR TITLE
fix section reference

### DIFF
--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -2533,9 +2533,9 @@ certificate_request_context
   which will be echoed in the client's Certificate message. The
   certificate_request_context MUST be unique within the scope
   of this connection (thus preventing replay of client
-  CertificateVerify messages).   This field SHALL be zero length
+  CertificateVerify messages). This field SHALL be zero length
   unless used for the post-handshake authentication exchanges
-  described in Section 4.5.2.
+  described in {{post-handshake-authentication}}.
 
 supported_signature_algorithms
 : A list of the signature algorithms that the server is


### PR DESCRIPTION
Fix a reference to a section that's directly citing a section number in plain text. (not linkified and will break if sections change) I assume this is a copy/paste error.