### PR TITLE
clients MUST send Finished when using 0-RTT

### DIFF
--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -2939,6 +2939,12 @@ servers MUST process the client's ClientHello and then immediately
 send the ServerHello, rather than waiting for the client's
 EndOfEarlyData message.
 
+Servers are permitted to buffer and postpone the processing of application
+data sent in 0-RTT until they receive client's Finished. Therefore, when
+using 0-RTT, clients MUST proceed the handshake to the point of sending
+their Finished messages even if there are no application data to be sent
+in 1-RTT.
+
 #### Replay Properties {#replay-time}
 
 As noted in {{zero-rtt-data}}, TLS provides a limited mechanism for

--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -2939,11 +2939,13 @@ servers MUST process the client's ClientHello and then immediately
 send the ServerHello, rather than waiting for the client's
 EndOfEarlyData message.
 
-Servers are permitted to buffer and postpone the processing of application
-data sent in 0-RTT until they receive client's Finished. Therefore, when
-using 0-RTT, clients MUST proceed the handshake to the point of sending
-the Finished message even if there are no application data to be sent
-in 1-RTT.
+When using 0-RTT, clients MUST send its Finished message in response to
+the handshake messages sent from the server, even if there is no
+application data to be sent in 1-RTT. Servers MAY accept 0-RTT data but
+can still decide to buffer and postpone the processing of the payload
+until the client sends Finished, which can be used as a confirmation
+that the data was not replayed. Using such strategy is beneficial when
+tolerance against replay attacks depend on the payload.
 
 #### Replay Properties {#replay-time}
 

--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -2942,7 +2942,7 @@ EndOfEarlyData message.
 Servers are permitted to buffer and postpone the processing of application
 data sent in 0-RTT until they receive client's Finished. Therefore, when
 using 0-RTT, clients MUST proceed the handshake to the point of sending
-their Finished messages even if there are no application data to be sent
+the Finished message even if there are no application data to be sent
 in 1-RTT.
 
 #### Replay Properties {#replay-time}

--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -2939,13 +2939,13 @@ servers MUST process the client's ClientHello and then immediately
 send the ServerHello, rather than waiting for the client's
 EndOfEarlyData message.
 
-When using 0-RTT, clients MUST send its Finished message in response to
+When using 0-RTT, a client MUST send its Finished message in response to
 the handshake messages sent from the server, even if there is no
-application data to be sent in 1-RTT. Servers MAY accept 0-RTT data but
-can still decide to buffer and postpone the processing of the payload
-until the client sends Finished, which can be used as a confirmation
-that the data was not replayed. Using such strategy is beneficial when
-tolerance against replay attacks depend on the payload.
+application data to be sent in 1-RTT. Servers MAY accept 0-RTT data yet
+still decide to buffer and postpone the processing of the payload
+until the client sends Finished, which can be used as confirmation
+that the data was not replayed. Using such a strategy is beneficial when
+tolerance against replay attacks depends on the payload.
 
 #### Replay Properties {#replay-time}
 


### PR DESCRIPTION
since servers are allowed to postpone processing of the application data sent in 0-RTT until seeing client's Finished.

This is what some deployments already do and what others are interested in doing[1].

[1] https://lists.w3.org/Archives/Public/ietf-http-wg/2017AprJun/0124.html