### PR TITLE
PSK context for 0-RTT needs version number

### DIFF
--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -1313,6 +1313,7 @@ the server and to encrypt the early data.
 When clients use a PSK obtained externally to send early data, then the following
 additional information MUST be provisioned to both parties:
 
+  * The TLS version number for use with this PSK
   * The cipher suite for use with this PSK
   * The Application-Layer Protocol Negotiation (ALPN) protocol, if any is to be used
   * The Server Name Indication (SNI), if any is to be used


### PR DESCRIPTION
The 0-RTT key might differ between TLS versions (as demonstrated with
the draft -20 changes). Be explicit about storing this version number
since section 4.2.9 requires this information too.