### PR TITLE
Align end_of_early_data text and diagram with processing order.

### DIFF
--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -1048,8 +1048,7 @@ as with a 1-RTT handshake with PSK resumption.
          + key_share*
          + psk_key_exchange_modes
          + pre_shared_key
-         (Application Data*)
-         (end_of_early_data)     -------->
+         (Application Data*)     -------->
                                                          ServerHello
                                                         + early_data
                                                     + pre_shared_key
@@ -1057,6 +1056,7 @@ as with a 1-RTT handshake with PSK resumption.
                                                {EncryptedExtensions}
                                                           {Finished}
                                  <--------       [Application Data*]
+         (end_of_early_data)
          {Finished}              -------->
 
          [Application Data]      <------->        [Application Data]
@@ -2380,11 +2380,10 @@ MUST be the first PSK listed in the client's "pre_shared_key" extension.
 0-RTT messages sent in the first flight have the same content types
 as their corresponding messages sent in other flights (handshake,
 application_data, and alert respectively) but are protected under
-different keys. After all the 0-RTT application data messages (if
-any) have been sent, an "end_of_early_data" alert of type
-"warning" is sent to indicate the end of the flight.
-0-RTT MUST always be followed by an "end_of_early_data" alert,
-which will be encrypted with the 0-RTT traffic keys.
+different keys.  After receiving the server's Finished message, if the
+server has accepted early data, an "end_of_early_data" alert of type
+"warning" MUST be sent to indicate the key change. This message will
+be encrypted with the 0-RTT traffic keys.
 
 A server which receives an "early_data" extension
 can behave in one of three ways:
@@ -3558,7 +3557,8 @@ close_notify
 end_of_early_data
 : This alert is sent by the client to indicate that all 0-RTT
   application_data messages have been transmitted (or none will
-  be sent at all) and that this is the end of the flight. This
+  be sent at all) and that the following records are protected
+  under handshake traffic keys. This
   alert MUST be at the warning level. Servers MUST NOT send this
   alert and clients receiving it MUST terminate the connection
   with an "unexpected_message" alert.


### PR DESCRIPTION
The alert is described as being part of the first flight, but it is
really sent when the server Finished is received, per the processing
order section. Notably, servers MUST NOT wait for end_of_early_data
before sending ServerHello through Finished. Group it with the client
Finished flight, and fix the text about it terminating the first flight.

(The division between the first and second client flight isn't
especially well-defined because early data may flow in parallel with the
ServerHello flight. But if there is to be a division, end_of_early_data
certainly falls into the second one.)