### PR TITLE
Set minimum label size in HKDF-Expand-Label to 10 octets

### DIFF
--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -3744,7 +3744,7 @@ defined below:
 
     struct {
         uint16 length = Length;
-        opaque label<9..255> = "TLS 1.3, " + Label;
+        opaque label<10..255> = "TLS 1.3, " + Label;
         opaque hash_value<0..255> = HashValue;
     } HkdfLabel;
 


### PR DESCRIPTION
The prefix to the label in HKDF-Expand-Label is 9 octets long.

The grammar therefore permits the label to be empty.  That would
be bad given that it is supposed to disambiguate.

(Yes, a zero length string is potentially unique, but since only
one of them exists and use is more likely the result of an error
than intent, it seems prudent to forbid its use.)