### PR TITLE
Adding missing "no_application_protocol" alert

### DIFF
--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -4355,6 +4355,10 @@ unknown_psk_identity
 certificate_required
 : Sent by servers when a client certificate is desired but none was provided by
   the client.
+  
+no_application_protocol
+: Sent by servers when a client advertises protocols that the server does 
+  not support. 
 {:br }
 
 New Alert values are assigned by IANA as described in {{iana-considerations}}.

--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -4151,6 +4151,7 @@ enum) MUST terminate the connection with an "illegal_parameter" alert.
            bad_certificate_hash_value(114),
            unknown_psk_identity(115),
            certificate_required(116),
+           no_application_protocol(120),
            (255)
        } AlertDescription;
 


### PR DESCRIPTION
RFC 7301 defines the ALPN extension and defined a new alert "no_application_protocol". TLS 1.3 uses ALPN but currently misses the alert in Section 6.