### PR TITLE
DH params: Peers MUST validate each other's public key

### DIFF
--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -2315,7 +2315,7 @@ bytes.
 Note: For a given Diffie-Hellman group, the padding results in all public keys
 having the same length.
 
-Peers SHOULD validate each other's public key Y by ensuring that 1 < Y
+Peers MUST validate each other's public key Y by ensuring that 1 < Y
 < p-1. This check ensures that the remote peer is properly behaved and
 isn't forcing the local system into a small subgroup.
 


### PR DESCRIPTION
I wonder why this was only a `SHOULD` before.
Am I right to assume that this is because TLS 1.3 has removed support for static DH and leaking an ephemeral key is not considered to be a security problem?