### PR TITLE
Specify _which_ servers should set the random value's suffix

### DIFF
--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -1706,7 +1706,7 @@ random value. TLS 1.3 servers which negotiate TLS 1.2 or below in
 response to a ClientHello MUST set the last eight bytes of their
 Random value specially.
 
-If negotiating TLS 1.2, servers MUST set the last eight bytes of their
+If negotiating TLS 1.2, TLS 1.3 servers MUST set the last eight bytes of their
 Random value to the bytes:
 
       44 4F 57 4E 47 52 44 01


### PR DESCRIPTION
I guess this was removed by accident in https://github.com/tlswg/tls13-spec/commit/cbc261a864236fe1424ac3a9826a7833e164a218