### PR TITLE
Require implementations to verify record boundary when a key change h…

### DIFF
--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -3532,12 +3532,12 @@ that:
   types. That is, if a handshake message is split over two or more
   records, there MUST NOT be any other records between them.
 
-- Handshake messages MUST NOT span key changes. Because
-  the ClientHello, EndOfEarlyData, ServerHello, Finished, and KeyUpdate messages
-  can arrive immediately prior to a key change,
-  upon receiving these messages a receiver MUST verify that the end
-  of these messages aligns with a record boundary; if not, then it MUST
-  terminate the connection with an "unexpected_message" alert.
+- Handshake messages MUST NOT span key changes. Implementations MUST verify that
+  all messages immediately preceding a key change align with a record boundary;
+  if not, then they MUST terminate the connection with an "unexpected_message"
+  alert. Because the ClientHello, EndOfEarlyData, ServerHello, Finished, and
+  KeyUpdate messages can immediately precede a key change, implementations MUST
+  send these messages in alignment with a record boundary.
 
 Implementations MUST NOT send zero-length fragments of Handshake
 types, even if those fragments contain padding.


### PR DESCRIPTION
…appens rather than on receipt of handshake messages.

It is only actually necessary to verify that a handshake message aligns with a key change when changing keys, not when receiving the message, and it can be simpler to implement the check in this way. This change requires senders to align all these messages with a record boundary as before, but only requires recipients to verify the record boundary when the key change actually happens.