### PR TITLE
Add reference to draft-ietf-tls-tls13-vectors

### DIFF
--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -4536,7 +4536,8 @@ New cipher suite values are assigned by IANA as described in
 # Implementation Notes
 
 The TLS protocol cannot prevent many common security mistakes. This section
-provides several recommendations to assist implementors.
+provides several recommendations to assist implementors. Also
+{{?I-D.ietf-tls-tls13-vectors}} provides test vectors for TLS 1.3 handshakes.
 
 ## API considerations for 0-RTT
 

--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -109,6 +109,7 @@ informative:
   RFC7568:
   RFC7627:
   RFC7685:
+  I-D.ietf-tls-tls13-vectors:
 
   DSS:
        title: "Digital Signature Standard, version 4"
@@ -4537,7 +4538,7 @@ New cipher suite values are assigned by IANA as described in
 
 The TLS protocol cannot prevent many common security mistakes. This section
 provides several recommendations to assist implementors. Also
-{{?I-D.ietf-tls-tls13-vectors}} provides test vectors for TLS 1.3 handshakes.
+{{I-D.ietf-tls-tls13-vectors}} provides test vectors for TLS 1.3 handshakes.
 
 ## API considerations for 0-RTT
 

--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -4537,7 +4537,7 @@ New cipher suite values are assigned by IANA as described in
 # Implementation Notes
 
 The TLS protocol cannot prevent many common security mistakes. This section
-provides several recommendations to assist implementors. Also
+provides several recommendations to assist implementors.
 {{I-D.ietf-tls-tls13-vectors}} provides test vectors for TLS 1.3 handshakes.
 
 ## API considerations for 0-RTT


### PR DESCRIPTION
Since [draft-ietf-tls-tls13-vectors](https://datatracker.ietf.org/doc/draft-ietf-tls-tls13-vectors/) has been adopted, I think we need to mention it in the TLS 1.3 spec, don't we? It seems to me Appendix C is a right section to mention it.