### PR TITLE
Require that (EC)DHE public values be fresh.

### DIFF
--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -2244,9 +2244,10 @@ FFDHE groups.  The key_exchange values for each KeyShareEntry MUST be
 generated independently.  Clients MUST NOT offer multiple
 KeyShareEntry values for the same group.  Clients MUST NOT offer any
 KeyShareEntry values for groups not listed in the client's
-"supported_groups" extension.  Servers MAY check for violations of
-these rules and abort the handshake with an
-"illegal_parameter" alert if one is violated.
+"supported_groups" extension. Clients MUST NOT send the same KeyShareEntry
+in two ClientHello messages, even to different servers.  Servers MAY check for
+violations of these rules and abort the handshake with an "illegal_parameter"
+alert if one is violated.
 
 Upon receipt of this extension in a HelloRetryRequest, the client MUST
 verify that (1) the selected_group field corresponds to a group which was provided
@@ -2265,6 +2266,9 @@ by the client that the server has selected for the negotiated key exchange.
 Servers MUST NOT send a KeyShareEntry for any group not
 indicated in the "supported_groups" extension and
 MUST NOT send a KeyShareEntry when using the "psk_ke" PskKeyExchangeMode.
+Servers MUST NOT send the same KeyShareEntry in two ServerHello messages, even
+to different clients.
+
 If a HelloRetryRequest was received by the client, the client MUST verify that the
 selected NamedGroup matches one that the client sent in its supported_groups
 extension and MUST abort the handshake with an "illegal_parameter" alert otherwise.


### PR DESCRIPTION
This change requires that (EC)DHE public values be fresh, for both parties, in every handshake.

For clients, this is standard practice (as far as I'm aware) so should make no difference. For servers, this is not always the case:

Springall, Durumeric & Halderman [note](https://dl.acm.org/citation.cfm?id=2987480) that with TLS 1.2:

- 4.4% of the Alexa Top 1M reuse DHE values and 1.3% do so for more than a day.
- 14.4% of the Top 1M reuse ECDHE values, 3.4% for more than a day.

Since this defeats forward security, and is clearly something that implementations of previous versions have done, this change specifically calls it out as a MUST NOT. Implementations would then be free to detect and reject violations of this.

This does have a cost because it also excludes the reasonable practice of amortising public value generation over all connections for a few seconds. The draft could attempt to specify a precise, maximum duration for reuse but that is more complex and no value is clearly optimal.

Also, this cost doesn't seem too high: 85.6% of servers _don't_ reuse values and manage fine today. The generation of (EC)DH public values is also a fixed-based operation and thus can be much faster than DH key-agreement.

Lastly, some have [proposed](https://datatracker.ietf.org/doc/draft-green-tls-static-dh-in-tls13/) (EC)DH reuse as a mechanism for enabling TLS connections to be decrypted and monitored by a middlebox. TLS is not designed to be decrypted by third-parties—that's kind of the point. Thus anyone doing this should not be surprised to hit a few MUST NOTs and, potentially, to have to configure implementations to allow such a deployment.