### PR TITLE
removed empty cases for EarlyDataIndication presentation language

### DIFF
--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -2395,10 +2395,6 @@ The "extension_data" field of this extension contains an
            select (Handshake.msg_type) {
                case new_session_ticket:
                   uint32 max_early_data_size;
-
-               case client_hello:
-               case encrypted_extensions:
-                  // empty
            };
        } EarlyDataIndication;
 


### PR DESCRIPTION
removing confusing cases syntax after https://github.com/tlswg/tls13-spec/issues/861 discussion