### PR TITLE
Clarify authentication message language.

### DIFF
--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -2638,7 +2638,7 @@ The computations for the Authentication messages all uniformly
 take the following inputs:
 
 - The certificate and signing key to be used.
-- A Handshake Context based on the hash of the handshake messages
+- A Handshake Context based on the transcript of the handshake messages
 - A base key to be used to compute a MAC key.
 
 Based on these inputs, the messages then contain:


### PR DESCRIPTION
The handshake context here is just the transcript of the handshake messages, not the hash of the transcript. The language makes it seem like the authentication messages are Hash(Hash(handshake messages) + Certificate), etc.