### PR TITLE
change language on retransmission on 0-RTT data

### DIFF
--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -2409,11 +2409,14 @@ with a "bad_record_mac" alert as per {{record-payload-protection}}.
 
 If the server rejects the "early_data" extension, the client
 application MAY opt to retransmit the data once the handshake has
-been completed. If TLS stacks do this automatically, they should
-take care that the negotiated parameters from the full handshake
-are consistent with those it expected from the 0-RTT handshake. 
-For example, if the selected ALPN protocol has changed, it is 
-likely unsafe to retransmit the original application layer data.
+been completed. A TLS implementation MUST NOT automatically re-send 
+early data unless the negotiated connection selects the same ALPN 
+protocol. An application is required to construct different messages
+if a different protocol is selected. Before replaying early data, 
+additional checks might be necessary to verify that the resulting 
+connection is compatible with expections; this will vary based on 
+context. For example, a change to the server certificate is possible 
+if a pre-shared key is rejected.
 
 #### Processing Order
 

--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -2409,11 +2409,11 @@ with a "bad_record_mac" alert as per {{record-payload-protection}}.
 
 If the server rejects the "early_data" extension, the client
 application MAY opt to retransmit the data once the handshake has
-been completed. TLS stacks SHOULD not do this automatically and
-client applications MUST take care that the negotiated parameters
-are consistent with those it expected. For example, if the selected
-ALPN protocol has changed, it is likely unsafe to retransmit the
-original application layer data.
+been completed. If TLS stacks do this automatically, they should
+take care that the negotiated parameters from the full handshake
+are consistent with those it expected from the 0-RTT handshake. 
+For example, if the selected ALPN protocol has changed, it is 
+likely unsafe to retransmit the original application layer data.
 
 #### Processing Order
 


### PR DESCRIPTION
The previous language made it seem like if a TLS stack would choose to retransmit the data on 0-RTT rejection, it was doing the wrong thing. However TLS stacks should be free to choose how they want to deal with these cases. For example they could tear down the connection if ALPN changes. Practically these cases should almost never happen so these cases are very rare.

I think putting this restriction on TLS implementations is a bit unfair. As far as I can tell, cases where it's hard to retransmit 0-RTT data happen in cases where the abstraction boundary is violated when application features add TLS features as a performance optimization, for example in the case of ALPN and token binding. As with any performance optimization it's fair to ask for a slow path when the optimization fails.