### PR TITLE
cite RFC for alert

### DIFF
--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -4382,7 +4382,8 @@ certificate_required
 no_application_protocol
 : Sent by servers when a client
   "application_layer_protocol_negotiation" extension advertises
-  protocols that the server does not support.
+  protocols that the server does not support
+  (see {{RFC7301}}).
 {:br }
 
 New Alert values are assigned by IANA as described in {{iana-considerations}}.


### PR DESCRIPTION
Follow up to PR #981. Add a link for the ALPN RFC to the relevant alert's description. (same as with other extension alerts above)