### PR TITLE
obfuscated_ticket_age is part of the PSK extension

### DIFF
--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -3041,7 +3041,7 @@ ticket_lifetime
 
 ticket_age_add
 : A randomly generated 32-bit value that is used to obscure the age of
-  the ticket that the client includes in the "early_data" extension.
+  the ticket that the client includes in the "pre_shared_key" extension.
   The client-side ticket age is added to this value modulo 2^32 to
   obtain the value that is transmitted by the client.
 


### PR DESCRIPTION
Fix incorrect suggestion that `ticket_age_add` of NST affects `early_data` extension.