### PR TITLE
Require (2119 SHOULD) that the certificate context for post-handshake

### DIFF
--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -2837,6 +2837,11 @@ certificate_request_context
   CertificateVerify messages). This field SHALL be zero length
   unless used for the post-handshake authentication exchanges
   described in {{post-handshake-authentication}}.
+  When requesting post-handshake authentication, the server SHOULD
+  make the context unpredictable to the client (e.g., by
+  randomly generating it) in order to prevent an attacker who
+  has temporary access to the client's private key from
+  pre-computing valid CertificateVerify messages.
 
 extensions
 : A set of extensions describing the parameters of the


### PR DESCRIPTION
be unpredictable in order to prevent pre-computation of
CertificateVerify. Maybe this should actually be a MUST?