### PR TITLE
Sequence numbers do not wrap

### DIFF
--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -3354,13 +3354,11 @@ A 64-bit sequence number is maintained separately for reading and writing
 records.  Each sequence number is set to zero at the beginning of a connection
 and whenever the key is changed.
 
-The sequence number is incremented after reading or writing each record.
+The sequence number is incremented by one after reading or writing each record.
 The first record transmitted under a particular set of traffic keys
 record key MUST use sequence number 0.
 
-Sequence numbers do not wrap.  If a TLS implementation would need to
-wrap a sequence number, it MUST either rekey ({{key-update}}) or
-terminate the connection.
+Because the size of sequence numbers is 64-bit, they are guaranteed not to wrap.
 
 The length of the per-record nonce (iv_length) is set to max(8 bytes,
 N_MIN) for the AEAD algorithm (see {{RFC5116}} Section 4). An AEAD


### PR DESCRIPTION
If the sequence number is incremented by 1 each time an endpoint sends a record, how could it wrap, since it is so large (64-bit)?