### PR TITLE
removing the "subgroup attack" mention for FFDH

### DIFF
--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -2300,8 +2300,7 @@ Note: For a given Diffie-Hellman group, the padding results in all public keys
 having the same length.
 
 Peers SHOULD validate each other's public key Y by ensuring that 1 < Y
-< p-1. This check ensures that the remote peer is properly behaved and
-isn't forcing the local system into a small subgroup.
+< p-1. This check ensures that the remote peer is properly behaved.
 
 
 #### ECDHE Parameters {#ecdhe-param}


### PR DESCRIPTION
From the [Diffie-Hellman parameters](https://tlswg.github.io/tls13-spec/#ffdhe-param) section:

> Peers SHOULD validate each other’s public key Y by ensuring that 1 < Y < p-1. This check ensures that the remote peer is properly behaved and isn’t **forcing the local system into a small subgroup**.

Here at most you're avoiding the -1 public key that generates a subgroup of order 2, but that would never be enough to recover the full private key. 

So I think the "and isn’t forcing the local system into a small subgroup" is not necessary here. It just adds more words.

(A better check here would be to raise Y to the order of the used subgroup. [Looking at the list of groups](https://tools.ietf.org/html/rfc7919#appendix-A.1) I see that they are all safe primes so this check is useless (there is just no subgroup attack possible))