### PR TITLE
Add rekey events to the state machine

### DIFF
--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -4852,7 +4852,6 @@ indicated in [].
                                v
                             NEGOTIATED
                                | Send ServerHello
-                               | [Rekey in to early keys]
                                | Rekey out to handshake keys
                                | Send EncryptedExtensions
                                | [Send CertificateRequest]
@@ -4863,11 +4862,11 @@ after here                 +---+-------------+
                            |                 |
                   No 0-RTT |                 | 0-RTT
 Rekey in to handshake keys |                 | Rekey in to early keys
-[Read past decrypt errors] |                 v
+[Read past decrypt errors] |                 | Read early data
+                           |                 v
                            |             WAIT_EOED
                            |                 | Recv EndOfEarlyData
                            |                 | Rekey in to hs keys
-                           |                 |
                            +> WAIT_FLIGHT2 <-+
                                     |
                            +--------+--------+

--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -4810,7 +4810,7 @@ indicated in [].
 ~~~~
                            START <----+
             Send ClientHello |        | Recv HelloRetryRequest
-   [Rekey out to early keys] |        | Send ClientHello
+   [Rekey out to early keys] |        |
                              v        | 
          /                 WAIT_SH ---+
         |                    | Recv ServerHello

--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -4811,8 +4811,8 @@ indicated in [].
                            START <----+
             Send ClientHello |        | Recv HelloRetryRequest
    [Rekey out to early keys] |        | Send ClientHello
-         /                   v        | 
-        |                  WAIT_SH ---+
+                             v        | 
+         /                 WAIT_SH ---+
         |                    | Recv ServerHello
         |                    | Rekey in to handshake keys
     Can |                    V
@@ -4832,8 +4832,8 @@ indicated in [].
         |           +> WAIT_FINISHED <+
         |                  | Recv Finished
          \                 | Rekey in to application keys
-                           | Rekey out to handshake keys
                            | [Send EndOfEarlyData]
+                           | Rekey out to handshake keys
                            | [Send Certificate [+ CertificateVerify]]
  Can send                  | Send Finished
  app data   -->            | Rekey out to application keys
@@ -4866,7 +4866,8 @@ Rekey in to handshake keys |                 | Rekey in to early keys
                            |                 v
                            |             WAIT_EOED
                            |                 | Recv EndOfEarlyData
-                           |                 | Rekey in to hs keys
+                           |                 | Rekey in to 
+                           |                 | handshake keys
                            +> WAIT_FLIGHT2 <-+
                                     |
                            +--------+--------+


### PR DESCRIPTION
In updating [mint](https://github.com/bifurcation/mint) to use this state machine, I found that it was tricky to align re-key events with state transitions, since they happen in between the messages output by a given state transition (e.g., rekeying to the handshake keys in between `ServerHello` and `EncryptedExtensions` on the way out of `NEGOTIATED`).

This PR adds to the state machine diagrams notations of when the keys should be changed on the inbound and outbound sides, in the order in which they need to be sequenced with handshake messages.  It also makes a few more minor edits:

* Adds some missing handshake message sends
* Notes when the server needs to read past decrypt errors due to rejected early data
* Moves "Recv early data" to after finished, since it doesn't affect the state
