### PR TITLE
Encrypted extension refers to the table in IANA consideration.

### DIFF
--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -2523,7 +2523,7 @@ Structure of this message:
        } EncryptedExtensions;
 
 extensions
-: A list of extensions.
+: A list of extensions. For more information, see the table in {{iana-considerations}}.
 {:br }
 
 ###  Certificate Request


### PR DESCRIPTION
This would help to understand what extensions should be encrypted.