### PR TITLE
Use fewer newlines in verify_data expression.

### DIFF
--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -3152,12 +3152,9 @@ Structure of this message:
 The verify_data value is computed as follows:
 
        verify_data =
-           HMAC(finished_key, Hash(
-                                   Handshake Context +
+           HMAC(finished_key, Hash(Handshake Context +
                                    Certificate* +
-                                   CertificateVerify*
-                              )
-           )
+                                   CertificateVerify*))
 
        * Only included if present.
 


### PR DESCRIPTION
The other line-breaked expressions in the document do not use quite so
many newlines. I believe this matches the existing style, based on how
Derive-Secret is defined.