### PR TITLE
Clarifying the concatenation rule

### DIFF
--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -2646,7 +2646,7 @@ for each scenario:
 
 In all cases, the handshake context is formed by concatenating the
 indicated handshake messages, including the handshake message type
-and length fields.
+and length fields, but not including record layer headers.
 
 ###  Certificate
 
@@ -3754,7 +3754,9 @@ defined below:
 ~~~~
 
 The Hash function and the HKDF hash are the cipher suite hash algorithm.
-Hash.length is its output length.
+Hash.length is its output length. Messages are the concatenation of the
+indicated handshake messages, including the handshake message type
+and length fields, but not including record layer headers.
 
 Given a set of n InputSecrets, the final "master secret" is computed
 by iteratively invoking HKDF-Extract with InputSecret_1, InputSecret_2,


### PR DESCRIPTION
When I was implementing the key schedule, it was unclear to me what `Hash(Messages)` stands for. This additional note would help other implementors. 
Kazuho Oku pointed out the similarity to Handshake Context. So, I updated that part, too.