### PR TITLE
"supported_groups" is not MTU in EncryptedExtensions

### DIFF
--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -4695,7 +4695,9 @@ applicable features:
 
   * "supported_versions" is REQUIRED for all ClientHello messages.
   * "signature_algorithms" is REQUIRED for certificate authentication.
-  * "supported_groups" and "key_share" are REQUIRED for DHE or ECDHE key exchange.
+  * "supported_groups" is REQUIRED for ClientHello messages using
+    DHE or ECDHE key exchange.
+  * "key_share" is REQUIRED for DHE or ECDHE key exchange.
   * "pre_shared_key" is REQUIRED for PSK key agreement.
 
 A client is considered to be attempting to negotiate using this


### PR DESCRIPTION
Even when (EC)DHE is in use, the "supported_groups" extension is
only mandatory in the ClientHello; it can be omitted from the
EncryptedExtensions, as per section 4.2.6.

Given that, it is not MTI for the server sending to the client, but
the client must be prepared to accept the extension in EncryptedExtensions
(at least to the point of not crashing or aborting the handshake), so
leave the MTI text unchanged.  It would be too awkward to try to
express this subtlety in such a concise list.