### PR TITLE
Various ServerHello and HelloRetryRequest nitpicks.

### DIFF
--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -1647,10 +1647,9 @@ or HelloRetryRequest message.
 
 ### Server Hello {#server-hello}
 
-The server will send this message in response to a ClientHello message when
-it was able to find an acceptable set of algorithms and the client's
-"key_share" extension was acceptable. If it is not able to find an acceptable
-set of parameters, the server will respond with a "handshake_failure" fatal alert.
+The server will send this message in response to a ClientHello message if it is
+able to find an acceptable set of parameters and the ClientHello contains
+sufficient information to proceed with the handshake.
 
 Structure of this message:
 
@@ -1731,13 +1730,9 @@ interoperability failure.
 
 ###  Hello Retry Request
 
-Servers send this message in response to a ClientHello
-message if they were able to find an acceptable set of algorithms and
-groups that are mutually supported, but
-the client's ClientHello did not contain sufficient information to
-proceed with the handshake.
-If a server cannot successfully select algorithms and groups, it MUST abort
-the handshake with a "handshake_failure" alert.
+The server will send this message in response to a ClientHello message if it is
+able to find an acceptable set of parameters but the ClientHello does not
+contain sufficient information to proceed with the handshake.
 
 Structure of this message:
 


### PR DESCRIPTION
This is a giant pile of nitpicks, loosely inspired by the FFDHE alert
discussion.

The old text specifies a handshake_failure which is redundant with and
contradicts the Cryptographic Negotiation section. The old text says
only handshake_failure is allowed while Cryptographic Negotiation allows
both handshake_failure and insufficient_security. Fix this by avoiding
redundancy as the failure cases are global to the overall negotiation
algorithm.

Next, align the tense with itself and the rest of the text. Most of the
text appears to be written in present tense. The old text for SH said:

  The server *will send* [...] when it *was* able to [...]

which is a little odd. Also align the wording between the two. Talk
about a server (singular) to match Cryptographic Negotiation and say
"parameters" rather than "algorithms" or "algorithms and groups".

Also be consistent about the SH vs. HRR condition. The SH section said
"the client’s key_share extension was acceptable" while the HRR section
said "the client’s ClientHello did not contain sufficient information to
proceed with the handshake". Use the more general one.