### PR TITLE
[README.md] Update WG link

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ TLS 1.3 Draft Specifications
 =============================
 
 This is the working area for the [IETF TLS Working
-Group](https://trac.tools.ietf.org/wg/tls/trac/wiki) draft of [TLS 1.3]
+Group](https://datatracker.ietf.org/wg/tls/documents/) draft of [TLS 1.3]
 
 TLS 1.3 specification:
 * [Editor's copy](https://tlswg.github.io/tls13-spec/)


### PR DESCRIPTION
I overlooked this link in #698. Let's change the link in the top section to https://datatracker.ietf.org/wg/tls/documents/ as well.