### PR TITLE
Rewrite the anti-downgrade protection.

### DIFF
--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -1602,32 +1602,34 @@ extensions
 {:br }
 
 TLS 1.3 has a downgrade protection mechanism embedded in the server's
-random value. TLS 1.3 server implementations which respond to a
-ClientHello indicating only support for TLS 1.2 or below
-MUST set the last eight bytes of their Random value
-to the bytes:
+random value.  TLS 1.3 server implementations MAY respond to a
+ClientHello indicating only support for TLS 1.2 or below with a
+ServerHello containing the appropriate version field.
+
+TLS 1.3 server implementations which respond with a TLS 1.2
+ServerHello, MUST set the last eight bytes of their Random value to
+the bytes:
 
       44 4F 57 4E 47 52 44 01
 
-TLS 1.3 server implementations which respond to a
-ClientHello indicating only support for TLS 1.1 or below
-SHOULD set the last eight
-bytes of their Random value to the bytes:
+TLS 1.3 server implementations which respond with a ServerHello
+indicating support for TLS 1.1 or below SHOULD set the last
+eight bytes of their Random value to the bytes:
 
       44 4F 57 4E 47 52 44 00
 
-
 TLS 1.3 clients receiving a TLS 1.2 or below ServerHello MUST check
-that the last eight octets are not equal to either of these values. TLS
-1.2 clients SHOULD also perform this check if the ServerHello
-indicates TLS 1.1 or below. If a match is found, the client MUST abort
-the handshake with an "illegal_parameter" alert. This mechanism
-provides limited protection against downgrade attacks over and above
-that provided by the Finished exchange: because the ServerKeyExchange
-includes a signature over both random values, it is not possible for
-an active attacker to modify the randoms without detection as long as
-ephemeral ciphers are used. It does not provide downgrade protection
-when static RSA is used.
+that the last eight octets are not equal to either of these values.
+TLS 1.2 clients SHOULD also check that the last eight bytes are not
+equal to the second value if the ServerHello indicates TLS 1.1 or
+below.  If a match is found, the client MUST abort the handshake
+with an "illegal_parameter" alert.  This mechanism provides limited
+protection against downgrade attacks over and above that provided
+by the Finished exchange: because the ServerKeyExchange, a message
+present in TLS 1.2 and below, includes a signature over both random
+values, it is not possible for an active attacker to modify the
+randoms without detection as long as ephemeral ciphers are used.
+It does not provide downgrade protection when static RSA is used.
 
 Note: This is an update to TLS 1.2 so in practice many TLS 1.2 clients
 and servers will not behave as specified above.


### PR DESCRIPTION
Following the mail "[TLS] Draft 18 review: Downgrade protection" (https://www.ietf.org/mail-archive/web/tls/current/msg21987.html), this is a proposal to amend the anti-downgrade protection when a TLS 1.3 implementation accepts to use an earlier version.