### PR TITLE
Clarify encoding of sequence number

### DIFF
--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -3367,8 +3367,8 @@ N_MIN) for the AEAD algorithm (see {{RFC5116}} Section 4). An AEAD
 algorithm where N_MAX is less than 8 bytes MUST NOT be used with TLS.
 The per-record nonce for the AEAD construction is formed as follows:
 
-  1. The 64-bit record sequence number is padded to the left with zeroes
-     to iv_length.
+  1. The little endian 64-bit record sequence number is padded to the 
+     left with zeroes to iv_length.
 
   2. The padded sequence number is XORed with the static client_write_iv
      or server_write_iv, depending on the role.

--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -3367,7 +3367,7 @@ N_MIN) for the AEAD algorithm (see {{RFC5116}} Section 4). An AEAD
 algorithm where N_MAX is less than 8 bytes MUST NOT be used with TLS.
 The per-record nonce for the AEAD construction is formed as follows:
 
-  1. The little endian 64-bit record sequence number is padded to the 
+  1. The big endian 64-bit record sequence number is padded to the 
      left with zeroes to iv_length.
 
   2. The padded sequence number is XORed with the static client_write_iv


### PR DESCRIPTION
Clarify encoding of sequence number in nonce. I believe the intention of it is to be little endian. 
This could help offer a hint to implementations to "do the right thing"