### PR TITLE
- Remove support for disallowed extensions (cert_type, user_mapping).

### DIFF
--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -2971,8 +2971,6 @@ Structure of this message:
 
 %%% Authentication Messages
 
-       opaque ASN1Cert<1..2^24-1>;
-
        struct {
            select(certificate_type){
                case RawPublicKey:
@@ -2980,7 +2978,7 @@ Structure of this message:
                  opaque ASN1_subjectPublicKeyInfo<1..2^24-1>;
 
                case X.509:
-                 ASN1Cert cert_data;
+                 opaque cert_data<1..2^24-1>;
            }
            Extension extensions<0..2^16-1>;
        } CertificateEntry;

--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -1895,10 +1895,7 @@ appears it MUST abort the handshake with an "illegal_parameter" alert.
 |:-----------------------------------------|------------:|
 | server_name [RFC6066]                    |      CH, EE |
 | max_fragment_length [RFC6066]            |      CH, EE |
-| client_certificate_url [RFC6066]         |      CH, EE |
 | status_request [RFC6066]                 |  CH, CR, CT |
-| user_mapping [RFC4681]                   |      CH, EE |
-| cert_type [RFC6091]                      |      CH, EE |
 | supported_groups [RFC7919]               |      CH, EE |
 | signature_algorithms [RFC5246]           |      CH, CR |
 | use_srtp [RFC5764]                       |      CH, EE |
@@ -2977,7 +2974,14 @@ Structure of this message:
        opaque ASN1Cert<1..2^24-1>;
 
        struct {
-           ASN1Cert cert_data;
+           select(certificate_type){
+               case RawPublicKey:
+                 // From RFC 7250 ASN.1_subjectPublicKeyInfo
+                 opaque ASN1_subjectPublicKeyInfo<1..2^24-1>;
+
+               case X.509:
+                 ASN1Cert cert_data;
+           }
            Extension extensions<0..2^16-1>;
        } CertificateEntry;
 
@@ -2993,13 +2997,7 @@ certificate_request_context
 
 certificate_list
 : This is a sequence (chain) of CertificateEntry structures, each
-  containing a single certificate and set of extensions. The sender's
-  certificate MUST come in the first CertificateEntry in the list.
-  Each following certificate SHOULD directly certify one preceding it.
-  Because certificate validation requires that trust anchors be distributed
-  independently, a certificate that specifies a
-  trust anchor MAY be omitted from the chain, provided that
-  supported peers are known to possess any omitted certificates.
+  containing a single certificate and set of extensions.
 
 extensions:
 : A set of extension values for the CertificateEntry. The "Extension"
@@ -3012,6 +3010,17 @@ extensions:
   in the first CertificateEntry.
 {:br }
 
+If the corresponding certificate type extension
+("server_certificate_type" or "client_certificate_type") was not used
+or the X.509 certificate type was negotiated, then each
+CertificateEntry contains an X.509 certificate. The sender's
+certificate MUST come in the first CertificateEntry in the list.  Each
+following certificate SHOULD directly certify one preceding it.
+Because certificate validation requires that trust anchors be
+distributed independently, a certificate that specifies a trust anchor
+MAY be omitted from the chain, provided that supported peers are known
+to possess any omitted certificates.
+
 Note: Prior to TLS 1.3, "certificate_list" ordering required each certificate
 to certify the one immediately preceding it;
 however, some implementations allowed some flexibility. Servers sometimes send
@@ -3020,6 +3029,11 @@ are simply configured incorrectly, but these cases can nonetheless be validated
 properly. For maximum compatibility, all implementations SHOULD be prepared to
 handle potentially extraneous certificates and arbitrary orderings from any TLS
 version, with the exception of the end-entity certificate which MUST be first.
+
+If the RawPublicKey certificate type was negotiated, then the
+certificate_list MUST contain no more than one CertificateEntry, which
+contains an ASN1_subjectPublicKeyInfo value as defined in {{RFC7250}},
+Section 3.
 
 The server's certificate_list MUST always be non-empty. A client will
 send an empty certificate_list if it does not have an appropriate
@@ -4786,7 +4800,6 @@ If no such mechanism is used, then the connection has no protection
 against active man-in-the-middle attack; applications MUST NOT use TLS
 in such a way absent explicit configuration or a specific application
 profile.
-
 
 # Backward Compatibility
 


### PR DESCRIPTION
- Explicitly define RFC 7250 certificate support.