### PR TITLE
trivial comment fix

### DIFF
--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -3209,7 +3209,7 @@ replaced with a special synthetic handshake message of handshake
 type "message_hash" containing Hash(ClientHello1). I.e.,
 
      Transcript-Hash(ClientHello1, HelloRetryRequest, ... MN) =
-         Hash(message_hash ||                 // Handshake Type
+         Hash(message_hash ||        // Handshake type
               00 00 Hash.length ||   // Handshake message length
               Hash(ClientHello1) ||  // Hash of ClientHello1
               HelloRetryRequest ... MN)


### PR DESCRIPTION
Very trivial comment fix. Just makes the indentation & capitalization of a comment match the others near it.