### PR TITLE
update references

### DIFF
--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -42,7 +42,7 @@ normative:
   RFC7539:
   RFC7748:
   RFC7919:
-  I-D.irtf-cfrg-eddsa:
+  RFC8032:
 
   AES:
        title: Specification for the Advanced Encryption Standard (AES)
@@ -2059,7 +2059,7 @@ RSASSA-PSS algorithms
 
 EdDSA algorithms
 : Indicates a signature algorithm using EdDSA as defined in
-  {{I-D.irtf-cfrg-eddsa}} or its successors. Note that these correspond to the
+  {{RFC8032}} or its successors. Note that these correspond to the
   "PureEdDSA" algorithms and not the "prehash" variants.
 {:br }
 

--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -4311,7 +4311,7 @@ and their allocation policies are below:
   IANA \[SHALL add/has added] the cipher suites listed in {{cipher-suites}} to
   the registry. The "Value" and "Description" columns are taken from the table.
   The "DTLS-OK" and "Recommended" columns are both marked as "Yes" for each new
-  cipher suite. \[\[This assumes {{?I-D.sandj-tls-iana-registry-updates}} has been
+  cipher suite. \[\[This assumes {{?I-D.ietf-tls-iana-registry-updates}} has been
   applied.]]
 
 -  TLS ContentType Registry: Future values are allocated via


### PR DESCRIPTION
draft_eddsa is now [RFC8032](https://tools.ietf.org/html/rfc8032). sandj-tls-iana-registry-updates is now ietf-tls-iana-registry-updates.