### PR TITLE
Align SignatureScheme ALL-CAPS-VERBS with RESERVED labels.

### DIFF
--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -2244,16 +2244,18 @@ SignatureSchemeList value:
            ed25519(0x0807),
            ed448(0x0808),
 
+           /* Legacy algorithms */
+           ecdsa_sha1(0x0203),
+
            /* Reserved Code Points */
-           dsa_sha1_RESERVED(0x0202),
-           dsa_sha256_RESERVED(0x0402),
-           dsa_sha384_RESERVED(0x0502),
-           dsa_sha512_RESERVED(0x0602),
-           ecdsa_sha1_RESERVED(0x0203),
            obsolete_RESERVED(0x0000..0x0200),
+           obsolete_RESERVED(0x0202),
            obsolete_RESERVED(0x0204..0x0400),
+           obsolete_RESERVED(0x0402),
            obsolete_RESERVED(0x0404..0x0500),
+           obsolete_RESERVED(0x0502),
            obsolete_RESERVED(0x0504..0x0600),
+           obsolete_RESERVED(0x0602),
            obsolete_RESERVED(0x0604..0x06FF),
            private_use(0xFE00..0xFFFF),
            (0xFFFF)
@@ -2301,9 +2303,14 @@ EdDSA algorithms
 : Indicates a signature algorithm using EdDSA as defined in
   {{RFC8032}} or its successors. Note that these correspond to the
   "PureEdDSA" algorithms and not the "prehash" variants.
+
+ecdsa_sha1
+: Indicates a signature algorithm using ECDSA and SHA-1. This value refers
+  solely to signatures which appear in certificates and is not defined for use
+  in signed TLS handshake messages.
 {:br }
 
-rsa_pkcs1_sha1, dsa_sha1, and ecdsa_sha1 SHOULD NOT be offered. Clients
+rsa_pkcs1_sha1 and ecdsa_sha1 SHOULD NOT be offered. Clients
 offering these values (e.g., for backwards compatibility) MUST list them as the lowest
 priority (listed after all other algorithms in SignatureSchemeList).
 TLS 1.3 servers MUST NOT offer a SHA-1
@@ -2326,8 +2333,8 @@ willing to negotiate TLS 1.2 MUST behave in accordance with the requirements of
   encoded in two octets, so SignatureScheme values have been allocated to
   align with TLS 1.2's encoding. Some legacy pairs are left unallocated. These
   algorithms are deprecated as of TLS 1.3. They MUST NOT be offered or
-  negotiated by any implementation. In particular, MD5 {{SLOTH}} and SHA-224
-  MUST NOT be used.
+  negotiated by any implementation. In particular, MD5 {{SLOTH}}, SHA-224, and
+  DSA MUST NOT be used.
 
 * ECDSA signature schemes align with TLS 1.2's ECDSA hash/signature pairs.
   However, the old semantics did not constrain the signing curve.  If TLS 1.2 is


### PR DESCRIPTION
Values in RESERVED labels, per the note at the top of Appendix B, MUST
NOT be sent. This conflicts other text which tags ecdsa_sha1 and
dsa_sha1 as SHOULD NOT.

Back in early drafts, {*, dsa} and {sha1, ecdsa} were not tagged
RESERVED and were merely SHOULD NOT in the text:
https://tools.ietf.org/html/draft-ietf-tls-tls13-11#section-6.3.2.1

Then things were redone as SignatureScheme with the intent of preserving
SHOULD NOTs and MUST NOTs. Accordingly, dsa_* values were defined, and
with SHOULD NOTs in prose.
https://github.com/tlswg/tls13-spec/pull/404

That was followed up by a cleanup change which left dsa_* values in
there, but not defined. Intentionally or not, this took away the SHOULD
NOT and left it with something unclear.
https://github.com/tlswg/tls13-spec/commit/bed72816a2cbcb2695718c3936c44b78498e07da

Then the RESERVED tag was added, in response to the cleanup.
Intentionally or not, this kicked in the Appendix B MUST NOT, which
means TLS 1.3 implementations are forbidden from offering DSA to TLS 1.2
servers. Nonetheless, the SHOULD NOT reference to the now non-existent
and verboten dsa_sha1 remained.
https://github.com/tlswg/tls13-spec/pull/434

Next, an oversight in PR #404 was "corrected". PR #404 was intended to
leave SHOULD NOTs and MUST NOTs as-is but downgraded {sha1, ecdsa} to a
MUST NOT by omission. However, I did not notice the Appendix B text, so
my correction was, in fact, a no-op.
https://github.com/tlswg/tls13-spec/pull/488

Restoring ecdsa_sha1 was motivated by existing many implementations
still offering {sha1, ecdsa} at TLS 1.2, so it was not clear whether
removing it was realistic yet. (Notably, dependence on {sha1, rsa} aka
rsa_pkcs1_sha1 is known to be prevalent.) Since then, BoringSSL has
removed ecdsa_sha1, so that is some evidence it is unnecessary.  NSS
still offers it, however.

So now we have a small mess on our hands. This PR attempts to bring
things to a self-consistent picture. Implementations I'm involved with
no longer offer ecdsa_sha1 or dsa_*, so I am personally fine with any
self-consistent option. For this PR, I went with:

Since PR#488 was accepted and even called out in the changelog, my
interpretation was that it should end at SHOULD NOT. That I failed to
actually implement originally is a bug.

DSA is less clear, but since there were two changes by two separate
people who chipped away at the SHOULD NOT, my interpretation is to leave
it at MUST NOT. I have taken the two changes to their logical
conclusion, removing the named dsa_*_RESERVED values and references to
non-existent dsa_sha1.