### PR TITLE
Add an extra Derive-Secret stage prior to HKDF-Extract. This has two

### DIFF
--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -4056,14 +4056,11 @@ In this diagram, the following formatting conventions apply:
                  +-----> Derive-Secret(., "early exporter master secret",
                  |                     ClientHello)
                  |                     = early_exporter_secret
-                 |
-           Derive-Secret(., "derived early secret", "")
+                 v
+           Derive-Secret(., "derived secret", "")
                  |
                  v
-(EC)DHE -> HKDF-Extract
-                 |
-                 v
-         Handshake Secret
+(EC)DHE -> HKDF-Extract = Handshake Secret
                  |
                  +-----> Derive-Secret(., "client handshake traffic secret",
                  |                     ClientHello...ServerHello)
@@ -4073,13 +4070,10 @@ In this diagram, the following formatting conventions apply:
                  |                     ClientHello...ServerHello)
                  |                     = server_handshake_traffic_secret
                  |
-           Derive-Secret(., "derived handshake secret", "")
+           Derive-Secret(., "derived secret", "")
                  |
                  v
-      0 -> HKDF-Extract
-                 |
-                 v
-            Master Secret
+      0 -> HKDF-Extract = Master Secret
                  |
                  +-----> Derive-Secret(., "client application traffic secret",
                  |                     ClientHello...Server Finished)

--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -483,6 +483,8 @@ draft-19
 
 - Change end_of_early_data to be a handshake message (*).
 
+- Add pre-extract Derive-Secret stages to key schedule (*).
+
 - Remove spurious requirement to implement "pre_shared_key".
 
 - Clarify location of "early_data" from server (it goes in EE,

--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -4056,6 +4056,9 @@ In this diagram, the following formatting conventions apply:
                  +-----> Derive-Secret(., "early exporter master secret",
                  |                     ClientHello)
                  |                     = early_exporter_secret
+                 |
+           Derive-Secret(., "derived early secret", "")
+                 |
                  v
 (EC)DHE -> HKDF-Extract
                  |
@@ -4069,6 +4072,8 @@ In this diagram, the following formatting conventions apply:
                  +-----> Derive-Secret(., "server handshake traffic secret",
                  |                     ClientHello...ServerHello)
                  |                     = server_handshake_traffic_secret
+                 |
+           Derive-Secret(., "derived handshake secret", "")
                  |
                  v
       0 -> HKDF-Extract


### PR DESCRIPTION
benefits:

(1) Restoring extract/expand parity, thus cleaning up the theoretical
    treatment wrt HKDF and future replacements.
(2) Futureproofing against someone being able to force the ECDHE
    value in the second HKDF-Extract to collide with one of the labels.
    This seems unlikely with current groups, but might be possible
    with some future algorithm. (Issue due to Trevor Perrin).