### PR TITLE
Using "identity" instead of "label".

### DIFF
--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -2303,8 +2303,8 @@ The "extension_data" field of this extension contains a
        } PreSharedKeyExtension;
 
 identity
-: A label for a key. For instance, a ticket defined
-  in {{ticket-establishment}}, or a label for a pre-shraed key
+: A PSK identity. For instance, a ticket defined
+  in {{ticket-establishment}}, or an identity for a pre-shraed key
   established externally.
 
 obfuscated_ticket_age


### PR DESCRIPTION
"label" is a term for derive-key.
We should avoid using "label" for PSK.