### PR TITLE
add "legacy_" prefix to alert level

### DIFF
--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -3888,7 +3888,7 @@ message. Unknown alert types MUST be treated as fatal.
        } AlertDescription;
 
        struct {
-           AlertLevel level;
+           AlertLevel legacy_level;
            AlertDescription description;
        } Alert;
 


### PR DESCRIPTION
Not used anymore, so label it appropriately.

Pointed out by Ben Kaduk on list.

https://www.ietf.org/mail-archive/web/tls/current/msg22792.html