### PR TITLE
(Re-)tighten and clarify KeyShareEntry ordering

### DIFF
--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -2225,8 +2225,10 @@ The "extension_data" field of this extension contains a
 client_shares
 : A list of offered KeyShareEntry values in descending order of client preference.
   This vector MAY be empty if the client is requesting a HelloRetryRequest.
-  The ordering of values here SHOULD match that of the ordering of offered support
-  in the "supported_groups" extension.
+  Each KeyShareEntry value MUST correspond to a group offered in the
+  "supported_groups" extension and MUST appear in the same order.  However, the
+  values MAY be a non-contiguous subset of the "supported_groups" extension and
+  MAY omit the most preferred groups.
 
 selected_group
 : The mutually supported group the server intends to negotiate and


### PR DESCRIPTION
This is a redo of PR #643 now that PR #678 has removed the appending
rule and resolved issue #644.