### PR TITLE
End of ClientHello and EndOfEarlyData messages should be on a record boundary

### DIFF
--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -3460,7 +3460,8 @@ that:
   records, there MUST NOT be any other records between them.
 
 - Handshake messages MUST NOT span key changes. Because
-  the ServerHello, Finished, and KeyUpdate messages signal a key change,
+  the ClientHello, EndOfEarlyData, ServerHello, Finished, and KeyUpdate messages
+  can arrive immediately prior to a key change,
   upon receiving these messages a receiver MUST verify that the end
   of these messages aligns with a record boundary; if not, then it MUST
   terminate the connection with an "unexpected_message" alert.


### PR DESCRIPTION
An EndOfEarlyData message signals a key change. A ClientHello can be the
last message read before a key is changed, and it never makes sense for a
ClientHello to have more data after it in the record.