### PR TITLE
Fix the description of Derive-Secret's argument

### DIFF
--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -4071,7 +4071,7 @@ In this diagram, the following formatting conventions apply:
 - HKDF-Extract is drawn as taking the Salt argument from the top and the IKM argument
   from the left.
 - Derive-Secret's Secret argument is indicated by the arrow coming in
-  from the left. For instance, the Early Secret is the Secret for
+  from the left or from the top. For instance, the Early Secret is the Secret for
   generating the client_early_traffic_secret.
 
 ~~~~


### PR DESCRIPTION
Since the addition of the pre-extract Derive-Secret stages the argument
may come from the top in the diagram.