### PR TITLE
Allow clients to use any suitable alert if a non-acceptable cert chain

### DIFF
--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -3373,7 +3373,8 @@ use the deprecated SHA-1 hash algorithm only if the "signature_algorithms"
 extension provided by the client permits it.
 If the client cannot construct an acceptable chain using the provided
 certificates and decides to abort the handshake, then it MUST abort the
-handshake with an "unsupported_certificate" alert.
+handshake with an appropriate certificate-related alert (by default,
+"unsupported_certificate"; see {{error-alerts}} for more).
 
 If the server has multiple certificates, it chooses one of them based on the
 above-mentioned criteria (in addition to other criteria, such as transport


### PR DESCRIPTION
There are a number of different alerts that may be suitable for sending
to indicate a non-acceptable cert chain, e.g. certificate_revoked,
certificate_expired, unknown_ca, etc. We should not restrict the client
to only sending one specific alert.