### PR TITLE
Remove outdated implementation pitfall about RSA padding.

### DIFF
--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -124,12 +124,6 @@ informative:
        date: 2005-11
        seriesinfo:
          ANSI: ANS X9.62-2005
-  FI06:
-       title: "Bleichenbacher's RSA signature forgery based on implementation error"
-       author:
-         - name: Hal Finney
-       date: 2006-08-27
-       target: https://www.ietf.org/mail-archive/web/openpgp/current/msg00999.html
 
   GCM:
        title: "Recommendation for Block Cipher Modes of Operation: Galois/Counter Mode (GCM) and GMAC"
@@ -4586,10 +4580,6 @@ TLS protocol issues:
 Cryptographic details:
 
 -  What countermeasures do you use to prevent timing attacks {{TIMING}}?
-
-- When verifying RSA signatures, do you accept both NULL and missing parameters?
-  Do you verify that the RSA padding
-  doesn't have additional data after the hash value? {{FI06}}
 
 -  When using Diffie-Hellman key exchange, do you correctly preserve
   leading zero bytes in the negotiated key (see {{diffie-hellman}})?


### PR DESCRIPTION
This advice is about RSASSA-PKCS1-v1_5 which is no longer applicable.

(The note to accept both NULL and missing parameters was also wrong in
TLS 1.2 and encourages using an actual ASN.1 parser, a dangerous
implementation strategy for RSASSA-PKCS1-v1_5. RFC 3447 section 8.2.2
says verification must compute the serialized EM' and compare EM against
it, which implies one and only one padded DigestInfo serialization is
valid.)