### PR TITLE
Add post-handshake state transitions

### DIFF
--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -4799,11 +4799,11 @@ by IANA:
 
 # State Machine
 
-This section provides a summary of the legal state transitions for the
-client and server handshakes.  State names (in all capitals, e.g.,
-START) have no formal meaning but are provided for ease of
-comprehension.  Messages which are sent only sometimes are indicated
-in [].
+This section provides a summary of the legal state transitions for the client
+and server handshakes and handshake-level interactions that occur after the
+initial handshake.  State names (in all capitals, e.g., START) have no formal
+meaning but are provided for ease of comprehension.  Messages which are sent
+only sometimes are indicated in [].
 
 ## Client
 
@@ -4877,6 +4877,29 @@ here         No 0-RTT |                 | 0-RTT
                                | Recv Finished
                                v
                            CONNECTED
+~~~~
+
+## Post-Handshake
+
+~~~~
+                        CONNECTED---------------+
+                         |   ^                  | Send 
+                         |   |                  | CertificateRequest
+          Send KeyUpdate |   |                  V
+                -- or -- |   |              WAIT_CERT
+          Recv KeyUpdate |   |         Recv |       | Recv Certificate
+        [Send KeyUpdate] |   |        empty |       v
+                -- or -- |   |  Certificate |    WAIT_CV
+   Send NewSessionTicket |   |              |       | Recv 
+                -- or -- |   |              |       | CertificateVerify
+   Recv NewSessionTicket |   |              v       V 
+                -- or -- |   |            WAIT_FINISHED
+ Recv CertificateRequest |   |                  | Recv Finished
+        Send Certificate |   |                  v
+[Send CertificateVerify] |   |              CONNECTED
+           Send Finished |   |                  |
+                         |   |                  |
+                         +-->+<-----------------+
 ~~~~
 
 # Protocol Data Structures and Constant Values

--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -4895,10 +4895,9 @@ here         No 0-RTT |                 | 0-RTT
    Recv NewSessionTicket |   |              v       V 
                 -- or -- |   |            WAIT_FINISHED
  Recv CertificateRequest |   |                  | Recv Finished
-        Send Certificate |   |                  v
-[Send CertificateVerify] |   |              CONNECTED
+        Send Certificate |   |                  |
+[Send CertificateVerify] |   |                  |
            Send Finished |   |                  |
-                         |   |                  |
                          +-->+<-----------------+
 ~~~~
 


### PR DESCRIPTION
If an implementation is using a state machine structure to process incoming handshake messages, then it could be useful to have a similar diagram for state transitions that result from handshake messages that show up after the initial handshake.  For the most part, these are trivial (`CONNECTED -> CONNECTED`), but post-handshake authentication needs the sub-graph with `WAIT_CERT` etc.