### PR TITLE
Convert the handshake hash into a hash of hashes. This enables

### DIFF
--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -1951,8 +1951,8 @@ Cookies serve two primary purposes:
 
 - Allowing the server to offload state to the client, thus allowing it to send
   a HelloRetryRequest without storing any state. The server does this by
-  storing the serialized hash state in the cookie (protected
-  with some suitable integrity algorithm).
+  storing the hash of the ClientHello in the HelloRetryRequest cookie
+  (protected with some suitable integrity algorithm).
 
 When sending a HelloRetryRequest, the server MAY provide a "cookie" extension to the
 client (this is an exception to the usual rule that the only extensions that
@@ -2589,7 +2589,7 @@ The PSK binder value forms a binding between a PSK and the current
 handshake, as well as between the session where the PSK was
 established (if via a NewSessionTicket message) and the session where
 it was used.  Each entry in the binders list is computed as an HMAC
-over the portion of the ClientHello (including the handshake header)
+over a transcript hash (see {{the-transcript-hash}}) containing a partial ClientHello
 up to and including the PreSharedKeyExtension.identities field. That
 is, it includes all of the ClientHello but not the binder list
 itself. The length fields for the message (including the overall
@@ -2607,12 +2607,14 @@ and HelloRetryRequest are included in the transcript along with the
 new ClientHello.  For instance, if the client sends ClientHello1, its
 binder will be computed over:
 
-       ClientHello1[truncated]
+       Transcript-Hash(ClientHello1[truncated])
 
 If the server responds with HelloRetryRequest, and the client then sends
 ClientHello2, its binder will be computed over:
 
-       ClientHello1 + HelloRetryRequest + ClientHello2[truncated]
+       Transcript-Hash(ClientHello1,
+                       HelloRetryRequest,
+                       ClientHello2[truncated])
 
 The full ClientHello is included in all other handshake hash computations.
 
@@ -2822,7 +2824,8 @@ The computations for the Authentication messages all uniformly
 take the following inputs:
 
 - The certificate and signing key to be used.
-- A Handshake Context based on the transcript of the handshake messages
+- A Handshake Context consisting of the set of messages to be
+  included in the transcript hash.
 - A base key to be used to compute a MAC key.
 
 Based on these inputs, the messages then contain:
@@ -2833,19 +2836,13 @@ supporting certificates in the chain. Note that certificate-based
 client authentication is not available in the 0-RTT case.
 
 CertificateVerify
-: A signature over the value Hash(Handshake Context + Certificate)
+: A signature over the value Transcript-Hash(Handshake Context, Certificate)
 
 Finished
-: A MAC over the value Hash(Handshake Context + Certificate + CertificateVerify)
+: A MAC over the value Transcript-Hash(Handshake Context, Certificate, CertificateVerify)
 using a MAC key derived from the base key.
 {:br}
 
-Because the CertificateVerify signs the Handshake Context +
-Certificate and the Finished MACs the Handshake Context + Certificate
-+ CertificateVerify, this is mostly equivalent to keeping a running hash
-of the handshake messages (exactly so in the pure 1-RTT cases). Note,
-however, that subsequent post-handshake authentications do not include
-each other, just the messages through the end of the main handshake.
 
 The following table defines the Handshake Context and MAC Base Key
 for each scenario:
@@ -2856,9 +2853,25 @@ for each scenario:
 | Client | ClientHello ... ServerFinished     | client_handshake_traffic_secret |
 | Post-Handshake | ClientHello ... ClientFinished + CertificateRequest | client_traffic_secret_N |
 
-In all cases, the handshake context is formed by concatenating the
-indicated handshake messages, including the handshake message type
-and length fields, but not including record layer headers.
+
+### The Transcript Hash
+
+Many of the cryptographic computations in TLS make use of a transcript
+hash. This value is computed by hashing the concatenation of the
+hashes of each included handshake message, including the handshake
+message header including the handshake message type and length fields,
+but not including record layer headers.
+
+Specifically, the transcript hash of a set of messages M1 ... MN
+is given by:
+
+     Transcript-HasH(M1, M2, ... MN) =
+         Hash(Hash(M1) + Hash(M2) ... + Hash(MN))
+
+In general, implementations can implement this by keeping a running
+transcript hash value based on the negotiated hash. Note,
+however, that subsequent post-handshake authentications do not include
+each other, just the messages through the end of the main handshake.
 
 ###  Certificate
 
@@ -3069,10 +3082,9 @@ Structure of this message:
 The algorithm field specifies the signature algorithm used (see
 {{signature-algorithms}} for the definition of this field). The
 signature is a digital signature using that algorithm. The content 
-to be signed is the hash output as described in 
-{{authentication-messages}} namely:
+to be signed consists of:
 
-       Hash(Handshake Context + Certificate)
+       Transcript-Hash(Handshake Context, Certificate)
 
 The digital signature is then computed over the concatenation of:
 
@@ -3093,7 +3105,7 @@ and for a client signature is "TLS 1.3, client
 CertificateVerify". It is used to provide separation between signatures
 made in different contexts, helping against potential cross-protocol attacks.
 
-For example, if Hash(Handshake Context + Certificate) was 32 bytes of
+For example, if the transcript hash was 32 bytes of
 01 (this length would make sense for SHA-256), the content covered by 
 the digital signature for a server CertificateVerify would be:
 
@@ -3188,9 +3200,9 @@ Structure of this message:
 The verify_data value is computed as follows:
 
        verify_data =
-           HMAC(finished_key, Hash(Handshake Context +
-                                   Certificate* +
-                                   CertificateVerify*))
+           HMAC(finished_key,
+                Transcript-Hash(Handshake Context,
+                                Certificate*, CertificateVerify*))
 
        * Only included if present.
 
@@ -4006,7 +4018,8 @@ defined below:
 
     Derive-Secret(Secret, Label, Messages) =
          HKDF-Expand-Label(Secret, Label,
-                           Hash(Messages), Hash.Length)
+                           Transcript-Hash(Messages),
+                           Hash.Length)
 ~~~~
 
 The Hash function and the HKDF hash are the cipher suite hash algorithm.


### PR DESCRIPTION
HRR to just contain a hash value rather than some odd partial
hash state.