### PR TITLE
Document the static key share attack

### DIFF
--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -3,8 +3,8 @@ title: The Transport Layer Security (TLS) Protocol Version 1.3
 abbrev: TLS
 docname: draft-ietf-tls-tls13-latest
 category: std
-updates: 4492
-obsoletes: 5077, 5246, 5746
+updates: 4492, 5705, 6066, 6961
+obsoletes: 5077, 5246
 
 ipr: pre5378Trust200902
 area: General
@@ -33,28 +33,16 @@ author:
 normative:
   RFC2104:
   RFC2119:
-  RFC2434:
-  RFC3447:
+  RFC5226:
   RFC5280:
-  RFC5288:
-  RFC5289:
   RFC5869:
   RFC6066:
-  RFC6209:
-  RFC6367:
   RFC6655:
-  RFC7251:
-  I-D.ietf-tls-chacha20-poly1305:
-  I-D.irtf-cfrg-curves:
-  I-D.irtf-cfrg-eddsa:
-
-  AES:
-       title: Specification for the Advanced Encryption Standard (AES)
-       date: 2001-11-26
-       author:
-         org: National Institute of Standards and Technology
-       seriesinfo:
-         NIST: FIPS 197
+  RFC7539:
+  RFC7748:
+  RFC7919:
+  RFC8032:
+  RFC8017:
   SHS:
        title: Secure Hash Standard
        date: 2012-03
@@ -83,44 +71,34 @@ normative:
           - ins: M. Hellman
         date: 1977-06
         seriesinfo: IEEE Transactions on Information Theory, V.IT-22 n.6
-
+  GCM:
+        title: "Recommendation for Block Cipher Modes of Operation: Galois/Counter Mode (GCM) and GMAC"
+        date: 2007-11
+        author:
+          - ins: M. Dworkin
+        seriesinfo:
+          NIST: Special Publication 800-38D
 
 informative:
-  RFC0793:
-  RFC1948:
   RFC4086:
-  RFC4279:
-  RFC4302:
-  RFC4303:
   RFC4346:
   RFC4366:
   RFC4492:
-  RFC4506:
-  RFC4507:
   RFC4681:
-  RFC5054:
   RFC5077:
-  RFC5081:
   RFC5116:
   RFC5246:
-  RFC5746:
-  RFC5763:
   RFC5764:
-  RFC5878:
   RFC5929:
   RFC6176:
   RFC6091:
   RFC6520:
-  RFC6961:
-  RFC6962:
-  RFC7301:
+  RFC7230:
   RFC7250:
-  RFC7366:
   RFC7465:
   RFC7568:
   RFC7627:
   RFC7685:
-  I-D.ietf-tls-negotiated-ff-dhe:
 
   DSS:
        title: "Digital Signature Standard, version 4"
@@ -136,30 +114,20 @@ informative:
        date: 2005-11
        seriesinfo:
          ANSI: ANS X9.62-2005
-  FI06:
-       title: "Bleichenbacher's RSA signature forgery based on implementation error"
+  KEYAGREEMENT:
+       title: "Recommendation for Pair-Wise Key Establishment Schemes Using Discrete Logarithm Cryptography"
        author:
-         - name: Hal Finney
-       date: 2006-08-27
-       target: https://www.ietf.org/mail-archive/web/openpgp/current/msg00999.html
-       
-  GCM:
-       title: "Recommendation for Block Cipher Modes of Operation: Galois/Counter Mode (GCM) and GMAC"
-       date: 2007-11
-       author:
-         ins: M. Dworkin
+         -
+           ins: E. Barker
+         -
+           ins: Lily Chen
+         -
+           ins: A. Roginsky
+         -
+           ins: M. Smid
+       date: 2013-05
        seriesinfo:
          NIST: Special Publication 800-38D
-  PKCS6:
-       title: "PKCS #6: RSA Extended Certificate Syntax Standard, version 1.5"
-       author:
-         org: RSA Laboratories
-       date: 1993-11
-  PKCS7:
-       title: "PKCS #7: RSA Cryptographic Message Syntax Standard, version 1.5"
-       author:
-         org: RSA Laboratories
-       date: 1993-11
   RSA:
        title: "A Method for Obtaining Digital Signatures and Public-Key Cryptosystems"
        author:
@@ -226,19 +194,319 @@ informative:
          ins: T. van der Merwe
        -
          ins: S. Scott
+  CHHSV17:
+       title: "Awkward Handshake: Possible mismatch of client/server view on client authentication in post-handshake mode in Revision 18"
+       date: 2017
+       target: https://www.ietf.org/mail-archive/web/tls/current/msg22382.html
+       author:
+       -
+         ins: C. Cremers
+       -
+         ins: M. Horvat
+       -
+         ins: J. Hoyland
+       -
+         ins: T. van der Merwe
+       -
+         ins: S. Scott
+  SLOTH:
+       title: "Transcript Collision Attacks: Breaking Authentication in TLS, IKE, and SSH"
+       author:
+       -
+         ins: K. Bhargavan
+       -
+         ins: G. Leurent
+       seriesinfo: Network and Distributed System Security Symposium (NDSS 2016)
+       date: 2016
+  AEAD-LIMITS:
+       title: "Limits on Authenticated Encryption Use in TLS"
+       author:
+       -
+         ins: A. Luykx
+       -
+         ins: K. Paterson
+       target: http://www.isg.rhul.ac.uk/~kp/TLS-AEbounds.pdf
+       date: 2016
+  CK01:
+       title: "Analysis of Key-Exchange Protocols and Their Use for Building Secure Channels"
+       author:
+       -
+         ins: R. Canetti
+       -
+         ins: H. Krawczyk
+       seriesinfo: Proceedings of Eurocrypt 2001
+       date: 2001
+  CCG16:
+       title: "On Post-Compromise Security"
+       author:
+       -
+         ins: K. Cohn-Gordon
+       -
+         ins: C. Cremers
+       -
+         ins: L. Garratt
+       seriesinfo: IEEE Computer Security Foundations Symposium
+       date: 2015
+  BBFKZG16:
+       title: "Downgrade Resilience in Key-Exchange Protocols"
+       author:
+       -
+         ins: K. Bhargavan
+       -
+         ins: C. Brzuska
+       -
+         ins: C. Fournet
+       -
+         ins: M. Kohlweiss
+       -
+         ins: S. Zanella-Beguelin
+       -
+         ins: M. Green
+       seriesinfo: Proceedings of IEEE Symposium on Security and Privacy (Oakland) 2016
+       date: 2016
+  DOW92:
+       title: “Authentication and authenticated key exchanges”
+       author:
+       -
+         ins: W. Diffie
+       -
+         ins: P. van Oorschot
+       -
+         ins: M. Wiener
+       seriesinfo: Designs, Codes and Cryptography
+       date: 1992
+  HGFS15:
+       title: "Prying Open Pandora's Box: KCI Attacks against TLS"
+       author:
+       -
+         ins: C. Hlauschek
+       -
+         ins: M. Gruber
+       -
+         ins: F. Fankhauser
+       -
+         ins: C. Schanes
+       seriesinfo: Proceedings of USENIX Workshop on Offensive Technologies
+       date: 2015
+  SIGMA:
+       title: "SIGMA: the 'SIGn-and-MAc' approach to authenticated Diffie-Hellman and its use in the IKE protocols"
+       author:
+       -
+         ins: H. Krawczyk
+       seriesinfo: Proceedings of CRYPTO 2003
+       date: 2003
+  CHSV16:
+       title: "Automated Analysis and Verification of TLS 1.3: 0-RTT, Resumption and Delayed Authentication"
+       author:
+       -
+         ins: C. Cremers
+       -
+         ins: M. Horvat
+       -
+         ins: S. Scott
+       -
+         ins: T. van der Merwe
+       seriesinfo: Proceedings of IEEE Symposium on Security and Privacy (Oakland) 2016
+       target: http://ieeexplore.ieee.org/document/7546518/
+       date: 2016
+  FGSW16:
+       title: "Key Confirmation in Key Exchange: A Formal Treatment and Implications for TLS 1.3"
+       author:
+       -
+         ins: M. Fischlin
+       -
+         ins: F. Guenther
+       -
+         ins: B. Schmidt
+       -
+         ins: B. Warinschi
+       seriesinfo: Proceedings of IEEE Symposium on Security and Privacy (Oakland) 2016
+       target: http://ieeexplore.ieee.org/document/7546517/
+       date: 2016
+  LXZFH16:
+       title: "Multiple Handshakes Security of TLS 1.3 Candidates"
+       author:
+       -
+         ins: X. Li
+       -
+         ins: J. Xu
+       -
+         ins: D. Feng
+       -
+         ins: Z. Zhang
+       -
+         ins: H. Hu
+       seriesinfo: Proceedings of IEEE Symposium on Security and Privacy (Oakland) 2016
+       target: http://ieeexplore.ieee.org/document/7546519/
+       date: 2016
+  FW15:
+       title: "Factoring RSA Keys With TLS Perfect Forward Secrecy"
+       author:
+       -
+         ins: Florian Weimer
+         org: Red Hat Product Security
+       date: 2015-09
+  REKEY:
+      title: "Increasing the Lifetime of a Key: A Comparative Analysis of the Security of Re-keying Techniques"
+      author:
+      -
+        ins: M. Abdalla
+      -
+        ins: M. Bellare
+      seriesinfo: ASIACRYPT2000
+      date: 2000-10
+  BDFKPPRSZZ16:
+      title: "Implementing and Proving the TLS 1.3 Record Layer"
+      author:
+      -
+        ins: K. Bhargavan
+      -
+        ins: A. Delignat-Lavaud
+      -
+        ins: C. Fournet
+      -
+        ins: M. Kohlweiss
+      -
+        ins: J. Pan
+      -
+        ins: J. Protzenko
+      -
+        ins: A. Rastogi
+      -
+        ins: N. Swamy
+      -
+        ins: S. Zanella-Beguelin
+      -
+        ins: J.K. Zinzindohoue
+      seriesinfo: Proceedings of IEEE Symposium on Security and Privacy (Oakland) 2017
+      date: 2016-12
+      target: https://eprint.iacr.org/2016/1178
+
+  BMMT15:
+      title: "Augmented Secure Channels and the Goal of the TLS 1.3 Record Layer"
+      author:
+      -
+        ins: C. Badertscher
+      -
+        ins: C. Matt
+      -
+        ins: U. Maurer
+      -
+        ins: B. Tackmann
+      seriesinfo: ProvSec 2015
+      date: 2015-09
+      target: https://eprint.iacr.org/2015/394
+
+  BT16:
+      title: "The Multi-User Security of Authenticated Encryption: AES-GCM in TLS 1.3"
+      author:
+      -
+        ins: M. Bellare
+      -
+        ins: B. Tackmann
+      seriesinfo: Proceedings of CRYPTO 2016
+      date: 2016
+      target: https://eprint.iacr.org/2016/564
+
+  Kraw16:
+       title: "A Unilateral-to-Mutual Authentication Compiler for Key Exchange (with Applications to Client Authentication in TLS 1.3"
+       date: 2016
+       seriesinfo: Proceedings of ACM CCS 2016
+       target: https://eprint.iacr.org/2016/711
+       author:
+       -
+         ins: H. Krawczyk
+
+  KW16:
+       title: "The OPTLS Protocol and TLS 1.3"
+       date: 2016
+       seriesinfo: Proceedings of Euro S&quot;P 2016
+       target: https://eprint.iacr.org/2015/978
+       author:
+       -
+         ins: H. Krawczyk
+       -
+         ins: H. Wee
+
+  DFGS15:
+       title: "A Cryptographic Analysis of the TLS 1.3 draft-10 Full and Pre-shared Key Handshake Protocol"
+       date: 2015
+       seriesinfo: Proceedings of ACM CCS 2015
+       target: https://eprint.iacr.org/2015/914
+       author:
+       -
+         ins: B. Dowling
+       -
+         ins: M. Fischlin
+       -
+         ins: F. Guenther
+       -
+         ins: D. Stebila
+
+  DFGS16:
+       title: "A Cryptographic Analysis of the TLS 1.3 draft-10 Full and Pre-shared Key Handshake Protocol"
+       date: 2016
+       seriesinfo: TRON 2016
+       target: https://eprint.iacr.org/2016/081
+       author:
+       -
+         ins: B. Dowling
+       -
+         ins: M. Fischlin
+       -
+         ins: F. Guenther
+       -
+         ins: D. Stebila
+
+  FG17:
+       title: "Replay Attacks on Zero Round-Trip Time: The Case of the TLS 1.3 Handshake Candidates"
+       date: 2017
+       seriesinfo: Proceedings of Euro S&quot;P 2017
+       target: https://eprint.iacr.org/2017/082
+       author:
+       -
+         ins: M. Fischlin
+       -
+         ins: F. Guenther
+
+  BBK17:
+       title: "Verified Models and Reference Implementations for the TLS 1.3 Standard Candidate"
+       date: 2017
+       seriesinfo: Proceedings of IEEE Symposium on Security and Privacy (Oakland) 2017
+       author:
+       -
+         ins: K. Bhargavan
+       -
+         ins: B. Blanchet
+       -
+         ins: N. Kobeissi
+  Kraw10:
+       title: "Cryptographic Extraction and Key Derivation: The HKDF Scheme"
+       date: 2010
+       seriesinfo: Proceedings of CRYPTO 2010
+       target: https://eprint.iacr.org/2010/264
+       author:
+       -
+         ins: H. Krawczyk
+  Mac17:
+       title: "Security Review of TLS1.3 0-RTT"
+       date: 2017
+       target: https://github.com/tlswg/tls13-spec/issues/1001
+       author:
+       -
+         ins: C. MacCarthaigh
+
 
 --- abstract
 
-This document specifies Version 1.3 of the Transport Layer Security
-(TLS) protocol.  The TLS protocol allows client/server applications to
+This document specifies version 1.3 of the Transport Layer Security
+(TLS) protocol.  TLS allows client/server applications to
 communicate over the Internet in a way that is designed to prevent eavesdropping,
 tampering, and message forgery.
 --- middle
 
 
 #  Introduction
-
-DISCLAIMER: This is a WIP draft of TLS 1.3 and has not yet seen significant security analysis.
 
 RFC EDITOR: PLEASE REMOVE THE FOLLOWING PARAGRAPH
 The source for this draft is maintained in GitHub. Suggested changes
@@ -247,55 +515,66 @@ https://github.com/tlswg/tls13-spec. Instructions are on that page as
 well. Editorial changes can be managed in GitHub, but any substantive
 change should be discussed on the TLS mailing list.
 
-The primary goal of the TLS protocol is to provide privacy and data integrity
-between two communicating peers. The TLS protocol is composed of two layers:
-the TLS Record Protocol and the TLS Handshake Protocol. At the lowest level,
-layered on top of some reliable transport protocol (e.g., TCP {{RFC0793}}), is
-the TLS Record Protocol. The TLS Record Protocol provides connection security
-that has two basic properties:
+The primary goal of TLS is to provide a secure channel
+between two communicating peers. Specifically, the channel should
+provide the following properties:
 
-- The connection is private.  Symmetric cryptography is used for
-  data encryption (e.g., AES {{AES}}).  The keys for
-  this symmetric encryption are generated uniquely for each
-  connection and are based on a secret negotiated by another
-  protocol (such as the TLS Handshake Protocol).
+- Authentication: The server side of the channel is always
+  authenticated; the client side is optionally
+  authenticated. Authentication can happen via asymmetric cryptography
+  (e.g., RSA {{RSA}}, ECDSA {{ECDSA}}, EdDSA {{RFC8032}}) or a pre-shared key (PSK).
 
-- The connection is reliable.  Messages include an authentication
-  tag which protects them against modification.
+- Confidentiality: Data sent over the channel after establishment
+  is only visible to the
+  endpoints. TLS does not hide the length of the data it transmits,
+  though endpoints are able to pad TLS records in order to obscure lengths
+  and improve protection against traffic analysis techniques.
 
-Note: The TLS Record Protocol can operate in an insecure mode but is generally
-only used in this mode while another protocol is using the TLS Record
-Protocol as a transport for negotiating security parameters.
+- Integrity: Data sent over the channel after establishment cannot be
+  modified by attackers.
 
-The TLS Record Protocol is used for encapsulation of various higher-level
-protocols. One such encapsulated protocol, the TLS Handshake Protocol, allows
-the server and client to authenticate each other and to negotiate an encryption
-algorithm and cryptographic keys before the application protocol transmits or
-receives its first byte of data. The TLS Handshake Protocol provides connection
-security that has three basic properties:
+These properties should be true even in the face of an attacker who has complete
+control of the network, as described in {{?RFC3552}}.
+See {{security-analysis}} for a more complete statement of the relevant security
+properties.
 
+TLS consists of two primary components:
 
-- The peer's identity can be authenticated using asymmetric, or
-  public key, cryptography (e.g., RSA {{RSA}}, ECDSA {{ECDSA}}).  This
-  authentication can be made optional, but is generally required for
-  at least one of the peers.
+- A handshake protocol ({{handshake-protocol}}) that authenticates the communicating parties,
+  negotiates cryptographic modes and parameters, and establishes
+  shared keying material. The handshake protocol is designed to
+  resist tampering; an active attacker should not be able to force
+  the peers to negotiate different parameters than they would
+  if the connection were not under attack.
 
-- The negotiation of a shared secret is secure: the negotiated
-  secret is unavailable to eavesdroppers, and for any authenticated
-  connection the secret cannot be obtained, even by an attacker who
-  can place himself in the middle of the connection.
+- A record protocol ({{record-protocol}}) that uses the parameters established by the
+  handshake protocol to protect traffic between the communicating
+  peers. The record protocol divides traffic up into a series of
+  records, each of which is independently protected using the
+  traffic keys.
 
-- The negotiation is reliable: no attacker can modify the
-  negotiation communication without being detected by the parties to
-  the communication.
+TLS is application protocol independent; higher-level protocols can
+layer on top of TLS transparently. The TLS standard, however, does not
+specify how protocols add security with TLS; how to
+initiate TLS handshaking and how to interpret the authentication
+certificates exchanged are left to the judgment of the designers and
+implementors of protocols that run on top of TLS.
 
+This document defines TLS version 1.3. While TLS 1.3 is not directly
+compatible with previous versions, all versions of TLS incorporate a
+versioning mechanism which allows clients and servers to interoperably
+negotiate a common version if one is supported by both peers.
 
-One advantage of TLS is that it is application protocol independent.
-Higher-level protocols can layer on top of the TLS protocol transparently. The
-TLS standard, however, does not specify how protocols add security with TLS;
-the decisions on how to initiate TLS handshaking and how to interpret the
-authentication certificates exchanged are left to the judgment of the designers
-and implementors of protocols that run on top of TLS.
+This document supersedes and obsoletes previous versions of TLS
+including version 1.2 {{RFC5246}}.  It also obsoletes the TLS ticket
+mechanism defined in {{RFC5077}} and replaces it with the mechanism
+defined in {{resumption-and-psk}}. {{negotiated-groups}} updates
+{{RFC4492}} by modifying the protocol attributes used to negotiate
+Elliptic Curves.  Because TLS 1.3 changes the way keys are derived it
+updates {{RFC5705}} as described in {{exporters}} it also changes
+how OCSP messages are carried and therefore updates {{RFC6066}}
+and obsoletes {{RFC6961}} as described in section {{ocsp-and-sct}}.
+
 
 ##  Conventions and Terminology
 
@@ -311,20 +590,262 @@ connection: A transport-layer connection between two endpoints.
 
 endpoint: Either the client or server of the connection.
 
-handshake: An initial negotiation between client and server that establishes the parameters of their transactions.
+handshake: An initial negotiation between client and server that establishes the parameters of their subsequent interactions.
 
-peer: An endpoint. When discussing a particular endpoint, "peer" refers to the endpoint that is remote to the primary subject of discussion.
+peer: An endpoint. When discussing a particular endpoint, "peer" refers to the endpoint that is not the primary subject of discussion.
 
 receiver: An endpoint that is receiving records.
 
 sender: An endpoint that is transmitting records.
 
-session: An association between a client and a server resulting from a handshake.
-
 server: The endpoint which did not initiate the TLS connection.
 
 
-##  Major Differences from TLS 1.2
+##  Change Log
+
+RFC EDITOR PLEASE DELETE THIS SECTION.
+
+
+(*) indicates changes to the wire protocol which may require implementations
+    to update.
+
+draft-21
+
+- Add a per-ticket nonce so that each ticket is associated with a
+  different PSK (*).
+
+- Clarify that clients should send alerts with the handshake key
+  if possible.
+
+- Update state machine to show rekeying events
+
+- Add discussion of 0-RTT and replay. Recommend that implementations
+  implement some anti-replay mechanism.
+
+draft-20
+
+- Add "post_handshake_auth" extension to negotiate post-handshake authentication
+  (*).
+
+- Shorten labels for HKDF-Expand-Label so that we can fit within one
+  compression block (*).
+
+- Define how RFC 7250 works (*).
+
+- Re-enable post-handshake client authentication even when you do PSK.
+  The previous prohibition was editorial error.
+
+- Remove cert_type and user_mapping, which don't work on TLS 1.3 anyway.
+
+- Added the no_application_protocol alert from {{!RFC7301}} to the list
+  of extensions.
+
+- Added discussion of traffic analysis and side channel attacks.
+
+draft-19
+
+- Hash context_value input to Exporters (*)
+
+- Add an additional Derive-Secret stage to Exporters (*).
+
+- Hash ClientHello1 in the transcript when HRR is used. This
+  reduces the state that needs to be carried in cookies. (*)
+
+- Restructure CertificateRequest to have the selectors
+  in extensions. This also allowed defining a "certificate_authorities"
+  extension which can be used by the client instead of trusted_ca_keys (*).
+
+- Tighten record framing requirements and require checking of them (*).
+
+- Consolidate "ticket_early_data_info" and "early_data" into a single
+  extension (*).
+
+- Change end_of_early_data to be a handshake message (*).
+
+- Add pre-extract Derive-Secret stages to key schedule (*).
+
+- Remove spurious requirement to implement "pre_shared_key".
+
+- Clarify location of "early_data" from server (it goes in EE,
+  as indicated by the table in S 10).
+
+- Require peer public key validation
+
+- Add state machine diagram.
+
+
+draft-18
+
+- Remove unnecessary resumption_psk which is the only thing expanded from
+  the resumption master secret. (*).
+
+- Fix signature_algorithms entry in extensions table.
+
+- Restate rule from RFC 6066 that you can't resume unless SNI is the same.
+
+
+draft-17
+
+- Remove 0-RTT Finished and resumption_context, and replace with a
+  psk_binder field in the PSK itself (*)
+
+- Restructure PSK key exchange negotiation modes (*)
+
+- Add max_early_data_size field to TicketEarlyDataInfo (*)
+
+- Add a 0-RTT exporter and change the transcript for the regular exporter (*)
+
+- Merge TicketExtensions and Extensions registry. Changes
+  ticket_early_data_info code point (*)
+
+- Replace Client.key_shares in response to HRR (*)
+
+- Remove redundant labels for traffic key derivation (*)
+
+- Harmonize requirements about cipher suite matching: for resumption you
+  need to match KDF but for 0-RTT you need whole cipher suite. This
+  allows PSKs to actually negotiate cipher suites. (*)
+
+- Move SCT and OCSP into Certificate.extensions (*)
+
+- Explicitly allow non-offered extensions in NewSessionTicket
+
+- Explicitly allow predicting client Finished for NST
+
+- Clarify conditions for allowing 0-RTT with PSK
+
+
+draft-16
+
+- Revise version negotiation (*)
+
+- Change RSASSA-PSS and EdDSA SignatureScheme codepoints for better backwards compatibility (*)
+
+- Move HelloRetryRequest.selected_group to an extension (*)
+
+- Clarify the behavior of no exporter context and make it the same
+  as an empty context.(*)
+
+- New KeyUpdate format that allows for requesting/not-requesting an
+  answer. This also means changes to the key schedule to support
+  independent updates (*)
+
+- New certificate_required alert (*)
+
+- Forbid CertificateRequest with 0-RTT and PSK.
+
+- Relax requirement to check SNI for 0-RTT.
+
+
+draft-15
+
+- New negotiation syntax as discussed in Berlin (*)
+
+- Require CertificateRequest.context to be empty during handshake (*)
+
+- Forbid empty tickets (*)
+
+- Forbid application data messages in between post-handshake messages
+  from the same flight (*)
+
+- Clean up alert guidance (*)
+
+- Clearer guidance on what is needed for TLS 1.2.
+
+- Guidance on 0-RTT time windows.
+
+- Rename a bunch of fields.
+
+- Remove old PRNG text.
+
+- Explicitly require checking that handshake records not span
+  key changes.
+
+
+
+draft-14
+
+- Allow cookies to be longer (*)
+
+- Remove the "context" from EarlyDataIndication as it was undefined
+  and nobody used it (*)
+
+- Remove 0-RTT EncryptedExtensions and replace the ticket_age extension
+  with an obfuscated version. Also necessitates a change to
+  NewSessionTicket (*).
+
+- Move the downgrade sentinel to the end of ServerHello.Random
+  to accommodate tlsdate (*).
+
+- Define ecdsa_sha1 (*).
+
+- Allow resumption even after fatal alerts. This matches current
+  practice.
+
+- Remove non-closure warning alerts. Require treating unknown alerts as
+  fatal.
+
+- Make the rules for accepting 0-RTT less restrictive.
+
+- Clarify 0-RTT backward-compatibility rules.
+
+- Clarify how 0-RTT and PSK identities interact.
+
+- Add a section describing the data limits for each cipher.
+
+- Major editorial restructuring.
+
+- Replace the Security Analysis section with a WIP draft.
+
+
+draft-13
+
+- Allow server to send SupportedGroups.
+
+- Remove 0-RTT client authentication
+
+- Remove (EC)DHE 0-RTT.
+
+- Flesh out 0-RTT PSK mode and shrink EarlyDataIndication
+
+- Turn PSK-resumption response into an index to save room
+
+- Move CertificateStatus to an extension
+
+- Extra fields in NewSessionTicket.
+
+- Restructure key schedule and add a resumption_context value.
+
+- Require DH public keys and secrets to be zero-padded to the size
+  of the group.
+
+- Remove the redundant length fields in KeyShareEntry.
+
+- Define a cookie field for HRR.
+
+
+draft-12
+
+- Provide a list of the PSK cipher suites.
+
+- Remove the ability for the ServerHello to have no extensions
+  (this aligns the syntax with the text).
+
+- Clarify that the server can send application data after its first
+  flight (0.5 RTT data)
+
+- Revise signature algorithm negotiation to group hash, signature
+  algorithm, and curve together. This is backwards compatible.
+
+- Make ticket lifetime mandatory and limit it to a week.
+
+- Make the purpose strings lower-case. This matches how people
+  are implementing for interop.
+
+- Define exporters.
+
+- Editorial cleanup
+
 
 draft-11
 
@@ -343,6 +864,8 @@ draft-11
 
 - Remove early_handshake content type. Terminate 0-RTT data with
   an alert.
+
+- Reset sequence number upon key change (as proposed by Fournet et al.)
 
 
 draft-10
@@ -458,71 +981,451 @@ draft-03
 
 draft-02
 
--  Increment version number.
+- Increment version number.
 
--  Rework handshake to provide 1-RTT mode.
+- Rework handshake to provide 1-RTT mode.
 
--  Remove custom DHE groups.
+- Remove custom DHE groups.
 
--  Remove support for compression.
+- Remove support for compression.
 
--  Remove support for static RSA and DH key exchange.
+- Remove support for static RSA and DH key exchange.
 
--  Remove support for non-AEAD ciphers.
-
-
-#  Goals
-
-The goals of the TLS protocol, in order of priority, are as follows:
-
-1. Cryptographic security: TLS should be used to establish a secure connection
-between two parties.
-
-2. Interoperability: Independent programmers should be able to develop
-applications utilizing TLS that can successfully exchange cryptographic
-parameters without knowledge of one another's code.
-
-3. Extensibility: TLS seeks to provide a framework into which new public key
-and record protection methods can be incorporated as necessary. This will also
-accomplish two sub-goals\: preventing the need to create a new protocol (and
-risking the introduction of possible new weaknesses) and avoiding the need to
-implement an entire new security library.
-
-4. Relative efficiency: Cryptographic operations tend to be highly CPU
-intensive, particularly public key operations. For this reason, the TLS
-protocol has incorporated an optional session caching scheme to reduce the
-number of connections that need to be established from scratch. Additionally,
-care has been taken to reduce network activity.
+- Remove support for non-AEAD ciphers.
 
 
-#  Goals of This Document
+##  Major Differences from TLS 1.2
 
-This document and the TLS protocol itself have evolved from the SSL 3.0 Protocol
-Specification as published by Netscape. The differences between this version
-and previous versions are significant enough that the various
-versions of TLS and SSL 3.0 do not interoperate (although each protocol
-incorporates a mechanism by which an implementation can back down to prior
-versions). This document is intended primarily for readers who will be
-implementing the protocol and for those doing cryptographic analysis of it. The
-specification has been written with this in mind, and it is intended to reflect
-the needs of those two groups. For that reason, many of the algorithm-dependent
-data structures and rules are included in the body of the text (as opposed to
-in an appendix), providing easier access to them.
+The following is a list of the major functional differences between
+TLS 1.2 and TLS 1.3. It is not intended to be exhaustive and there
+are many minor differences.
 
-This document is not intended to supply any details of service definition or of
-interface definition, although it does cover select areas of policy as they are
-required for the maintenance of solid security.
+- The list of supported symmetric algorithms has been pruned of all algorithms that
+  are considered legacy. Those that remain all use Authenticated Encryption
+  with Associated Data (AEAD) algorithms. The ciphersuite concept has been
+  changed to separate the authentication and key exchange mechanisms from
+  the record protection algorithm (including secret key length) and a hash
+  to be used with the key derivation function and HMAC.
+
+- A Zero-RTT mode was added, saving a round-trip at connection setup for
+  some application data, at the cost of certain security properties.
+
+- Static RSA and Diffie-Hellman cipher suites have been removed;
+  all public-key based key exchange mechanisms now provide forward secrecy.
+
+- All handshake messages after the ServerHello are now encrypted. The
+  newly introduced EncryptedExtension message allows various extensions
+  previously sent in clear in the ServerHello to also enjoy
+  confidentiality protection.
+
+- The key derivation functions have been re-designed. The new design allows
+  easier analysis by cryptographers due to their improved key separation
+  properties. The HMAC-based Extract-and-Expand Key Derivation Function (HKDF)
+  is used as an underlying primitive.
+
+- The handshake state machine has been significantly restructured to
+  be more consistent and to remove superfluous messages such as
+  ChangeCipherSpec.
+
+- Elliptic curve algorithms are now in the base spec and includes new signature
+  algorithms, such as ed25519 and ed448. TLS 1.3 removed point format
+  negotiation in favor of a single point format for each curve.
+
+- Other cryptographic improvements including the removal of compression and
+  custom DHE groups, changing the RSA padding to use PSS, and the removal of
+  DSA.
+
+- The TLS 1.2 version negotiation mechanism has been deprecated in favor
+  of a version list in an extension. This increases compatibility with
+  servers which incorrectly implemented version negotiation.
+
+- Session resumption with and without server-side state as well as the
+  PSK-based ciphersuites of earlier TLS versions have been replaced by a
+  single new PSK exchange.
+
+- Updated references to point to the updated versions of RFCs, as
+  appropriate (e.g., RFC 5280 rather than RFC 3280).
+
+
+## Updates Affecting TLS 1.2
+
+This document defines several changes that optionally affect implementations of
+TLS 1.2:
+
+* A version downgrade protection mechanism is described in {{server-hello}}.
+
+* RSASSA-PSS signature schemes are defined in {{signature-algorithms}}.
+
+* The "supported_versions" ClientHello extension can be used to negotiate
+  the version of TLS to use, in preference to the legacy_version field of
+  the ClientHello.
+
+An implementation of TLS 1.3 that also supports TLS 1.2 might need to include
+changes to support these changes even when TLS 1.3 is not in use.  See the
+referenced sections for more details.
+
+
+# Protocol Overview
+
+The cryptographic parameters used by the secure channel are produced by the
+TLS handshake protocol. This sub-protocol of TLS is used by the client
+and server when first communicating with each other.
+The handshake protocol allows peers to negotiate a protocol version,
+select cryptographic algorithms, optionally authenticate each other,
+and establish shared secret keying material.
+Once the handshake is complete, the peers use the established keys
+to protect the application layer traffic.
+
+A failure of the handshake or other protocol error triggers the
+termination of the connection, optionally preceded by an alert message
+({{alert-protocol}}).
+
+TLS supports three basic key exchange modes:
+
+- (EC)DHE (Diffie-Hellman over either finite fields or elliptic curves)
+
+- PSK-only
+
+- PSK with (EC)DHE
+
+{{tls-full}} below shows the basic full TLS handshake:
+
+~~~
+       Client                                               Server
+
+Key  ^ ClientHello
+Exch | + key_share*
+     | + signature_algorithms*
+     | + psk_key_exchange_modes*
+     v + pre_shared_key*         -------->
+                                                       ServerHello  ^ Key
+                                                      + key_share*  | Exch
+                                                 + pre_shared_key*  v
+                                             {EncryptedExtensions}  ^  Server
+                                             {CertificateRequest*}  v  Params
+                                                    {Certificate*}  ^
+                                              {CertificateVerify*}  | Auth
+                                                        {Finished}  v
+                                 <--------     [Application Data*]
+     ^ {Certificate*}
+Auth | {CertificateVerify*}
+     v {Finished}                -------->
+       [Application Data]        <------->      [Application Data]
+
+              +  Indicates noteworthy extensions sent in the
+                 previously noted message.
+
+              *  Indicates optional or situation-dependent
+                 messages/extensions that are not always sent.
+
+              {} Indicates messages protected using keys
+                 derived from a [sender]_handshake_traffic_secret.
+
+              [] Indicates messages protected using keys
+                 derived from [sender]_application_traffic_secret_N
+~~~
+{: #tls-full title="Message flow for full TLS Handshake"}
+
+The handshake can be thought of as having three phases (indicated
+in the diagram above):
+
+- Key Exchange: Establish shared keying material and select the
+   cryptographic parameters. Everything after this phase is
+   encrypted.
+
+- Server Parameters: Establish other handshake parameters
+   (whether the client is authenticated, application layer protocol support, etc.).
+
+- Authentication: Authenticate the server (and optionally the client)
+   and provide key confirmation and handshake integrity.
+
+In the Key Exchange phase, the client sends the ClientHello
+({{client-hello}}) message, which contains a random nonce
+(ClientHello.random); its offered protocol versions; a list of
+symmetric cipher/HKDF hash pairs; either a set of Diffie-Hellman key shares (in the
+"key_share" extension {{key-share}}), a set of pre-shared key labels (in the
+"pre_shared_key" extension {{pre-shared-key-extension}}) or both; and
+potentially additional extensions.
+
+The server processes the ClientHello and determines the appropriate
+cryptographic parameters for the connection. It then responds with its
+own ServerHello ({{server-hello}}), which indicates the negotiated connection
+parameters. The combination of the ClientHello
+and the ServerHello determines the shared keys. If (EC)DHE
+key establishment is in use, then the ServerHello
+contains a "key_share" extension with the server's ephemeral
+Diffie-Hellman share which MUST be in the same group as one of the
+client's shares. If PSK key establishment is
+in use, then the ServerHello contains a "pre_shared_key"
+extension indicating which of the client's offered PSKs was selected.
+Note that implementations can use (EC)DHE and PSK together, in which
+case both extensions will be supplied.
+
+The server then sends two messages to establish the Server Parameters:
+
+EncryptedExtensions:
+: responses to ClientHello extensions that are not required to
+  determine the cryptographic parameters, other than those
+  that are specific to individual certificates. \[{{encrypted-extensions}}]
+
+CertificateRequest:
+: if certificate-based client authentication is desired, the
+  desired parameters for that certificate. This message is
+  omitted if client authentication is not desired. \[{{certificate-request}}]
+
+Finally, the client and server exchange Authentication messages. TLS
+uses the same set of messages every time that authentication is needed.
+Specifically:
+
+Certificate:
+: the certificate of the endpoint and any per-certificate extensions.
+  This message is omitted by the server if not authenticating with a
+  certificate and by the client if the server did not send
+  CertificateRequest (thus indicating that the client should not
+  authenticate with a certificate). Note that if raw
+  public keys {{RFC7250}} or the cached information extension
+  {{?RFC7924}} are in use, then this message will not
+  contain a certificate but rather some other value corresponding to
+  the server's long-term key.  \[{{certificate}}]
+
+CertificateVerify:
+: a signature over the entire handshake using the private key
+  corresponding to the public key in the Certificate message. This
+  message is omitted if the endpoint is not authenticating via a
+  certificate. \[{{certificate-verify}}]
+
+Finished:
+: a MAC (Message Authentication Code) over the entire handshake.
+  This message provides key confirmation, binds the endpoint's identity
+  to the exchanged keys, and in PSK mode
+  also authenticates the handshake. \[{{finished}}]
+{:br }
+
+Upon receiving the server's messages, the client responds with its Authentication
+messages, namely Certificate and CertificateVerify (if requested), and Finished.
+
+At this point, the handshake is complete, and the client and server
+derive the keying material required by the record layer to exchange
+application-layer data protected through authenticated encryption.
+Application data MUST NOT be sent prior to sending the Finished message and
+until the record layer starts using encryption keys.
+Note that while the server may send application data prior to receiving
+the client's Authentication messages, any data sent at that point is,
+of course, being sent to an unauthenticated peer.
+
+
+## Incorrect DHE Share
+
+If the client has not provided a sufficient "key_share" extension (e.g., it
+includes only DHE or ECDHE groups unacceptable to or unsupported by the
+server), the server corrects the mismatch with a HelloRetryRequest and
+the client needs to restart the handshake with an appropriate
+"key_share" extension, as shown in Figure 2.
+If no common cryptographic parameters can be negotiated,
+the server MUST abort the handshake with an appropriate alert.
+
+~~~
+         Client                                               Server
+
+         ClientHello
+         + key_share             -------->
+                                 <--------         HelloRetryRequest
+                                                         + key_share
+
+         ClientHello
+         + key_share             -------->
+                                                         ServerHello
+                                                         + key_share
+                                               {EncryptedExtensions}
+                                               {CertificateRequest*}
+                                                      {Certificate*}
+                                                {CertificateVerify*}
+                                                          {Finished}
+                                 <--------       [Application Data*]
+         {Certificate*}
+         {CertificateVerify*}
+         {Finished}              -------->
+         [Application Data]      <------->        [Application Data]
+~~~
+{: #tls-restart title="Message flow for a full handshake with mismatched parameters"}
+
+Note: The handshake transcript includes the initial
+ClientHello/HelloRetryRequest exchange; it is not reset with the new
+ClientHello.
+
+TLS also allows several optimized variants of the basic handshake, as
+described in the following sections.
+
+
+## Resumption and Pre-Shared Key (PSK) {#resumption-and-psk}
+
+Although TLS PSKs can be established out of band,
+PSKs can also be established in a previous connection and
+then reused ("session resumption"). Once a handshake has completed, the server can
+send to the client a PSK identity that corresponds to a unique key derived from
+the initial handshake (see {{NSTMessage}}). The client
+can then use that PSK identity in future handshakes to negotiate the use
+of the associated PSK. If the server accepts it, then the security context of the
+new connection is cryptographically tied to the original connection and the key derived
+from the initial handshake is used to bootstrap the cryptographic state
+instead of a full handshake.
+In TLS 1.2 and below, this functionality was provided by "session IDs" and
+"session tickets" {{RFC5077}}. Both mechanisms are obsoleted in TLS 1.3.
+
+PSKs can be used with (EC)DHE key exchange in order to provide forward
+secrecy in combination with shared keys, or can be used alone, at the
+cost of losing forward secrecy for the application data.
+
+{{tls-resumption-psk}} shows a pair of handshakes in which the first establishes
+a PSK and the second uses it:
+
+~~~
+       Client                                               Server
+
+Initial Handshake:
+       ClientHello
+       + key_share               -------->
+                                                       ServerHello
+                                                       + key_share
+                                             {EncryptedExtensions}
+                                             {CertificateRequest*}
+                                                    {Certificate*}
+                                              {CertificateVerify*}
+                                                        {Finished}
+                                 <--------     [Application Data*]
+       {Certificate*}
+       {CertificateVerify*}
+       {Finished}                -------->
+                                 <--------      [NewSessionTicket]
+       [Application Data]        <------->      [Application Data]
+
+
+Subsequent Handshake:
+       ClientHello
+       + key_share*
+       + psk_key_exchange_modes
+       + pre_shared_key          -------->
+                                                       ServerHello
+                                                  + pre_shared_key
+                                                      + key_share*
+                                             {EncryptedExtensions}
+                                                        {Finished}
+                                 <--------     [Application Data*]
+       {Finished}                -------->
+       [Application Data]        <------->      [Application Data]
+~~~
+{: #tls-resumption-psk title="Message flow for resumption and PSK"}
+
+As the server is authenticating via a PSK, it does not send a
+Certificate or a CertificateVerify message. When a client offers resumption
+via PSK, it SHOULD also supply a "key_share" extension to the server to
+allow the server to decline resumption and fall back
+to a full handshake, if needed. The server responds with a "pre_shared_key"
+extension to negotiate use of PSK key establishment and can (as shown here)
+respond with a "key_share" extension to do (EC)DHE key establishment, thus
+providing forward secrecy.
+
+When PSKs are provisioned out of band, the PSK identity and the KDF hash
+algorithm to
+be used with the PSK MUST also be provisioned.
+
+Note:
+: When using an out-of-band provisioned pre-shared secret, a critical
+  consideration is using sufficient entropy during the key generation, as
+  discussed in [RFC4086]. Deriving a shared secret from a password or other
+  low-entropy sources is not secure. A low-entropy secret, or password, is
+  subject to dictionary attacks based on the PSK binder.  The specified PSK
+  authentication is not a strong password-based authenticated key exchange even
+  when used with Diffie-Hellman key establishment.
+
+
+## Zero-RTT Data
+
+When clients and servers share a PSK (either obtained externally or
+via a previous handshake), TLS 1.3 allows clients to send data on the
+first flight ("early data"). The client uses the PSK to authenticate
+the server and to encrypt the early data.
+
+When clients use a PSK obtained externally to send early data, then the following
+additional information MUST be provisioned to both parties:
+
+  * The TLS version number for use with this PSK
+  * The cipher suite for use with this PSK
+  * The Application-Layer Protocol Negotiation (ALPN) protocol {{!RFC7301}}, if
+    any is to be used
+  * The Server Name Indication (SNI), if any is to be used
+
+As shown in {{tls-0-rtt}}, the 0-RTT data is just added to the 1-RTT
+handshake in the first flight. The rest of the handshake uses the same messages
+as with a 1-RTT handshake with PSK resumption.
+
+~~~
+         Client                                               Server
+
+         ClientHello
+         + early_data
+         + key_share*
+         + psk_key_exchange_modes
+         + pre_shared_key
+         (Application Data*)     -------->
+                                                         ServerHello
+                                                    + pre_shared_key
+                                                        + key_share*
+                                               {EncryptedExtensions}
+                                                       + early_data*
+                                                          {Finished}
+                                 <--------       [Application Data*]
+         (EndOfEarlyData)
+         {Finished}              -------->
+
+         [Application Data]      <------->        [Application Data]
+
+               +  Indicates noteworthy extensions sent in the
+                  previously noted message.
+
+               *  Indicates optional or situation-dependent
+                  messages/extensions that are not always sent.
+
+               () Indicates messages protected using keys
+                  derived from client_early_traffic_secret.
+
+               {} Indicates messages protected using keys
+                  derived from a [sender]_handshake_traffic_secret.
+
+               [] Indicates messages protected using keys
+                  derived from [sender]_application_traffic_secret_N
+~~~
+{: #tls-0-rtt title="Message flow for a zero round trip handshake"}
+
+
+IMPORTANT NOTE: The security properties for 0-RTT data are weaker than
+those for other kinds of TLS data.  Specifically:
+
+1. This data is not forward secret, as it is encrypted solely under
+keys derived using the offered PSK.
+
+2. There are no guarantees of non-replay between connections.
+Protection against replay for ordinary TLS 1.3 1-RTT data is
+provided via the server's Random value, but 0-RTT data does not depend
+on the ServerHello and therefore has weaker guarantees.  This is especially
+relevant if the data is authenticated either with TLS client
+authentication or inside the application protocol. The same warnings
+apply to any use of the early_exporter_master_secret.
+
+0-RTT data cannot be duplicated within a connection (i.e., the server will
+not process the same data twice for the same connection) and an
+attacker will not be able to make 0-RTT data appear to be 1-RTT data
+(because it is protected with different keys.) {{replay-0rtt}}
+contains a description of potential attacks and {{anti-replay}}
+describes mechanisms which the server can use to limit the impact of
+replay.
 
 
 #  Presentation Language
 
 This document deals with the formatting of data in an external representation.
 The following very basic and somewhat casually defined presentation syntax will
-be used. The syntax draws from several sources in its structure. Although it
-resembles the programming language "C" in its syntax and XDR {{RFC4506}} in
-both its syntax and intent, it would be risky to draw too many parallels. The
-purpose of this presentation language is to document TLS only; it has no
-general application beyond that particular goal.
+be used.
 
 
 ##  Basic Block Size
@@ -557,7 +1460,7 @@ A vector (single-dimensioned array) is a stream of homogeneous data elements.
 The size of the vector may be specified at documentation time or left
 unspecified until runtime. In either case, the length declares the number of
 bytes, not the number of elements, in the vector. The syntax for specifying a
-new type, T', that is a fixed- length vector of type T is
+new type, T', that is a fixed-length vector of type T is
 
        T T'[n];
 
@@ -569,7 +1472,7 @@ the protocol does not interpret, while Data is three consecutive Datum,
 consuming a total of nine bytes.
 
        opaque Datum[3];      /* three uninterpreted bytes */
-       Datum Data[9];        /* 3 consecutive 3 byte vectors */
+       Datum Data[9];        /* 3 consecutive 3-byte vectors */
 
 Variable-length vectors are defined by specifying a subrange of legal lengths,
 inclusively, using the notation \<floor..ceiling\>. When these are encoded, the
@@ -583,10 +1486,10 @@ actual length field of zero is referred to as an empty vector.
 In the following example, mandatory is a vector that must contain between 300
 and 400 bytes of type opaque. It can never be empty. The actual length field
 consumes two bytes, a uint16, which is sufficient to represent the value 400
-(see {{numbers}}). On the other hand, longer can represent up to 800 bytes of
+(see {{numbers}}). Similarly, longer can represent up to 800 bytes of
 data, or 400 uint16 elements, and it may be empty. Its encoding will include a
 two-byte actual length field prepended to the vector. The length of an encoded
-vector must be an even multiple of the length of a single element (for example,
+vector must be an exact multiple of the length of a single element (e.g.,
 a 17-byte vector of uint16 would be illegal).
 
        opaque mandatory<300..400>;
@@ -611,22 +1514,20 @@ All values, here and elsewhere in the specification, are stored in network byte
 (big-endian) order; the uint32 represented by the hex bytes 01 02 03 04 is
 equivalent to the decimal value 16909060.
 
-Note that in some cases (e.g., DH parameters) it is necessary to represent
-integers as opaque vectors. In such cases, they are represented as unsigned
-integers (i.e., leading zero octets are not required even if the most
-significant bit is set).
-
 
 ##  Enumerateds
 
-An additional sparse data type is available called enum. A field of type enum
-can only assume the values declared in the definition. Each definition is a
+An additional sparse data type is available called enum. Each definition is a
 different type. Only enumerateds of the same type may be assigned or compared.
 Every element of an enumerated must be assigned a value, as demonstrated in the
 following example. Since the elements of the enumerated are not ordered, they
 can be assigned any unique value, in any order.
 
        enum { e1(v1), e2(v2), ... , en(vn) [[, (n)]] } Te;
+
+Future extensions or additions to the protocol may define new values.
+Implementations need to be able to parse and ignore unknown values unless the
+definition of the field states otherwise.
 
 An enumerated occupies as much space in the byte stream as would its maximal
 defined ordinal value. The following definition would cause one byte to be used
@@ -638,7 +1539,7 @@ One may optionally specify a value without its associated tag to force the
 width definition without defining a superfluous element.
 
 In the following example, Taste will consume two bytes in the data stream but
-can only assume the values 1, 2, or 4.
+can only assume the values 1, 2, or 4 in the current version of the protocol.
 
        enum { sweet(1), sour(2), bitter(4), (32000) } Taste;
 
@@ -650,10 +1551,12 @@ target of the assignment is well specified.
        Color color = Color.blue;     /* overspecified, legal */
        Color color = blue;           /* correct, type implicit */
 
-For enumerateds that are never converted to external representation, the
-numerical information may be omitted.
+The names assigned to enumerateds do not need to be unique.  The numerical value
+can describe a range over which the same name applies.  The value includes the
+minimum and maximum inclusive values in that range, separated by two period
+characters. This is principally useful for reserving regions of the space.
 
-       enum { low, medium, high } Amount;
+       enum { sad(0), meh(1..254), happy(255) } Mood;
 
 
 ##  Constructed Types
@@ -672,40 +1575,44 @@ like that of C.
 The fields within a structure may be qualified using the type's name, with a
 syntax much like that available for enumerateds. For example, T.f2 refers to
 the second field of the previous declaration. Structure definitions may be
-embedded.
+embedded. Anonymous structs may also be defined inside other structures.
 
-###  Variants
 
-Defined structures may have variants based on some knowledge that is available
-within the environment. The selector must be an enumerated type that defines
-the possible variants the structure defines. There must be a case arm for every
-element of the enumeration declared in the select. Case arms have limited
-fall-through: if two case arms follow in immediate succession with no fields in
-between, then they both contain the same fields. Thus, in the example below,
-"orange" and "banana" both contain V2. Note that this is a new piece of syntax
-in TLS 1.2.
+## Constants
 
-The body of the variant structure may be given a label for reference. The
-mechanism by which the variant is selected at runtime is not prescribed by the
-presentation language.
+Fields and variables may be assigned a fixed value using "=", as in:
+
+       struct {
+           T1 f1 = 8;  /* T.f1 must always be 8 */
+           T2 f2;
+       } T;
+
+
+##  Variants
+
+Defined structures may have variants based on some knowledge that is
+available within the environment. The selector must be an enumerated
+type that defines the possible variants the structure defines.
+The body of the variant structure may be given a label
+for reference. The mechanism by which the variant is selected at
+runtime is not prescribed by the presentation language.
 
        struct {
            T1 f1;
            T2 f2;
            ....
            Tn fn;
-            select (E) {
-                case e1: Te1;
-                case e2: Te2;
-                case e3: case e4: Te3;
-                ....
-                case en: Ten;
-            } [[fv]];
+           select (E) {
+               case e1: Te1;
+               case e2: Te2;
+               ....
+               case en: Ten;
+           } [[fv]];
        } [[Tv]];
 
 For example:
 
-       enum { apple, orange, banana } VariantTag;
+       enum { apple(0), orange(1) } VariantTag;
 
        struct {
            uint16 number;
@@ -718,307 +1625,2227 @@ For example:
        } V2;
 
        struct {
-           select (VariantTag) { /* value of selector is implicit */
-               case apple:
-                 V1;   /* VariantBody, tag = apple */
-               case orange:
-               case banana:
-                 V2;   /* VariantBody, tag = orange or banana */
-           } variant_body;       /* optional label on variant */
+           VariantTag type;
+           select (VariantRecord.type) {
+               case apple:  V1;
+               case orange: V2;
+           };
        } VariantRecord;
 
 
-##  Constants
+# Handshake Protocol
 
-Typed constants can be defined for purposes of specification by declaring a
-symbol of the desired type and assigning values to it.
+The handshake protocol is used to negotiate the security parameters
+of a connection. Handshake messages are supplied to the TLS record layer, where
+they are encapsulated within one or more TLSPlaintext or TLSCiphertext structures, which are
+processed and transmitted as specified by the current active connection state.
 
-Under-specified types (opaque, variable-length vectors, and structures that
-contain opaque) cannot be assigned values. No fields of a multi-element
-structure or vector may be elided.
+%%% Handshake Protocol
 
-For example:
-
-       struct {
-           uint8 f1;
-           uint8 f2;
-       } Example1;
-
-       Example1 ex1 = {1, 4};  /* assigns f1 = 1, f2 = 4 */
-
-##  Cryptographic Attributes
-
-The two cryptographic operations --- digital signing, and authenticated
-encryption with additional data (AEAD) --- are designated digitally-signed,
-and aead-ciphered, respectively. A field's cryptographic processing
-is specified by prepending an appropriate key word designation before
-the field's type specification.  Cryptographic keys are implied by the
-current session state (see {{connection-states}}).
-
-### Digital Signing
-
-A digitally-signed element is encoded as a struct DigitallySigned:
-
-       struct {
-          SignatureAndHashAlgorithm algorithm;
-          opaque signature<0..2^16-1>;
-       } DigitallySigned;
-
-The algorithm field specifies the algorithm used (see {{signature-algorithms}}
-for the definition of this field). Note that the algorithm
-field was introduced in TLS 1.2, and is not in earlier versions. The signature is a digital signature
-using those algorithms over the contents of the element. The contents
-themselves do not appear on the wire but are simply calculated. The length of
-the signature is specified by the signing algorithm and key.
-
-In previous versions of TLS, the ServerKeyExchange format meant that attackers
-can obtain a signature of a message with a chosen, 32-byte prefix. Because TLS
-1.3 servers are likely to also implement prior versions, the contents of the
-element always start with 64 bytes of octet 32 in order to clear that
-chosen-prefix.
-
-Following that padding is a NUL-terminated context string in order to
-disambiguate signatures for different purposes. The context string will be
-specified whenever a digitally-signed element is used.
-
-Finally, the specified contents of the digitally-signed structure follow the
-NUL at the end of the context string. (See the example at the end of this
-section.)
-
-In RSA signing, the opaque vector contains the signature generated
-using the RSASSA-PSS signature scheme defined in {{RFC3447}} with
-MGF1. The digest used in the mask generation function MUST be the same
-as the digest which is being signed (i.e., what appears in
-algorithm.signature). The length of the salt MUST be equal to the length
-of the digest output. Note that previous versions of TLS used RSASSA-PKCS1-v1_5,
-not RSASSA-PSS.
-
-All ECDSA computations MUST be performed according to ANSI X9.62 {{X962}}
-or its successors.  Data to be signed/verified is hashed, and the
-result run directly through the ECDSA algorithm with no additional
-hashing.  The SignatureAndHashAlgorithm parameter in the DigitallySigned
-object indicates the digest algorithm which was used in the signature.
-Signature-only curves MUST NOT be used for ECDSA unless otherwise noted.
-
-All EdDSA computations MUST be performed according to {{I-D.irtf-cfrg-eddsa}}
-or its successors. Data to be signed/verified is passed as-is to the EdDSA
-algorithm with no hashing. The signature output is placed as-is in the
-signature field. The SignatureAndHashAlgorithm.hash value MUST set to none(0).
-
-In the following example
+       enum {
+           hello_request_RESERVED(0),
+           client_hello(1),
+           server_hello(2),
+           hello_verify_request_RESERVED(3),
+           new_session_ticket(4),
+           end_of_early_data(5),
+           hello_retry_request(6),
+           encrypted_extensions(8),
+           certificate(11),
+           server_key_exchange_RESERVED(12),
+           certificate_request(13),
+           server_hello_done_RESERVED(14),
+           certificate_verify(15),
+           client_key_exchange_RESERVED(16),
+           finished(20),
+           key_update(24),
+           message_hash(254),
+           (255)
+       } HandshakeType;
 
        struct {
-           uint8 field1;
-           uint8 field2;
-           digitally-signed opaque {
-             uint8 field3<0..255>;
-             uint8 field4;
-           };
-       } UserType;
+           HandshakeType msg_type;    /* handshake type */
+           uint24 length;             /* bytes in message */
+           select (Handshake.msg_type) {
+               case client_hello:          ClientHello;
+               case server_hello:          ServerHello;
+               case end_of_early_data:     EndOfEarlyData;
+               case hello_retry_request:   HelloRetryRequest;
+               case encrypted_extensions:  EncryptedExtensions;
+               case certificate_request:   CertificateRequest;
+               case certificate:           Certificate;
+               case certificate_verify:    CertificateVerify;
+               case finished:              Finished;
+               case new_session_ticket:    NewSessionTicket;
+               case key_update:            KeyUpdate;
+           } body;
+       } Handshake;
 
-Assume that the context string for the signature was specified as "Example".
-The input for the signature/hash algorithm would be:
+Protocol messages MUST be sent in the order defined in
+{{the-transcript-hash}} and shown in the diagrams in {{protocol-overview}}.
+A peer which receives a handshake message in an unexpected order
+MUST abort the handshake with an "unexpected_message" alert.
 
-       2020202020202020202020202020202020202020202020202020202020202020
-       2020202020202020202020202020202020202020202020202020202020202020
-       4578616d706c6500
-
-followed by the encoding of the inner struct (field3 and field4).
-
-The length of the structure, in bytes, would be equal to two
-bytes for field1 and field2, plus two bytes for the signature and hash
-algorithm, plus two bytes for the length of the signature, plus the length of
-the output of the signing algorithm. The length of the signature is known
-because the algorithm and key used for the signing are known prior to encoding
-or decoding this structure.
-
-
-### Authenticated Encryption with Additional Data (AEAD)
-
-In AEAD encryption, the plaintext is simultaneously encrypted and integrity
-protected. The input may be of any length, and aead-ciphered output is
-generally larger than the input in order to accommodate the integrity check
-value.
+New handshake message types are assigned by IANA as described in
+{{iana-considerations}}.
 
 
-#  The TLS Record Protocol
+## Key Exchange Messages
 
-The TLS Record Protocol is a layered protocol. At each layer, messages
-may include fields for length, description, and content.  The TLS Record
-Protocol takes messages to be transmitted, fragments the data into
-manageable blocks, protects the records, and transmits the
-result. Received data is decrypted and verified, reassembled, and then
-delivered to higher-level clients.
+The key exchange messages are used to determine the security capabilities
+of the client and the server and to establish shared secrets including
+the traffic keys used to protect the rest of the handshake and the data.
 
-Three protocols that use the TLS Record Protocol are described in this document: the TLS
-Handshake Protocol, the Alert Protocol, and
-the application data protocol. In order to allow extension of the TLS protocol,
-additional record content types can be supported by the TLS Record Protocol. New
-record content type values are assigned by IANA in the TLS Content Type
-Registry as described in {{iana-considerations}}.
+### Cryptographic Negotiation
 
-Implementations MUST NOT send record types not defined in this document unless
-negotiated by some extension. If a TLS implementation receives an unexpected
-record type, it MUST send an "unexpected_message" alert.
+In TLS, the cryptographic negotiation proceeds by the client offering the
+following four sets of options in its ClientHello:
 
-Any protocol designed for use over TLS must be carefully designed to deal with
-all possible attacks against it. As a practical matter, this means that the
-protocol designer must be aware of what security properties TLS does and does
-not provide and cannot safely rely on the latter.
+- A list of cipher suites which indicates the AEAD algorithm/HKDF hash
+  pairs which the client supports.
+- A "supported_groups" ({{negotiated-groups}}) extension which indicates the (EC)DHE groups
+  which the client supports and a "key_share" ({{key-share}}) extension which contains
+  (EC)DHE shares for some or all of these groups.
+- A "signature_algorithms" ({{signature-algorithms}}) extension which indicates the signature
+  algorithms which the client can accept.
+- A "pre_shared_key" ({{pre-shared-key-extension}}) extension which
+  contains a list of symmetric key identities known to the client and a
+  "psk_key_exchange_modes" ({{pre-shared-key-exchange-modes}})
+  extension which indicates the key exchange modes that may be used
+  with PSKs.
 
-Note in particular that the length of a record or absence of traffic
-itself is not protected by encryption unless the sender uses the
-supplied padding mechanism -- see {{record-padding}} for more details.
+If the server does not select a PSK, then the first three of these
+options are entirely orthogonal: the server independently selects a
+cipher suite, an (EC)DHE group and key share for key establishment,
+and a signature algorithm/certificate pair to authenticate itself to
+the client. If there is no overlap between the received "supported_groups"
+and the groups supported by the server then the server MUST abort the
+handshake with a "handshake_failure" or an "insufficient_security" alert.
 
+If the server selects a PSK, then it MUST also select a key
+establishment mode from the set indicated by client's
+"psk_key_exchange_modes" extension (at present, PSK alone or with (EC)DHE). Note
+that if the PSK can be used without (EC)DHE then non-overlap in the
+"supported_groups" parameters need not be fatal, as it is in the
+non-PSK case discussed in the previous paragraph.
 
-##  Connection States
+If the server selects an (EC)DHE group and the client did not offer a
+compatible "key_share" extension in the initial ClientHello, the server MUST
+respond with a HelloRetryRequest ({{hello-retry-request}}) message.
 
-[[TODO: I plan to totally rewrite or remove this. IT seems like just cruft.]]
+If the server successfully selects parameters and does not require a
+HelloRetryRequest, it indicates the selected parameters in the ServerHello as
+follows:
 
-A TLS connection state is the operating environment of the TLS Record
-Protocol.  It specifies a record protection algorithm and its
-parameters as well as the record protection keys and IVs for the
-connection in both the read and the write directions. The security
-parameters are set by the TLS Handshake Protocol, which also determines
-when new cryptographic keys are installed and used for record
-protection.
-The initial current state always specifies that records are
-not protected.
+- If PSK is being used, then the server will send a
+  "pre_shared_key" extension indicating the selected key.
 
-The security parameters for a TLS Connection read and write state are set by
-providing the following values:
+- If PSK is not being used, then (EC)DHE and certificate-based
+  authentication are always used.
 
-{:br: vspace="0"}
+- When (EC)DHE is in use, the server will also provide a
+  "key_share" extension.
 
-connection end
+- When authenticating via a certificate, the server will send
+  the Certificate ({{certificate}}) and CertificateVerify
+  ({{certificate-verify}}) messages. In TLS 1.3
+  as defined by this document, either a PSK or a certificate
+  is always used, but not both. Future documents may define how
+  to use them together.
 
-: Whether this entity is considered the "client" or the "server" in
-  this connection.
+If the server is unable to negotiate a supported set of parameters
+(i.e., there is no overlap between the client and server parameters),
+it MUST abort the handshake with either
+a "handshake_failure" or "insufficient_security" fatal alert
+(see {{alert-protocol}}).
 
-Hash algorithm
+###  Client Hello
 
-: An algorithm used to generate keys from the appropriate secret (see
-  {{key-schedule}} and {{traffic-key-calculation}}).
+When a client first connects to a server, it is REQUIRED to send the
+ClientHello as its first message. The client will also send a
+ClientHello when the server has responded to its ClientHello with a
+HelloRetryRequest. In that case, the client MUST send the same
+ClientHello (without modification) except:
 
-record protection algorithm
+- If a "key_share" extension was supplied in the HelloRetryRequest,
+  replacing the list of shares with a list containing a single
+  KeyShareEntry from the indicated group.
 
-: The algorithm to be used for record protection. This algorithm must
-  be of the AEAD type and thus provides integrity and confidentiality
-  as a single primitive. This specification
-  includes the key size of this algorithm and of the nonce for
-  the AEAD algorithm.
+- Removing the "early_data" extension ({{early-data-indication}}) if one was
+  present. Early data is not permitted after HelloRetryRequest.
 
-master secret
+- Including a "cookie" extension if one was provided in the
+  HelloRetryRequest.
 
-: A 48-byte secret shared between the two peers in the connection
-  and used to generate keys for protecting data.
+- Updating the "pre_shared_key" extension if present by
+  recomputing the "obfuscated_ticket_age" and binder values
+  and (optionally) removing
+  any PSKs which are incompatible with the server's indicated
+  cipher suite.
 
+Because TLS 1.3 forbids renegotiation, if a server has negotiated TLS
+1.3 and receives a ClientHello at any other time, it MUST terminate
+the connection with an "unexpected_message" alert.
 
-client random
+If a server established a TLS connection with a previous version of TLS
+and receives a TLS 1.3 ClientHello in a renegotiation, it MUST retain the
+previous protocol version. In particular, it MUST NOT negotiate TLS 1.3.
 
-: A 32-byte value provided by the client.
+Structure of this message:
 
-server random
+%%% Key Exchange Messages
 
-: A 32-byte value provided by the server.
-{: br}
+       uint16 ProtocolVersion;
+       opaque Random[32];
 
-These parameters are defined in the presentation language as:
-
-%%% Security Parameters
-       enum { server, client } ConnectionEnd;
-
-       enum { tls_kdf_sha256, tls_kdf_sha384 } KDFAlgorithm;
-
-       enum { aes_gcm } RecordProtAlgorithm;
-
-       /* The algorithms specified in KDFAlgorithm and
-          RecordProtAlgorithm may be added to. */
+       uint8 CipherSuite[2];    /* Cryptographic suite selector */
 
        struct {
-           ConnectionEnd          entity;
-           KDFAlgorithm           kdf_algorithm;
-           RecordProtAlgorithm    record_prot_algorithm;
-           uint8                  enc_key_length;
-           uint8                  iv_length;
-           opaque                 hs_master_secret[48];
-           opaque                 master_secret[48];
-           opaque                 client_random[32];
-           opaque                 server_random[32];
-       } SecurityParameters;
+           ProtocolVersion legacy_version = 0x0303;    /* TLS v1.2 */
+           Random random;
+           opaque legacy_session_id<0..32>;
+           CipherSuite cipher_suites<2..2^16-2>;
+           opaque legacy_compression_methods<1..2^8-1>;
+           Extension extensions<8..2^16-1>;
+       } ClientHello;
 
-[TODO: update this to handle new key hierarchy.]
+legacy_version
+: In previous versions of TLS, this field was used for version negotiation
+  and represented the highest version number supported by the client.
+  Experience has shown that many servers do not properly implement
+  version negotiation, leading to "version intolerance" in which
+  the server rejects an otherwise acceptable ClientHello with a version
+  number higher than it supports.
+  In TLS 1.3, the client indicates its version preferences in the
+  "supported_versions" extension ({{supported-versions}}) and the legacy_version field MUST
+  be set to 0x0303, which is the version number for TLS 1.2.
+  (See {{backward-compatibility}} for details about backward compatibility.)
 
-The connection state will use the security parameters to generate the following four
-items:
+random
+: 32 bytes generated by a secure random number generator.
+  See {{implementation-notes}} for additional information.
 
-       client write key
-       server write key
-       client write iv
-       server write iv
+legacy_session_id
+: Versions of TLS before TLS 1.3 supported a "session resumption"
+  feature which has been merged with Pre-Shared Keys in this version
+  (see {{resumption-and-psk}}).
+  This field MUST be ignored by a server negotiating TLS 1.3 and
+  MUST be set as a zero length vector (i.e., a single zero byte
+  length field) by clients that do not have a cached session ID
+  set by a pre-TLS 1.3 server.
 
-The client write parameters are used by the server when receiving and
-processing records and vice versa. The algorithm used for generating these
-items from the security parameters is described in {{traffic-key-calculation}}.
+cipher_suites
+: This is a list of the symmetric cipher options supported by the
+  client, specifically the record protection algorithm (including
+  secret key length) and a hash to be used with HKDF, in descending
+  order of client preference. If the list contains cipher suites that
+  the server does not recognize, support or wish to use, the server
+  MUST ignore those cipher suites and process the remaining ones as
+  usual. Values are defined in {{cipher-suites}}. If the client is
+  attempting a PSK key establishment, it SHOULD advertise at least one
+  cipher suite indicating a Hash associated with the PSK.
 
-Once the security parameters have been set and the keys have been generated,
-the connection states can be instantiated by making them the current states.
-These current states MUST be updated for each record processed. Each connection
-state includes the following elements:
+legacy_compression_methods
+: Versions of TLS before 1.3 supported compression with the list of
+  supported compression methods being sent in this field. For every TLS 1.3
+  ClientHello, this vector MUST contain exactly one byte set to
+  zero, which corresponds to the "null" compression method in
+  prior versions of TLS. If a TLS 1.3 ClientHello is
+  received with any other value in this field, the server MUST
+  abort the handshake with an "illegal_parameter" alert. Note that TLS 1.3
+  servers might receive TLS 1.2 or prior ClientHellos which contain
+  other compression methods and MUST follow the procedures for
+  the appropriate prior version of TLS.  TLS 1.3 ClientHellos are identified
+  as having a legacy_version of 0x0303 and a supported_versions extension
+  present with 0x0304 as the highest version indicated therein.
 
-cipher state
-: The current state of the encryption algorithm.  This will consist
-  of the scheduled key for that connection.
+extensions
+: Clients request extended functionality from servers by sending
+  data in the extensions field.  The actual "Extension" format is
+  defined in {{extensions}}.  In TLS 1.3, use
+  of certain extensions is mandatory, as functionality is moved into
+  extensions to preserve ClientHello compatibility with previous versions of TLS.
+  Servers MUST ignore unrecognized extensions.
+{:br }
 
-sequence number
-: Each connection state contains a sequence number, which is
-  maintained separately for read and write states.  The sequence
-  number is set to zero at the beginning of a connection, and whenever
-  the key is changed.
+All versions of TLS allow an extensions field to optionally follow the
+compression_methods field. TLS 1.3 ClientHello
+messages always contain extensions (minimally "supported_versions", otherwise
+they will be interpreted as TLS 1.2 ClientHello messages).
+However, TLS 1.3 servers might receive ClientHello messages without an
+extensions field from prior versions of TLS.
+The presence of extensions can be detected by determining whether there
+are bytes following the compression_methods field at the end of the
+ClientHello. Note that this method of detecting optional data differs
+from the normal TLS method of having a variable-length field, but it
+is used for compatibility with TLS before extensions were defined.
+TLS 1.3 servers will need to perform this check first and only
+attempt to negotiate TLS 1.3 if a "supported_version" extension
+is present.
+If negotiating a version of TLS prior to 1.3, a server MUST check that
+the message either contains no data after legacy_compression_methods
+or that it contains a valid extensions block with no data following.
+If not, then it MUST abort the handshake with a "decode_error" alert.
 
-  The sequence number is incremented after each record: specifically,
-  the first record transmitted under a particular connection state and
-  record key MUST use sequence number 0.
-  
-  Sequence numbers are of type uint64 and MUST NOT exceed 2^64-1.
-  Sequence numbers do not wrap.  If a TLS implementation would need to
-  wrap a sequence number, it MUST either rekey ({{key-update}}) or
-  terminate the connection.
+In the event that a client requests additional functionality using
+extensions, and this functionality is not supplied by the server, the
+client MAY abort the handshake.
+
+After sending the ClientHello message, the client waits for a ServerHello
+or HelloRetryRequest message. If early data
+is in use, the client may transmit early application data
+{{zero-rtt-data}} while waiting for the next handshake message.
+
+### Server Hello {#server-hello}
+
+The server will send this message in response to a ClientHello message
+to proceed with the handshake if it is able to negotiate an acceptable
+set of handshake parameters based on the ClientHello.
+
+Structure of this message:
+
+%%% Key Exchange Messages
+
+       struct {
+           ProtocolVersion version;
+           Random random;
+           CipherSuite cipher_suite;
+           Extension extensions<6..2^16-1>;
+       } ServerHello;
+
+version
+: This field contains the version of TLS negotiated for this connection.  Servers
+  MUST select a version from the list in ClientHello's supported_versions extension,
+  or otherwise negotiate TLS 1.2 or previous.
+  A client that receives a version that was not offered MUST abort the handshake.
+  For this version of the specification, the version is 0x0304.  (See
+  {{backward-compatibility}} for details about backward compatibility.)
+
+random
+: 32 bytes generated by a secure random number generator.
+  See {{implementation-notes}} for additional information.
+  The last eight bytes MUST be overwritten as described
+  below if negotiating TLS 1.2 or TLS 1.1, but the
+  remaining bytes MUST be random.
+  This structure is generated by the server and MUST be
+  generated independently of the ClientHello.random.
+
+cipher_suite
+: The single cipher suite selected by the server from the list in
+  ClientHello.cipher_suites. A client which receives a cipher suite
+  that was not offered MUST abort the handshake with an "illegal_parameter"
+  alert.
+
+extensions
+: A list of extensions.  The ServerHello MUST only include extensions
+  which are required to establish the cryptographic context. Currently
+  the only such extensions are "key_share" and "pre_shared_key".
+  All current TLS 1.3 ServerHello messages will contain one of these
+  two extensions, or both when using a PSK with (EC)DHE key establishment.
+  The remaining extensions are sent separately in the EncryptedExtensions
+  message.
+{:br }
+
+TLS 1.3 has a downgrade protection mechanism embedded in the server's
+random value. TLS 1.3 servers which negotiate TLS 1.2 or below in
+response to a ClientHello MUST set the last eight bytes of their
+Random value specially.
+
+If negotiating TLS 1.2, TLS 1.3 servers MUST set the last eight bytes of their
+Random value to the bytes:
+
+      44 4F 57 4E 47 52 44 01
+
+If negotiating TLS 1.1 or below, TLS 1.3 servers MUST and TLS 1.2
+servers SHOULD set the last eight bytes of their Random value to the
+bytes:
+
+      44 4F 57 4E 47 52 44 00
+
+
+TLS 1.3 clients receiving a ServerHello indicating TLS 1.2 or below
+MUST check that the last eight bytes are not equal to either of these values.
+TLS 1.2 clients SHOULD also check that the last eight bytes are not
+equal to the second value if the ServerHello indicates TLS 1.1 or
+below.  If a match is found, the client MUST abort the handshake
+with an "illegal_parameter" alert.  This mechanism provides limited
+protection against downgrade attacks over and above what is provided
+by the Finished exchange: because the ServerKeyExchange, a message
+present in TLS 1.2 and below, includes a signature over both random
+values, it is not possible for an active attacker to modify the
+random values without detection as long as ephemeral ciphers are used.
+It does not provide downgrade protection when static RSA is used.
+
+Note: This is a change from {{RFC5246}}, so in practice many TLS 1.2 clients
+and servers will not behave as specified above.
+
+A legacy TLS client performing renegotiation with TLS 1.2 or prior
+and which receives a TLS 1.3 ServerHello during renegotiation
+MUST abort the handshake with a "protocol_version" alert.
+Note that renegotiation is not possible when TLS 1.3 has been
+negotiated.
+
+RFC EDITOR: PLEASE REMOVE THE FOLLOWING PARAGRAPH
+Implementations of draft versions (see {{draft-version-indicator}}) of this
+specification SHOULD NOT implement this mechanism on either client and server.
+A pre-RFC client connecting to RFC servers, or vice versa, will appear to
+downgrade to TLS 1.2. With the mechanism enabled, this will cause an
+interoperability failure.
+
+###  Hello Retry Request
+
+The server will send this message in response to a ClientHello message if it is
+able to find an acceptable set of parameters but the ClientHello does not
+contain sufficient information to proceed with the handshake.
+
+Structure of this message:
+
+%%% Key Exchange Messages
+
+       struct {
+           ProtocolVersion server_version;
+           CipherSuite cipher_suite;
+           Extension extensions<2..2^16-1>;
+       } HelloRetryRequest;
+
+{:br }
+
+The version, cipher_suite, and extensions fields have the
+same meanings as their corresponding values in the ServerHello.
+The server SHOULD send only the extensions necessary for the client to
+generate a correct ClientHello pair. As with ServerHello, a
+HelloRetryRequest MUST NOT contain any extensions that were not first
+offered by the client in its ClientHello, with the exception of optionally the
+"cookie" (see {{cookie}}) extension.
+
+Upon receipt of a HelloRetryRequest, the client MUST verify that the
+extensions block is not empty and otherwise MUST abort the handshake
+with a "decode_error" alert. Clients MUST abort the handshake with
+an "illegal_parameter" alert if the HelloRetryRequest would not result in
+any change in the ClientHello. If a client receives a second
+HelloRetryRequest in the same connection (i.e., where
+the ClientHello was itself in response to a HelloRetryRequest), it
+MUST abort the handshake with an "unexpected_message" alert.
+
+Otherwise, the client MUST process all extensions in the HelloRetryRequest and
+send a second updated ClientHello. The HelloRetryRequest extensions defined in
+this specification are:
+
+- cookie (see {{cookie}})
+
+- key_share (see {{key-share}})
+
+In addition, in its updated ClientHello, the client SHOULD NOT offer
+any pre-shared keys associated with a hash other than that of the
+selected cipher suite. This allows the client to avoid having to
+compute partial hash transcripts for multiple hashes in the second
+ClientHello.  A client which receives a cipher suite that was not
+offered MUST abort the handshake.  Servers MUST ensure that they
+negotiate the same cipher suite when receiving a conformant updated
+ClientHello (if the server selects the cipher suite as the first step
+in the negotiation, then this will happen automatically). Upon
+receiving the ServerHello, clients MUST check that the cipher suite
+supplied in the ServerHello is the same as that in the
+HelloRetryRequest and otherwise abort the handshake with an
+"illegal_parameter" alert.
+
+
+##  Extensions
+
+A number of TLS messages contain tag-length-value encoded extensions structures.
+
+%%% Key Exchange Messages
+
+       struct {
+           ExtensionType extension_type;
+           opaque extension_data<0..2^16-1>;
+       } Extension;
+
+       enum {
+           server_name(0),                             /* RFC 6066 */
+           max_fragment_length(1),                     /* RFC 6066 */
+           status_request(5),                          /* RFC 6066 */
+           supported_groups(10),                       /* RFC 4492, 7919 */
+           signature_algorithms(13),                   /* RFC 5246 */
+           use_srtp(14),                               /* RFC 5764 */
+           heartbeat(15),                              /* RFC 6520 */
+           application_layer_protocol_negotiation(16), /* RFC 7301 */
+           signed_certificate_timestamp(18),           /* RFC 6962 */
+           client_certificate_type(19),                /* RFC 7250 */
+           server_certificate_type(20),                /* RFC 7250 */
+           padding(21),                                /* RFC 7685 */
+           key_share(40),                              /* [[this document]] */
+           pre_shared_key(41),                         /* [[this document]] */
+           early_data(42),                             /* [[this document]] */
+           supported_versions(43),                     /* [[this document]] */
+           cookie(44),                                 /* [[this document]] */
+           psk_key_exchange_modes(45),                 /* [[this document]] */
+           certificate_authorities(47),                /* [[this document]] */
+           oid_filters(48),                            /* [[this document]] */
+           post_handshake_auth(49),                    /* [[this document]] */
+           (65535)
+       } ExtensionType;
+
+Here:
+
+- "extension_type" identifies the particular extension type.
+
+- "extension_data" contains information specific to the particular
+  extension type.
+
+The list of extension types is maintained by IANA as described in
+{{iana-considerations}}.
+
+Extensions are generally structured in a request/response fashion, though
+some extensions are just indications with no corresponding response. The client
+sends its extension requests in the ClientHello message and the server sends
+its extension responses in the ServerHello, EncryptedExtensions,
+HelloRetryRequest and Certificate messages. The server sends extension requests
+in the CertificateRequest message which a client MAY respond to with
+a Certificate message. The server MAY also send unsolicited
+extensions in the NewSessionTicket, though the client does not respond
+directly to these.
+
+Implementations MUST NOT send extension responses
+if the remote endpoint did not send the corresponding extension requests,
+with the exception of the "cookie" extension in HelloRetryRequest.
+Upon receiving such an extension, an endpoint MUST abort the handshake with an
+"unsupported_extension" alert.
+
+The table below indicates the messages where a given extension may
+appear, using the following notation: CH (ClientHello), SH
+(ServerHello), EE (EncryptedExtensions), CT (Certificate), CR
+(CertificateRequest), NST (NewSessionTicket) and HRR
+(HelloRetryRequest). If an implementation receives an extension which
+it recognizes and which is not specified for the message in which it
+appears it MUST abort the handshake with an "illegal_parameter" alert.
+
+| Extension                                |   TLS 1.3   |
+|:-----------------------------------------|------------:|
+| server_name [RFC6066]                    |      CH, EE |
+| max_fragment_length [RFC6066]            |      CH, EE |
+| status_request [RFC6066]                 |  CH, CR, CT |
+| supported_groups [RFC7919]               |      CH, EE |
+| signature_algorithms [RFC5246]           |      CH, CR |
+| use_srtp [RFC5764]                       |      CH, EE |
+| heartbeat [RFC6520]                      |      CH, EE |
+| application_layer_protocol_negotiation [RFC7301]|      CH, EE |
+| signed_certificate_timestamp [RFC6962]   |  CH, CR, CT |
+| client_certificate_type [RFC7250]        |      CH, EE |
+| server_certificate_type [RFC7250]        |      CH, CT |
+| padding [RFC7685]                        |          CH |
+| key_share \[\[this document]]            | CH, SH, HRR |
+| pre_shared_key \[\[this document]]       |      CH, SH |
+| psk_key_exchange_modes \[\[this document]]|          CH |
+| early_data \[\[this document]]           | CH, EE, NST |
+| cookie \[\[this document]]               |     CH, HRR |
+| supported_versions \[\[this document]]   |          CH |
+| certificate_authorities \[\[this document]]|      CH, CR |
+| oid_filters \[\[this document]]          |          CR |
+| post_handshake_auth \[\[this document]]  |          CH |
+
+When multiple extensions of different types are present, the
+extensions MAY appear in any order, with the exception of
+"pre_shared_key" {{pre-shared-key-extension}} which MUST be
+the last extension in the ClientHello.
+There MUST NOT be more than one extension of the same type in a given
+extension block.
+
+In TLS 1.3, unlike TLS 1.2, extensions are negotiated for each
+handshake even when in resumption-PSK mode. However, 0-RTT parameters are
+those negotiated in the previous handshake; mismatches may require
+rejecting 0-RTT (see {{early-data-indication}}).
+
+There are subtle (and not so subtle) interactions that may occur in this
+protocol between new features and existing features which may result in a
+significant reduction in overall security. The following considerations should
+be taken into account when designing new extensions:
+
+- Some cases where a server does not agree to an extension are error
+  conditions, and some are simply refusals to support particular features. In
+  general, error alerts should be used for the former and a field in the
+  server extension response for the latter.
+
+- Extensions should, as far as possible, be designed to prevent any attack that
+  forces use (or non-use) of a particular feature by manipulation of handshake
+  messages. This principle should be followed regardless of whether the feature
+  is believed to cause a security problem.
+  Often the fact that the extension fields are included in the inputs to the
+  Finished message hashes will be sufficient, but extreme care is needed when
+  the extension changes the meaning of messages sent in the handshake phase.
+  Designers and implementors should be aware of the fact that until the
+  handshake has been authenticated, active attackers can modify messages and
+  insert, remove, or replace extensions.
+
+###  Supported Versions
+
+%%% Version Extension
+
+       struct {
+           ProtocolVersion versions<2..254>;
+       } SupportedVersions;
+
+The "supported_versions" extension is used by the client to indicate
+which versions of TLS it supports. The extension contains a list of
+supported versions in preference order, with the most preferred
+version first. Implementations of this specification MUST send this
+extension containing all versions of TLS which they are
+prepared to negotiate (for this specification, that means minimally
+0x0304, but if previous versions of TLS are allowed to be negotiated,
+they MUST be present as well).
+
+If this extension is not present, servers which are compliant with
+this specification MUST negotiate TLS 1.2 or prior as specified in
+{{RFC5246}}, even if ClientHello.legacy_version is 0x0304 or later.
+Servers MAY abort the handshake upon receiving a ClientHello with
+legacy_version 0x0304 or later.
+
+If this extension is present, servers MUST ignore the
+ClientHello.legacy_version value and MUST use only the
+"supported_versions" extension to determine client
+preferences. Servers MUST only select a version of TLS present in that
+extension and MUST ignore any unknown versions that are present in that
+extension. Note that this
+mechanism makes it possible to negotiate a version prior to TLS 1.2 if
+one side supports a sparse range. Implementations of TLS 1.3 which choose
+to support prior versions of TLS SHOULD support TLS 1.2.
+Servers should be prepared to receive ClientHellos that include this
+extension but do not include 0x0304 in the list of versions.
+
+The server MUST NOT send the "supported_versions" extension. The
+server's selected version is contained in the ServerHello.version field as
+in previous versions of TLS.
+
+#### Draft Version Indicator
+
+RFC EDITOR: PLEASE REMOVE THIS SECTION
+
+While the eventual version indicator for the RFC version of TLS 1.3 will
+be 0x0304, implementations of draft versions of this specification SHOULD
+instead advertise 0x7f00 | draft_version
+in ServerHello.version, and HelloRetryRequest.server_version.
+For instance, draft-17 would be encoded as the 0x7f11.
+This allows pre-RFC implementations to safely negotiate with each other,
+even if they would otherwise be incompatible.
+
+###  Cookie
+
+%%% Cookie Extension
+
+       struct {
+           opaque cookie<1..2^16-1>;
+       } Cookie;
+
+Cookies serve two primary purposes:
+
+- Allowing the server to force the client to demonstrate reachability
+  at their apparent network address (thus providing a measure of DoS
+  protection). This is primarily useful for non-connection-oriented
+  transports (see {{?RFC6347}} for an example of this).
+
+- Allowing the server to offload state to the client, thus allowing it to send
+  a HelloRetryRequest without storing any state. The server can do this by
+  storing the hash of the ClientHello in the HelloRetryRequest cookie
+  (protected with some suitable integrity algorithm).
+
+When sending a HelloRetryRequest, the server MAY provide a "cookie" extension to the
+client (this is an exception to the usual rule that the only extensions that
+may be sent are those that appear in the ClientHello). When sending the
+new ClientHello, the client MUST copy the contents of the extension received in
+the HelloRetryRequest into a "cookie" extension in the new ClientHello.
+Clients MUST NOT use cookies in subsequent connections.
+
+###  Signature Algorithms
+
+The client uses the "signature_algorithms" extension to indicate to the server
+which signature algorithms may be used in digital signatures. Clients which
+desire the server to authenticate itself via a certificate MUST send this extension.
+If a server is authenticating via a certificate and the client has not sent a
+"signature_algorithms" extension, then the server MUST
+abort the handshake with a "missing_extension" alert (see {{mti-extensions}}).
+
+The "extension_data" field of this extension in a ClientHello contains a
+SignatureSchemeList value:
+
+%%% Signature Algorithm Extension
+
+       enum {
+           /* RSASSA-PKCS1-v1_5 algorithms */
+           rsa_pkcs1_sha256(0x0401),
+           rsa_pkcs1_sha384(0x0501),
+           rsa_pkcs1_sha512(0x0601),
+
+           /* ECDSA algorithms */
+           ecdsa_secp256r1_sha256(0x0403),
+           ecdsa_secp384r1_sha384(0x0503),
+           ecdsa_secp521r1_sha512(0x0603),
+
+           /* RSASSA-PSS algorithms */
+           rsa_pss_sha256(0x0804),
+           rsa_pss_sha384(0x0805),
+           rsa_pss_sha512(0x0806),
+
+           /* EdDSA algorithms */
+           ed25519(0x0807),
+           ed448(0x0808),
+
+           /* Legacy algorithms */
+           rsa_pkcs1_sha1(0x0201),
+           ecdsa_sha1(0x0203),
+
+           /* Reserved Code Points */
+           obsolete_RESERVED(0x0000..0x0200),
+           dsa_sha1_RESERVED(0x0202),
+           obsolete_RESERVED(0x0204..0x0400),
+           dsa_sha256_RESERVED(0x0402),
+           obsolete_RESERVED(0x0404..0x0500),
+           dsa_sha384_RESERVED(0x0502),
+           obsolete_RESERVED(0x0504..0x0600),
+           dsa_sha512_RESERVED(0x0602),
+           obsolete_RESERVED(0x0604..0x06FF),
+           private_use(0xFE00..0xFFFF),
+           (0xFFFF)
+       } SignatureScheme;
+
+       struct {
+           SignatureScheme supported_signature_algorithms<2..2^16-2>;
+       } SignatureSchemeList;
+
+Note: This enum is named "SignatureScheme" because there is already
+a "SignatureAlgorithm" type in TLS 1.2, which this replaces.
+We use the term "signature algorithm" throughout the text.
+
+Each SignatureScheme value lists a single signature algorithm that the
+client is willing to verify. The values are indicated in descending order
+of preference. Note that a signature algorithm takes as input an
+arbitrary-length message, rather than a digest. Algorithms which
+traditionally act on a digest should be defined in TLS to first
+hash the input with a specified hash algorithm and then proceed as usual.
+The code point groups listed above have the following meanings:
+
+RSASSA-PKCS1-v1_5 algorithms
+: Indicates a signature algorithm using RSASSA-PKCS1-v1_5 {{RFC8017}}
+  with the corresponding hash algorithm as defined in {{SHS}}. These values
+  refer solely to signatures which appear in certificates (see
+  {{server-certificate-selection}}) and are not defined for use in signed
+  TLS handshake messages.
+
+ECDSA algorithms
+: Indicates a signature algorithm using ECDSA {{ECDSA}}, the corresponding
+  curve as defined in ANSI X9.62 {{X962}} and FIPS 186-4 {{DSS}}, and the
+  corresponding hash algorithm as defined in {{SHS}}. The signature is
+  represented as a DER-encoded {{X690}} ECDSA-Sig-Value structure.
+
+RSASSA-PSS algorithms
+: Indicates a signature algorithm using RSASSA-PSS {{RFC8017}} with mask
+  generation function 1. The
+  digest used in the mask generation function and the digest being signed are
+  both the corresponding hash algorithm as defined in {{SHS}}. When used in
+  signed TLS handshake messages, the length of the salt MUST be equal to the
+  length of the digest output.  This codepoint is new in this document and is also
+  defined for use with TLS 1.2.
+
+EdDSA algorithms
+: Indicates a signature algorithm using EdDSA as defined in
+  {{RFC8032}} or its successors. Note that these correspond to the
+  "PureEdDSA" algorithms and not the "prehash" variants.
+
+Legacy algorithms
+: Indicates algorithms which are being deprecated because they use
+  algorithms with known weaknesses, specifically SHA-1 which is used
+  in this context with either with RSA using RSASSA-PKCS1-v1_5 or ECDSA.  These values
+  refer solely to signatures which appear in certificates (see
+  {{server-certificate-selection}}) and are not defined for use in
+  signed TLS handshake messages. Endpoints SHOULD NOT negotiate these algorithms
+  but are permitted to do so solely for backward compatibility. Clients
+  offering these values MUST list
+  them as the lowest priority (listed after all other algorithms in
+  SignatureSchemeList). TLS 1.3 servers MUST NOT offer a SHA-1 signed
+  certificate unless no valid certificate chain can be produced
+  without it (see {{server-certificate-selection}}).
 {:br }
 
 
-##  Record Layer
+The signatures on certificates that are self-signed or certificates that are
+trust anchors are not validated since they begin a certification path (see
+{{RFC5280}}, Section 3.2).  A certificate that begins a certification
+path MAY use a signature algorithm that is not advertised as being supported
+in the "signature_algorithms" extension.
 
-The TLS record layer receives uninterpreted data from higher layers in
-non-empty blocks of arbitrary size.
+Note that TLS 1.2 defines this extension differently. TLS 1.3 implementations
+willing to negotiate TLS 1.2 MUST behave in accordance with the requirements of
+{{RFC5246}} when negotiating that version. In particular:
 
-###  Fragmentation
+* TLS 1.2 ClientHellos MAY omit this extension.
 
-The record layer fragments information blocks into TLSPlaintext records
-carrying data in chunks of 2^14 bytes or less. Client message boundaries are
-not preserved in the record layer (i.e., multiple client messages of the same
-ContentType MAY be coalesced into a single TLSPlaintext record, or a single
-message MAY be fragmented across several records).
-Alert messages {{alert-protocol}} MUST NOT be fragmented across records.
+* In TLS 1.2, the extension contained hash/signature pairs. The pairs are
+  encoded in two octets, so SignatureScheme values have been allocated to
+  align with TLS 1.2's encoding. Some legacy pairs are left unallocated. These
+  algorithms are deprecated as of TLS 1.3. They MUST NOT be offered or
+  negotiated by any implementation. In particular, MD5 {{SLOTH}}, SHA-224, and
+  DSA MUST NOT be used.
 
-%%% Record Layer
+* ECDSA signature schemes align with TLS 1.2's ECDSA hash/signature pairs.
+  However, the old semantics did not constrain the signing curve.  If TLS 1.2 is
+  negotiated, implementations MUST be prepared to accept a signature that uses
+  any curve that they advertised in the "supported_groups" extension.
+
+* Implementations that advertise support for RSASSA-PSS (which is mandatory in
+  TLS 1.3), MUST be prepared to accept a signature using that scheme even when
+  TLS 1.2 is negotiated. In TLS 1.2, RSASSA-PSS is used with RSA cipher suites.
+
+
+### Certificate Authorities
+
+The "certificate_authorities" extension is used to indicate the
+certificate authorities which an endpoint supports and which SHOULD
+be used by the receiving endpoint to guide certificate selection.
+
+The body of the "certificate_authorities" extension consists of a
+CertificateAuthoritiesExtension structure.
+
+%%% Server Parameters Messages
+
+       opaque DistinguishedName<1..2^16-1>;
+
        struct {
-           uint8 major;
-           uint8 minor;
-       } ProtocolVersion;
+           DistinguishedName authorities<3..2^16-1>;
+       } CertificateAuthoritiesExtension;
+
+authorities
+: A list of the distinguished names {{X501}} of acceptable
+  certificate authorities, represented in DER-encoded {{X690}} format.  These
+  distinguished names specify a desired distinguished name for trust anchor
+  or subordinate CA; thus, this message can be used to
+  describe known trust anchors as well as a desired authorization space.
+{:br}
+
+The client MAY send the "certificate_authorities" extension in the ClientHello
+message. The server MAY send it in the CertificateRequest message.
+
+The "trusted_ca_keys" extension, which serves a similar
+purpose {{RFC6066}}, but is more complicated, is not used in TLS 1.3
+(although it may appear in ClientHello messages from clients which are
+offering prior versions of TLS).
+
+#### OID Filters
+
+The "oid_filters" extension allows servers to provide a set of OID/value
+pairs which it would like the client's certificate to match. This
+extension, if provided by the server, MUST only be sent in the CertificateRequest message.
+
+%%% Server Parameters Messages
+
+       struct {
+           opaque certificate_extension_oid<1..2^8-1>;
+           opaque certificate_extension_values<0..2^16-1>;
+       } OIDFilter;
+
+       struct {
+           OIDFilter filters<0..2^16-1>;
+       } OIDFilterExtension;
+
+filters
+
+: A list of certificate extension OIDs {{RFC5280}} with their allowed values and
+  represented in DER-encoded {{X690}} format. Some certificate extension OIDs
+  allow multiple values (e.g., Extended Key Usage).  If the server has included
+  a non-empty filters list, the client certificate included in
+  the response MUST contain all of the specified extension OIDs that the client
+  recognizes. For each extension OID recognized by the client, all of the
+  specified values MUST be present in the client certificate (but the
+  certificate MAY have other values as well). However, the client MUST ignore
+  and skip any unrecognized certificate extension OIDs. If the client ignored
+  some of the required certificate extension OIDs and supplied a certificate
+  that does not satisfy the request, the server MAY at its discretion either
+  continue the connection without client authentication, or abort the handshake
+  with an "unsupported_certificate" alert.
+
+PKIX RFCs define a variety of certificate extension OIDs and their corresponding
+value types. Depending on the type, matching certificate extension values are
+not necessarily bitwise-equal. It is expected that TLS implementations will rely
+on their PKI libraries to perform certificate selection using certificate
+extension OIDs.
+
+This document defines matching rules for two standard certificate extensions
+defined in {{RFC5280}}:
+
+- The Key Usage extension in a certificate matches the request when all key
+  usage bits asserted in the request are also asserted in the Key Usage
+  certificate extension.
+
+- The Extended Key Usage extension in a certificate matches the request when all
+  key purpose OIDs present in the request are also found in the Extended Key
+  Usage certificate extension. The special anyExtendedKeyUsage OID MUST NOT be
+  used in the request.
+
+Separate specifications may define matching rules for other certificate
+extensions.
+
+### Post-Handshake Client Authentication {#post_handshake_auth}
+
+The "post_handshake_auth" extension is used to indicate that a client is willing
+to perform post-handshake authentication {{post-handshake-authentication}}. Servers
+MUST not send a post-handshake CertificateRequest to clients which do not
+offer this extension. Servers MUST NOT send this extension.
+
+The "extension_data" field of the "post_handshake_auth" extension is zero
+length.
+
+### Negotiated Groups
+
+When sent by the client, the "supported_groups" extension indicates
+the named groups which the client supports for key exchange, ordered
+from most preferred to least preferred.
+
+Note: In versions of TLS prior to TLS 1.3, this extension was named
+"elliptic_curves" and only contained elliptic curve groups. See {{RFC4492}} and
+{{RFC7919}}. This extension was also used to negotiate
+ECDSA curves. Signature algorithms are now negotiated independently (see
+{{signature-algorithms}}).
+
+The "extension_data" field of this extension contains a
+"NamedGroupList" value:
+
+%%% Supported Groups Extension
 
        enum {
-           invalid_RESERVED(0),
+           /* Elliptic Curve Groups (ECDHE) */
+           obsolete_RESERVED(0x0001..0x0016),
+           secp256r1(0x0017), secp384r1(0x0018), secp521r1(0x0019),
+           obsolete_RESERVED(0x001A..0x001C),
+           x25519(0x001D), x448(0x001E),
+
+           /* Finite Field Groups (DHE) */
+           ffdhe2048(0x0100), ffdhe3072(0x0101), ffdhe4096 (0x0102),
+           ffdhe6144(0x0103), ffdhe8192(0x0104),
+
+           /* Reserved Code Points */
+           ffdhe_private_use(0x01FC..0x01FF),
+           ecdhe_private_use(0xFE00..0xFEFF),
+           obsolete_RESERVED(0xFF01..0xFF02),
+           (0xFFFF)
+       } NamedGroup;
+
+       struct {
+           NamedGroup named_group_list<2..2^16-1>;
+       } NamedGroupList;
+
+Elliptic Curve Groups (ECDHE)
+: Indicates support for the corresponding named curve, defined
+  either in FIPS 186-4 {{DSS}} or in {{RFC7748}}.
+  Values 0xFE00 through 0xFEFF are reserved for private use.
+
+Finite Field Groups (DHE)
+: Indicates support of the corresponding finite field
+  group, defined in {{RFC7919}}.
+  Values 0x01FC through 0x01FF are reserved for private use.
+{:br }
+
+Items in named_group_list are ordered according to the client's
+preferences (most preferred choice first).
+
+As of TLS 1.3, servers are permitted to send the "supported_groups"
+extension to the client. Clients MUST NOT act upon any information
+found in "supported_groups" prior to successful completion of the
+handshake but MAY use the information learned from a successfully
+completed handshake to change what groups they use in their
+"key_share" extension in subsequent connections.
+If the server has a group it prefers to the
+ones in the "key_share" extension but is still willing to accept the
+ClientHello, it SHOULD send "supported_groups" to update the client's
+view of its preferences; this extension SHOULD contain all groups
+the server supports, regardless of whether they are currently
+supported by the client.
+
+### Key Share
+
+The "key_share" extension contains the endpoint's cryptographic parameters.
+
+Clients MAY send an empty client_shares vector in order to request
+group selection from the server at the cost of an additional round trip.
+(see {{hello-retry-request}})
+
+%%% Key Exchange Messages
+
+       struct {
+           NamedGroup group;
+           opaque key_exchange<1..2^16-1>;
+       } KeyShareEntry;
+
+group
+: The named group for the key being exchanged.
+  Finite Field Diffie-Hellman {{DH}} parameters are described in
+  {{ffdhe-param}}; Elliptic Curve Diffie-Hellman parameters are
+  described in {{ecdhe-param}}.
+
+key_exchange
+: Key exchange information.  The contents of this field are
+  determined by the specified group and its corresponding
+  definition.
+{:br }
+
+The "extension_data" field of this extension contains a
+"KeyShare" value:
+
+%%% Key Exchange Messages
+
+       struct {
+           select (Handshake.msg_type) {
+               case client_hello:
+                   KeyShareEntry client_shares<0..2^16-1>;
+
+               case hello_retry_request:
+                   NamedGroup selected_group;
+
+               case server_hello:
+                   KeyShareEntry server_share;
+           };
+       } KeyShare;
+
+client_shares
+: A list of offered KeyShareEntry values in descending order of client preference.
+  This vector MAY be empty if the client is requesting a HelloRetryRequest.
+  Each KeyShareEntry value MUST correspond to a group offered in the
+  "supported_groups" extension and MUST appear in the same order.  However, the
+  values MAY be a non-contiguous subset of the "supported_groups" extension and
+  MAY omit the most preferred groups. Such a situation could arise if the most
+  preferred groups are new and unlikely to be supported in enough places to
+  make pregenerating key shares for them efficient.
+
+selected_group
+: The mutually supported group the server intends to negotiate and
+  is requesting a retried ClientHello/KeyShare for.
+
+server_share
+: A single KeyShareEntry value that is in the same group as one of the
+  client's shares.
+{:br }
+
+Clients can offer an arbitrary number of KeyShareEntry values, each
+representing a single set of key exchange parameters. For instance, a
+client might offer shares for several elliptic curves or multiple
+FFDHE groups.  The key_exchange values for each KeyShareEntry MUST be
+generated independently.  Clients MUST NOT offer multiple
+KeyShareEntry values for the same group.  Clients MUST NOT offer any
+KeyShareEntry values for groups not listed in the client's
+"supported_groups" extension.  Servers MAY check for violations of
+these rules and abort the handshake with an "illegal_parameter" alert
+if one is violated.
+
+Upon receipt of this extension in a HelloRetryRequest, the client MUST
+verify that (1) the selected_group field corresponds to a group which was provided
+in the "supported_groups" extension in the original ClientHello; and (2)
+the selected_group field does not correspond to a group which was
+provided in the "key_share" extension in the original ClientHello. If either of
+these checks fails, then the client MUST abort the handshake with an
+"illegal_parameter" alert.  Otherwise, when sending the new ClientHello, the
+client MUST replace the original "key_share" extension with one
+containing only a new KeyShareEntry for the group indicated in the
+selected_group field of the triggering HelloRetryRequest.
+
+If using (EC)DHE key establishment, servers offer exactly one
+KeyShareEntry in the ServerHello. This value MUST be in the same group
+as the KeyShareEntry value offered
+by the client that the server has selected for the negotiated key exchange.
+Servers MUST NOT send a KeyShareEntry for any group not
+indicated in the "supported_groups" extension and
+MUST NOT send a KeyShareEntry when using the "psk_ke" PskKeyExchangeMode.
+If a HelloRetryRequest was received by the client, the client MUST verify that the
+selected NamedGroup in the ServerHello is the same as that in the HelloRetryRequest. If this check
+fails, the client MUST abort the handshake with an "illegal_parameter" alert.
+
+####  Diffie-Hellman Parameters {#ffdhe-param}
+
+Diffie-Hellman {{DH}} parameters for both clients and servers are encoded in
+the opaque key_exchange field of a KeyShareEntry in a KeyShare structure.
+The opaque value contains the
+Diffie-Hellman public value (Y = g^X mod p) for the specified group
+(see {{RFC7919}} for group definitions)
+encoded as a big-endian integer and padded to the left with zeros to the size of p in
+bytes.
+
+Note: For a given Diffie-Hellman group, the padding results in all public keys
+having the same length.
+
+Peers MUST validate each other's public key Y by ensuring that 1 < Y
+< p-1. This check ensures that the remote peer is properly behaved and
+isn't forcing the local system into a small subgroup.
+
+#### ECDHE Parameters {#ecdhe-param}
+
+ECDHE parameters for both clients and servers are encoded in the
+the opaque key_exchange field of a KeyShareEntry in a KeyShare structure.
+
+For secp256r1, secp384r1 and secp521r1, the contents are the serialized
+value of the following struct:
+
+       struct {
+           uint8                legacy_form = 4;
+           opaque               X[coordinate_length];
+           opaque               Y[coordinate_length];
+        } UncompressedPointRepresentation;
+
+X and Y respectively are the binary representations of the X and Y
+values in network byte order.  There are no internal length markers,
+so each number representation occupies as many octets as implied by
+the curve parameters.  For P-256 this means that each of X and Y use
+32 octets, padded on the left by zeros if necessary.  For P-384 they
+take 48 octets each, and for P-521 they take 66 octets each.
+
+For the curves secp256r1, secp384r1 and secp521r1,
+peers MUST validate each other's public value Y by ensuring
+that the point is a valid point on the elliptic curve.
+The appropriate validation procedures are defined in Section 4.3.7 of {{X962}}
+and alternatively in Section 5.6.2.6  of {{KEYAGREEMENT}}.
+This process consists of three steps: (1) verify that Y is not the point at
+infinity (O), (2) verify that for Y = (x, y) both integers are in the correct
+interval, (3) ensure that (x, y) is a correct solution to the elliptic curve equation.
+For these curves, implementers do not need to verify membership in the correct subgroup.
+
+For X25519 and X448, the contents of the public value are the byte string inputs and outputs of the
+corresponding functions defined in {{RFC7748}}, 32 bytes for X25519 and 56
+bytes for X448.
+
+Note: Versions of TLS prior to 1.3 permitted point format negotiation;
+TLS 1.3 removes this feature in favor of a single point format
+for each curve.
+
+### Pre-Shared Key Exchange Modes
+
+In order to use PSKs, clients MUST also send a "psk_key_exchange_modes"
+extension. The semantics of this extension are that the client only
+supports the use of PSKs with these modes, which restricts both the
+use of PSKs offered in this ClientHello and those which the server
+might supply via NewSessionTicket.
+
+A client MUST provide a "psk_key_exchange_modes" extension if it offers
+a "pre_shared_key" extension. If clients offer "pre_shared_key" without
+a "psk_key_exchange_modes" extension, servers MUST abort the handshake.
+Servers MUST NOT select a key exchange mode that is not listed by the
+client. This extension also restricts the modes for use with PSK resumption;
+servers SHOULD NOT send NewSessionTicket with tickets that are not
+compatible with the advertised modes; however, if a server does so, the impact
+will just be that the client's attempts at resumption fail.
+
+The server MUST NOT send a "psk_key_exchange_modes" extension.
+
+%%% Key Exchange Messages
+
+       enum { psk_ke(0), psk_dhe_ke(1), (255) } PskKeyExchangeMode;
+
+       struct {
+           PskKeyExchangeMode ke_modes<1..255>;
+       } PskKeyExchangeModes;
+
+psk_ke
+: PSK-only key establishment. In this mode, the server MUST NOT
+supply a "key_share" value.
+
+psk_dhe_ke
+: PSK with (EC)DHE key establishment. In this mode,
+the client and servers MUST supply "key_share" values as described
+in {{key-share}}.
+{:br}
+
+### Early Data Indication
+
+When a PSK is used, the client can send application data
+in its first flight of messages. If the client opts to do so, it MUST
+supply both the "early_data" extension as well as the "pre_shared_key"
+extension.
+
+The "extension_data" field of this extension contains an
+"EarlyDataIndication" value.
+
+%%% Key Exchange Messages
+
+       struct {} Empty;
+
+       struct {
+           select (Handshake.msg_type) {
+               case new_session_ticket:   uint32 max_early_data_size;
+               case client_hello:         Empty;
+               case encrypted_extensions: Empty;
+           };
+       } EarlyDataIndication;
+
+See {{NSTMessage}} for the use of the max_early_data_size field.
+
+The parameters for the 0-RTT data (symmetric cipher suite, ALPN
+protocol, etc.) are the same as those which were negotiated in the connection
+which established the PSK. The PSK used to encrypt the early data
+MUST be the first PSK listed in the client's "pre_shared_key" extension.
+
+For PSKs provisioned via NewSessionTicket, a server MUST validate that
+the ticket age for the selected PSK identity (computed by subtracting
+ticket_age_add from PskIdentity.obfuscated_ticket_age modulo 2^32)
+is within a small tolerance of the
+time since the ticket was issued (see {{anti-replay}}).  If it is not,
+the server SHOULD proceed with the handshake but reject 0-RTT, and
+SHOULD NOT take any other action that assumes that this ClientHello is
+fresh.
+
+0-RTT messages sent in the first flight have the same (encrypted) content types
+as their corresponding messages sent in other flights (handshake and
+application_data) but are protected under
+different keys.  After receiving the server's Finished message, if the
+server has accepted early data, an EndOfEarlyData message
+will be sent to indicate the key change. This message will be encrypted
+with the 0-RTT traffic keys.
+
+A server which receives an "early_data" extension
+MUST behave in one of three ways:
+
+- Ignore the extension and return a regular 1-RTT response.  The server then
+  ignores early data by attempting to decrypt received records in the handshake traffic
+  keys until it is able to receive the
+  client's second flight and complete an ordinary 1-RTT handshake, skipping
+  records that fail to decrypt, up to the configured max_early_data_size.
+
+- Request that the client send another ClientHello by responding with a
+  HelloRetryRequest.  A client MUST NOT include the "early_data" extension in
+  its followup ClientHello.  The server then ignores early data by skipping
+  all records with external content type of "application_data" (indicating
+  that they are encrypted).
+
+- Return its own extension in EncryptedExtensions,
+  indicating that it intends to
+  process the early data. It is not possible for the server
+  to accept only a subset of the early data messages.
+  Even though the server sends a message accepting early data, the actual early
+  data itself may already be in flight by the time the server generates this message.
+
+In order to accept early data, the server MUST have accepted a
+PSK cipher suite and selected the first key offered in the
+client's "pre_shared_key" extension. In addition, it MUST verify that
+the following values are consistent with those negotiated in the
+connection during which the ticket was established.
+
+- The TLS version number and cipher suite.
+- The selected ALPN {{RFC7301}} protocol, if any.
+
+Future extensions MUST define their interaction with 0-RTT.
+
+If any of these checks fail, the server MUST NOT respond
+with the extension and must discard all the first
+flight data using one of the first two mechanisms listed above
+(thus falling back to 1-RTT or 2-RTT). If the client attempts
+a 0-RTT handshake but the server rejects it, the server will generally
+not have the 0-RTT record protection keys and must instead
+use trial decryption (either with the 1-RTT handshake keys or
+by looking for a cleartext ClientHello in the case of HelloRetryRequest) to
+find the first non-0RTT message.
+
+If the server chooses to accept the "early_data" extension,
+then it MUST comply with the same error handling requirements
+specified for all records when processing early data records.
+Specifically, if the server fails to decrypt any 0-RTT record following
+an accepted "early_data" extension it MUST terminate the connection
+with a "bad_record_mac" alert as per {{record-payload-protection}}.
+
+If the server rejects the "early_data" extension, the client
+application MAY opt to retransmit early data once the handshake has
+been completed.  Note that automatic re-transmission of early data
+could result in assumptions about the status of the connection being
+incorrect. For instance, when the negotiated connection selects a
+different ALPN protocol from what was used for the early data, an
+application might need to construct different messages.  Similarly, if
+early data assumes anything about the connection state, it might be
+sent in error after the handshake completes.
+
+A TLS implementation SHOULD NOT automatically re-send early data;
+applications are in a better position to decide when re-transmission
+is appropriate. A TLS implementation MUST NOT automatically re-send
+early data unless the negotiated connection selects the same ALPN
+protocol.
+
+### Pre-Shared Key Extension
+
+The "pre_shared_key" extension is used to indicate the identity of the
+pre-shared key to be used with a given handshake in association
+with PSK key establishment.
+
+The "extension_data" field of this extension contains a
+"PreSharedKeyExtension" value:
+
+%%% Key Exchange Messages
+
+       struct {
+           opaque identity<1..2^16-1>;
+           uint32 obfuscated_ticket_age;
+       } PskIdentity;
+
+       opaque PskBinderEntry<32..255>;
+
+       struct {
+           select (Handshake.msg_type) {
+               case client_hello:
+                   PskIdentity identities<7..2^16-1>;
+                   PskBinderEntry binders<33..2^16-1>;
+
+               case server_hello:
+                   uint16 selected_identity;
+           };
+
+       } PreSharedKeyExtension;
+
+identity
+: A label for a key. For instance, a ticket defined
+  in {{ticket-establishment}} or a label for a pre-shared key
+  established externally.
+
+obfuscated_ticket_age
+: An obfuscated version of the age of the key.
+  {{ticket-age}} describes how to form this value
+  for identities established via the NewSessionTicket message.
+  For identities established externally an obfuscated_ticket_age of 0
+  SHOULD be used, and servers MUST ignore the value.
+
+identities
+: A list of the identities that the client is willing
+  to negotiate with the server. If sent alongside the "early_data"
+  extension (see {{early-data-indication}}), the first identity is the
+  one used for 0-RTT data.
+
+binders
+: A series of HMAC values, one for
+  each PSK offered in the "pre_shared_keys" extension and in the same
+  order, computed as described below.
+
+selected_identity
+: The server's chosen identity expressed as a (0-based) index into
+  the identities in the client's list.
+{: br}
+
+Each PSK is associated with a single Hash algorithm. For PSKs established
+via the ticket mechanism ({{NSTMessage}}), this is the KDF Hash algorithm
+on the connection where the ticket was established.
+For externally established PSKs, the Hash algorithm MUST be set when the
+PSK is established, or default to SHA-256 if no such algorithm
+is defined. The server must ensure that it selects a compatible
+PSK (if any) and cipher suite.
+
+Implementor's note: the most straightforward way to implement the
+PSK/cipher suite matching requirements is to negotiate the cipher
+suite first and then exclude any incompatible PSKs. Any unknown PSKs
+(e.g., they are not in the PSK database or are encrypted with an
+unknown key) SHOULD simply be ignored. If no acceptable PSKs are
+found, the server SHOULD perform a non-PSK handshake if possible.
+
+Prior to accepting PSK key establishment, the server MUST validate the
+corresponding binder value (see {{psk-binder}} below). If this value is
+not present or does not validate, the server MUST abort the handshake.
+Servers SHOULD NOT attempt to validate multiple binders; rather they
+SHOULD select a single PSK and validate solely the binder that
+corresponds to that PSK. In order to accept PSK key establishment, the
+server sends a "pre_shared_key" extension indicating the selected
+identity.
+
+Clients MUST verify that the server's selected_identity is within the
+range supplied by the client, that the server selected a cipher suite
+indicating a Hash associated with the PSK and that a server
+"key_share" extension is present if required by the
+ClientHello "psk_key_exchange_modes". If these values are not
+consistent the client MUST abort the handshake with an
+"illegal_parameter" alert.
+
+If the server supplies an "early_data" extension, the client MUST
+verify that the server's selected_identity is 0. If any
+other value is returned, the client MUST abort the handshake
+with an "illegal_parameter" alert.
+
+This extension MUST be the last extension in the ClientHello (this
+facilitates implementation as described below). Servers MUST check
+that it is the last extension and otherwise fail the handshake with an
+"illegal_parameter" alert.
+
+#### Ticket Age
+
+The client's view of the age of a ticket is the time since the receipt
+of the NewSessionTicket message. Clients MUST NOT attempt to use
+tickets which have ages greater than the "ticket_lifetime" value which
+was provided with the ticket. The "obfuscated_ticket_age" field of
+each PskIdentity contains an obfuscated version of the ticket age
+formed by taking the age in milliseconds and adding the "ticket_age_add"
+value that was included with the ticket, see {{NSTMessage}} modulo 2^32.
+This addition prevents passive observers from correlating connections
+unless tickets are reused. Note that the "ticket_lifetime" field in
+the NewSessionTicket message is in seconds but the "obfuscated_ticket_age"
+is in milliseconds. Because ticket lifetimes are
+restricted to a week, 32 bits is enough to represent any plausible
+age, even in milliseconds.
+
+#### PSK Binder
+
+The PSK binder value forms a binding between a PSK and the current
+handshake, as well as between the handshake in which the PSK was
+generated (if via a NewSessionTicket message) and the handshake where
+it was used.  Each entry in the binders list is computed as an HMAC
+over a transcript hash (see {{the-transcript-hash}}) containing a partial ClientHello
+up to and including the PreSharedKeyExtension.identities field. That
+is, it includes all of the ClientHello but not the binders list
+itself. The length fields for the message (including the overall
+length, the length of the extensions block, and the length of the
+"pre_shared_key" extension) are all set as if binders of the correct
+lengths were present.
+
+The PskBinderEntry is computed in the same way as the Finished
+message ({{finished}}) but with the BaseKey being the binder_key
+derived via the key schedule from the corresponding PSK which
+is being offered (see {{key-schedule}}).
+
+If the handshake includes a HelloRetryRequest, the initial ClientHello
+and HelloRetryRequest are included in the transcript along with the
+new ClientHello.  For instance, if the client sends ClientHello1, its
+binder will be computed over:
+
+       Transcript-Hash(ClientHello1[truncated])
+
+If the server responds with HelloRetryRequest, and the client then sends
+ClientHello2, its binder will be computed over:
+
+       Transcript-Hash(ClientHello1,
+                       HelloRetryRequest,
+                       ClientHello2[truncated])
+
+The full ClientHello1 is included in all other handshake hash computations.
+Note that in the first flight, ClientHello1\[truncated] is hashed directly,
+but in the second flight, ClientHello1 is hashed and then reinjected as a
+"handshake_hash" message, as described in {{the-transcript-hash}}.
+
+#### Processing Order
+
+Clients are permitted to "stream" 0-RTT data until they
+receive the server's Finished, only then sending the EndOfEarlyData
+message, followed by the rest of the handshake.
+In order to avoid deadlocks, when accepting "early_data",
+servers MUST process the client's ClientHello and then immediately
+send the ServerHello, rather than waiting for the client's
+EndOfEarlyData message.
+
+## Server Parameters
+
+The next two messages from the server, EncryptedExtensions and
+CertificateRequest, contain information from the server
+that determines the rest of the handshake. These messages
+are encrypted with keys derived from the server_handshake_traffic_secret.
+
+###  Encrypted Extensions
+
+In all handshakes, the server MUST send the
+EncryptedExtensions message immediately after the
+ServerHello message. This is the first message that is encrypted
+under keys derived from the server_handshake_traffic_secret.
+
+The EncryptedExtensions message contains extensions
+that can be protected, i.e., any which are not needed to
+establish the cryptographic context, but which are not
+associated with individual certificates. The client
+MUST check EncryptedExtensions for the presence of any forbidden
+extensions and if any are found MUST abort the handshake with an
+"illegal_parameter" alert.
+
+Structure of this message:
+
+%%% Server Parameters Messages
+
+       struct {
+           Extension extensions<0..2^16-1>;
+       } EncryptedExtensions;
+
+extensions
+: A list of extensions. For more information, see the table in {{extensions}}.
+{:br }
+
+###  Certificate Request
+
+A server which is authenticating with a certificate MAY optionally
+request a certificate from the client. This message, if sent, MUST
+follow EncryptedExtensions.
+
+Structure of this message:
+
+%%% Server Parameters Messages
+
+       struct {
+           opaque certificate_request_context<0..2^8-1>;
+           Extension extensions<2..2^16-1>;
+       } CertificateRequest;
+
+certificate_request_context
+: An opaque string which identifies the certificate request and
+  which will be echoed in the client's Certificate message. The
+  certificate_request_context MUST be unique within the scope
+  of this connection (thus preventing replay of client
+  CertificateVerify messages). This field SHALL be zero length
+  unless used for the post-handshake authentication exchanges
+  described in {{post-handshake-authentication}}.
+  When requesting post-handshake authentication, the server SHOULD
+  make the context unpredictable to the client (e.g., by
+  randomly generating it) in order to prevent an attacker who
+  has temporary access to the client's private key from
+  pre-computing valid CertificateVerify messages.
+
+extensions
+: A set of extensions describing the parameters of the
+  certificate being requested. The "signature_algorithms"
+  extension MUST be specified, and other extensions may optionally be
+  included if defined for this message.
+  Clients MUST ignore unrecognized extensions.
+{:br}
+
+In prior versions of TLS, the CertificateRequest message
+carried a list of signature algorithms and certificate authorities
+which the server would accept. In TLS 1.3 the former is expressed
+by sending the "signature_algorithms" extension. The latter is
+expressed by sending the "certificate_authorities" extension
+(see {{certificate-authorities}}).
+
+Servers which are authenticating with a PSK MUST NOT send the
+CertificateRequest message in the main handshake, though they
+MAY send it in post-handshake authentication (see {{post-handshake-authentication}})
+provided that the client has sent the "post_handshake_auth"
+extension (see {{post_handshake_auth}}).
+
+
+## Authentication Messages
+
+As discussed in {{protocol-overview}}, TLS generally uses a common
+set of messages for authentication, key confirmation, and handshake
+integrity: Certificate, CertificateVerify, and Finished.
+(The PreSharedKey binders also perform key confirmation, in a
+similar fashion.) These three
+messages are always sent as the last messages in their handshake
+flight. The Certificate and CertificateVerify messages are only
+sent under certain circumstances, as defined below. The Finished
+message is always sent as part of the Authentication block.
+These messages are encrypted under keys derived from
+\[sender]_handshake_traffic_secret.
+
+The computations for the Authentication messages all uniformly
+take the following inputs:
+
+- The certificate and signing key to be used.
+- A Handshake Context consisting of the set of messages to be
+  included in the transcript hash.
+- A base key to be used to compute a MAC key.
+
+Based on these inputs, the messages then contain:
+
+Certificate
+: The certificate to be used for authentication, and any
+  supporting certificates in the chain. Note that certificate-based
+  client authentication is not available in 0-RTT mode.
+
+CertificateVerify
+: A signature over the value Transcript-Hash(Handshake Context, Certificate)
+
+Finished
+: A MAC over the value Transcript-Hash(Handshake Context, Certificate, CertificateVerify)
+  using a MAC key derived from the base key.
+{:br}
+
+
+The following table defines the Handshake Context and MAC Base Key
+for each scenario:
+
+| Mode | Handshake Context | Base Key |
+|------|-------------------|----------|
+| Server | ClientHello ... later of EncryptedExtensions/CertificateRequest | server_handshake_traffic_secret |
+| Client | ClientHello ... later of server Finished/EndOfEarlyData | client_handshake_traffic_secret |
+| Post-Handshake | ClientHello ... client Finished + CertificateRequest | client_application_traffic_secret_N |
+
+### The Transcript Hash
+
+Many of the cryptographic computations in TLS make use of a transcript
+hash. This value is computed by hashing the concatenation of
+each included handshake message, including the handshake
+message header carrying the handshake message type and length fields,
+but not including record layer headers. I.e.,
+
+     Transcript-Hash(M1, M2, ... MN) = Hash(M1 || M2 ... MN)
+
+As an exception to this general rule, when the server responds to a
+ClientHello with a HelloRetryRequest, the value of ClientHello1 is
+replaced with a special synthetic handshake message of handshake
+type "message_hash" containing Hash(ClientHello1). I.e.,
+
+     Transcript-Hash(ClientHello1, HelloRetryRequest, ... MN) =
+         Hash(message_hash ||        // Handshake type
+              00 00 Hash.length ||   // Handshake message length (bytes)
+              Hash(ClientHello1) ||  // Hash of ClientHello1
+              HelloRetryRequest ... MN)
+
+The reason for this construction is to allow the server to do a
+stateless HelloRetryRequest by storing just the hash of ClientHello1
+in the cookie, rather than requiring it to export the entire intermediate
+hash state (see {{cookie}}).
+
+For concreteness, the transcript hash is always taken from the
+following sequence of handshake messages, starting at the first
+ClientHello and including only those messages that were sent:
+ClientHello, HelloRetryRequest, ClientHello, ServerHello,
+EncryptedExtensions, server CertificateRequest, server Certificate,
+server CertificateVerify, server Finished, EndOfEarlyData, client
+Certificate, client CertificateVerify, client Finished.
+
+In general, implementations can implement the transcript by keeping a
+running transcript hash value based on the negotiated hash. Note,
+however, that subsequent post-handshake authentications do not include
+each other, just the messages through the end of the main handshake.
+
+###  Certificate
+
+This message conveys the endpoint's certificate chain to the peer.
+
+The server MUST send a Certificate message whenever the agreed-upon
+key exchange method uses certificates for authentication (this
+includes all key exchange methods defined in this document except PSK).
+
+The client MUST send a Certificate message if and only if the server has
+requested client authentication via a CertificateRequest message
+({{certificate-request}}). If the server requests client authentication
+but no suitable certificate is available, the client
+MUST send a Certificate message containing no certificates (i.e., with
+the "certificate_list" field having length 0).
+
+Structure of this message:
+
+%%% Authentication Messages
+
+       struct {
+           select(certificate_type){
+               case RawPublicKey:
+                 // From RFC 7250 ASN.1_subjectPublicKeyInfo
+                 opaque ASN1_subjectPublicKeyInfo<1..2^24-1>;
+
+               case X509:
+                 opaque cert_data<1..2^24-1>;
+           };
+           Extension extensions<0..2^16-1>;
+       } CertificateEntry;
+
+       struct {
+           opaque certificate_request_context<0..2^8-1>;
+           CertificateEntry certificate_list<0..2^24-1>;
+       } Certificate;
+
+certificate_request_context
+: If this message is in response to a CertificateRequest, the
+  value of certificate_request_context in that message. Otherwise
+  (in the case of server authentication), this field SHALL be zero length.
+
+certificate_list
+: This is a sequence (chain) of CertificateEntry structures, each
+  containing a single certificate and set of extensions.
+
+extensions:
+: A set of extension values for the CertificateEntry. The "Extension"
+  format is defined in {{extensions}}. Valid extensions include
+  OCSP Status extensions ({{RFC6066}} and {{!RFC6961}}) and
+  SignedCertificateTimestamps ({{!RFC6962}}).  An extension MUST only be present
+  in a Certificate message if the corresponding
+  ClientHello extension was presented in the initial handshake.
+  If an extension applies to the entire chain, it SHOULD be included
+  in the first CertificateEntry.
+{:br }
+
+If the corresponding certificate type extension
+("server_certificate_type" or "client_certificate_type") was not used
+or the X.509 certificate type was negotiated, then each
+CertificateEntry contains an X.509 certificate. The sender's
+certificate MUST come in the first CertificateEntry in the list.  Each
+following certificate SHOULD directly certify one preceding it.
+Because certificate validation requires that trust anchors be
+distributed independently, a certificate that specifies a trust anchor
+MAY be omitted from the chain, provided that supported peers are known
+to possess any omitted certificates.
+
+Note: Prior to TLS 1.3, "certificate_list" ordering required each certificate
+to certify the one immediately preceding it;
+however, some implementations allowed some flexibility. Servers sometimes send
+both a current and deprecated intermediate for transitional purposes, and others
+are simply configured incorrectly, but these cases can nonetheless be validated
+properly. For maximum compatibility, all implementations SHOULD be prepared to
+handle potentially extraneous certificates and arbitrary orderings from any TLS
+version, with the exception of the end-entity certificate which MUST be first.
+
+If the RawPublicKey certificate type was negotiated, then the
+certificate_list MUST contain no more than one CertificateEntry, which
+contains an ASN1_subjectPublicKeyInfo value as defined in {{RFC7250}},
+Section 3.
+
+The OpenPGP certificate type {{RFC6091}} MUST NOT be used with TLS 1.3.
+
+The server's certificate_list MUST always be non-empty. A client will
+send an empty certificate_list if it does not have an appropriate
+certificate to send in response to the server's authentication
+request.
+
+#### OCSP Status and SCT Extensions {#ocsp-and-sct}
+
+{{RFC6066}} and {{!RFC6961}} provide extensions to negotiate the server
+sending OCSP responses to the client. In TLS 1.2 and below, the
+server replies with an empty extension to indicate negotiation of this
+extension and the OCSP information is carried in a CertificateStatus
+message. In TLS 1.3, the server's OCSP information is carried in
+an extension in the CertificateEntry containing the associated
+certificate. Specifically:
+The body of the "status_request" extension
+from the server MUST be a CertificateStatus structure as defined
+in {{RFC6066}}, which is interpreted as defined in {{!RFC6960}}.
+
+A server MAY request that a client present an OCSP response with its
+certificate by sending an empty "status_request" extension in its
+CertificateRequest message. If the client opts to send an OCSP response, the
+body of its "status_request" extension MUST be a CertificateStatus structure as
+defined in {{RFC6066}}.
+
+Similarly, {{!RFC6962}} provides a mechanism for a server to send a
+Signed Certificate Timestamp (SCT) as an extension in the ServerHello
+in TLS 1.2 and below.
+In TLS 1.3, the server's SCT information is carried in an extension in
+CertificateEntry.
+
+#### Server Certificate Selection
+
+The following rules apply to the certificates sent by the server:
+
+- The certificate type MUST be X.509v3 {{RFC5280}}, unless explicitly negotiated
+  otherwise (e.g., {{RFC7250}}).
+
+- The server's end-entity certificate's public key (and associated
+  restrictions) MUST be compatible with the selected authentication
+  algorithm (currently RSA, ECDSA, or EdDSA).
+
+- The certificate MUST allow the key to be used for signing (i.e., the
+  digitalSignature bit MUST be set if the Key Usage extension is present) with
+  a signature scheme indicated in the client's "signature_algorithms" extension.
+
+- The "server_name" and "certificate_authorities" extensions {{RFC6066}} are used to
+  guide certificate selection. As servers MAY require the presence of the "server_name"
+  extension, clients SHOULD send this extension, when applicable.
+
+All certificates provided by the server MUST be signed by a
+signature algorithm that appears in the "signature_algorithms"
+extension provided by the client, if they are able to provide such
+a chain (see {{signature-algorithms}}).
+Certificates that are self-signed
+or certificates that are expected to be trust anchors are not validated as
+part of the chain and therefore MAY be signed with any algorithm.
+
+If the server cannot produce a certificate chain that is signed only via the
+indicated supported algorithms, then it SHOULD continue the handshake by sending
+the client a certificate chain of its choice that may include algorithms
+that are not known to be supported by the client.
+This fallback chain SHOULD NOT use the deprecated SHA-1 hash algorithm in general,
+but MAY do so if the "signature_algorithms" extension provided by the client permits it,
+and MUST NOT do so otherwise.
+
+If the client cannot construct an acceptable chain using the provided
+certificates and decides to abort the handshake, then it MUST abort the
+handshake with an appropriate certificate-related alert (by default,
+"unsupported_certificate"; see {{error-alerts}} for more).
+
+If the server has multiple certificates, it chooses one of them based on the
+above-mentioned criteria (in addition to other criteria, such as transport
+layer endpoint, local configuration and preferences).
+
+#### Client Certificate Selection
+
+The following rules apply to certificates sent by the client:
+
+- The certificate type MUST be X.509v3 {{RFC5280}}, unless explicitly negotiated
+  otherwise (e.g., {{RFC7250}}).
+
+- If the "certificate_authorities" extension in the CertificateRequest
+  message was present, at least one of the certificates in the certificate
+  chain SHOULD be issued by one of the listed CAs.
+
+- The certificates MUST be signed using an acceptable signature
+  algorithm, as described in {{certificate-request}}.  Note that this
+  relaxes the constraints on certificate-signing algorithms found in
+  prior versions of TLS.
+
+- If the CertificateRequest message contained a non-empty "oid_filters"
+  extension, the end-entity certificate MUST match the extension OIDs
+  recognized by the client, as described in {{oid-filters}}.
+
+Note that, as with the server certificate, there are certificates that use
+algorithm combinations that cannot be currently used with TLS.
+
+#### Receiving a Certificate Message
+
+In general, detailed certificate validation procedures are out of scope for
+TLS (see {{RFC5280}}). This section provides TLS-specific requirements.
+
+If the server supplies an empty Certificate message, the client MUST abort
+the handshake with a "decode_error" alert.
+
+If the client does not send any certificates,
+the server MAY at its discretion either continue the handshake without client
+authentication, or abort the handshake with a "certificate_required" alert. Also, if some
+aspect of the certificate chain was unacceptable (e.g., it was not signed by a
+known, trusted CA), the server MAY at its discretion either continue the
+handshake (considering the client unauthenticated) or abort the handshake.
+
+Any endpoint receiving any certificate which it would need to validate
+using any signature algorithm using an MD5 hash MUST abort the
+handshake with a "bad_certificate" alert.  SHA-1 is deprecated and it
+is RECOMMENDED that any endpoint receiving any certificate which it
+would need to validate using any signature algorithm using a SHA-1
+hash abort the handshake with a "bad_certificate" alert. For clarity,
+this means that endpoints MAY accept these algorithms for
+certificates that are self-signed or are trust anchors.
+
+All endpoints are RECOMMENDED to transition to SHA-256 or better as soon
+as possible to maintain interoperability with implementations
+currently in the process of phasing out SHA-1 support.
+
+Note that a certificate containing a key for one signature algorithm
+MAY be signed using a different signature algorithm (for instance,
+an RSA key signed with an ECDSA key).
+
+###  Certificate Verify
+
+This message is used to provide explicit proof that an endpoint
+possesses the private key corresponding to its certificate.
+The CertificateVerify message also provides integrity for the handshake up
+to this point. Servers MUST send this message when authenticating via a certificate.
+Clients MUST send this message whenever authenticating via a certificate (i.e., when
+the Certificate message is non-empty). When sent, this message MUST appear immediately
+after the Certificate message and immediately prior to the Finished message.
+
+Structure of this message:
+
+%%% Authentication Messages
+
+       struct {
+           SignatureScheme algorithm;
+           opaque signature<0..2^16-1>;
+       } CertificateVerify;
+
+The algorithm field specifies the signature algorithm used (see
+{{signature-algorithms}} for the definition of this field). The
+signature is a digital signature using that algorithm. The
+content that is covered under the signature is the hash output as described in
+{{authentication-messages}}, namely:
+
+       Transcript-Hash(Handshake Context, Certificate)
+
+The digital signature is then computed over the concatenation of:
+
+- A string that consists of octet 32 (0x20) repeated 64 times
+- The context string
+- A single 0 byte which serves as the separator
+- The content to be signed
+
+This structure is intended to prevent an attack on previous versions
+of TLS in which the ServerKeyExchange format meant that
+attackers could obtain a signature of a message with a chosen 32-byte
+prefix (ClientHello.random). The initial 64-byte pad clears that prefix
+along with the server-controlled ServerHello.random.
+
+The context string for a server signature is
+"TLS 1.3, server CertificateVerify" and for a client signature is
+"TLS 1.3, client CertificateVerify".
+It is used to provide separation between signatures made in different
+contexts, helping against potential cross-protocol attacks.
+
+For example, if the transcript hash was 32 bytes of
+01 (this length would make sense for SHA-256), the content covered by
+the digital signature for a server CertificateVerify would be:
+
+       2020202020202020202020202020202020202020202020202020202020202020
+       2020202020202020202020202020202020202020202020202020202020202020
+       544c5320312e332c207365727665722043657274696669636174655665726966
+       79
+       00
+       0101010101010101010101010101010101010101010101010101010101010101
+
+On the sender side the process for computing the signature field of the
+CertificateVerify message takes as input:
+
+- The content covered by the digital signature
+- The private signing key corresponding to the certificate sent in the
+  previous message
+
+If the CertificateVerify message is sent by a server, the signature
+algorithm MUST be one offered in the client's "signature_algorithms" extension
+unless no valid certificate chain can be produced without unsupported
+algorithms (see {{signature-algorithms}}).
+
+If sent by a client, the signature algorithm used in the signature
+MUST be one of those present in the supported_signature_algorithms
+field of the "signature_algorithms" extension in the CertificateRequest message.
+
+In addition, the signature algorithm MUST be compatible with the key
+in the sender's end-entity certificate. RSA signatures MUST use an
+RSASSA-PSS algorithm, regardless of whether RSASSA-PKCS1-v1_5 algorithms
+appear in "signature_algorithms". The SHA-1 algorithm MUST NOT be used
+in any signatures of CertificateVerify messages.
+All SHA-1 signature algorithms in this specification are defined solely
+for use in legacy certificates and are not valid for CertificateVerify
+signatures.
+
+The receiver of a CertificateVerify message MUST verify the signature field.
+The verification process takes as input:
+
+- The content covered by the digital signature
+- The public key contained in the end-entity certificate found in the
+  associated Certificate message.
+- The digital signature received in the signature field of the
+  CertificateVerify message
+
+If the verification fails, the receiver MUST terminate the handshake
+with a "decrypt_error" alert.
+
+###  Finished
+
+The Finished message is the final message in the authentication
+block. It is essential for providing authentication of the handshake
+and of the computed keys.
+
+Recipients of Finished messages MUST verify that the contents are
+correct and if incorrect MUST terminate the connection
+with a "decrypt_error" alert.
+
+Once a side has sent its Finished message and received and
+validated the Finished message from its peer, it may begin to send and
+receive application data over the connection. There are two
+settings in which it is permitted to send data prior to
+receiving the peer's Finished:
+
+1. Clients sending 0-RTT data as described in {{early-data-indication}}.
+2. Servers MAY send data after sending their first flight, but
+   because the handshake is not yet complete, they have no assurance
+   of either the peer's identity or of its liveness (i.e.,
+   the ClientHello might have been replayed).
+
+The key used to compute the finished message is computed from the
+Base key defined in {{authentication-messages}} using HKDF (see
+{{key-schedule}}). Specifically:
+
+~~~
+finished_key =
+    HKDF-Expand-Label(BaseKey, "finished", "", Hash.length)
+~~~
+
+Structure of this message:
+
+%%% Authentication Messages
+
+       struct {
+           opaque verify_data[Hash.length];
+       } Finished;
+
+
+The verify_data value is computed as follows:
+
+       verify_data =
+           HMAC(finished_key,
+                Transcript-Hash(Handshake Context,
+                                Certificate*, CertificateVerify*))
+
+       * Only included if present.
+
+HMAC {{RFC2104}} uses the Hash algorithm for the handshake.
+As noted above, the HMAC input can generally be implemented by a running
+hash, i.e., just the handshake hash at this point.
+
+In previous versions of TLS, the verify_data was always 12 octets long. In
+TLS 1.3, it is the size of the HMAC output for the Hash used for the handshake.
+
+Note: Alerts and any other record types are not handshake messages
+and are not included in the hash computations.
+
+Any records following a 1-RTT Finished message MUST be encrypted under the
+appropriate application traffic key as described in {{updating-traffic-keys}}.
+In particular, this includes any alerts sent by the
+server in response to client Certificate and CertificateVerify messages.
+
+
+## End of Early Data
+
+%%% Updating Keys
+
+       struct {} EndOfEarlyData;
+
+If the server sent an "early_data" extension, the client MUST send an
+EndOfEarlyData message after receiving the server Finished.  If the server does
+not send an "early_data" extension, then the client MUST NOT send an
+EndOfEarlyData message. This message indicates that all
+0-RTT application_data messages, if any, have been transmitted and
+that the following records are protected under handshake traffic keys.
+Servers MUST NOT send this message and clients receiving it
+MUST terminate the connection with an "unexpected_message" alert.
+This message is encrypted under keys derived from the client_early_traffic_secret.
+
+
+## Post-Handshake Messages
+
+TLS also allows other messages to be sent after the main handshake.
+These messages use a handshake content type and are encrypted under the
+appropriate application traffic key.
+
+### New Session Ticket Message {#NSTMessage}
+
+At any time after the server has received the client Finished message,
+it MAY send a NewSessionTicket message. This message creates a unique
+association between the ticket value and a secret PSK
+derived from the resumption master secret.
+
+The client MAY use this PSK for future handshakes by including the
+ticket value in the "pre_shared_key" extension in its ClientHello
+({{pre-shared-key-extension}}). Servers MAY send multiple tickets on a
+single connection, either immediately after each other or
+after specific events.
+For instance, the server might send a new ticket after post-handshake
+authentication in order to encapsulate the additional client
+authentication state. Clients SHOULD attempt to use each
+ticket no more than once, with more recent tickets being used
+first.
+
+Any ticket MUST only be resumed with a cipher suite that has the
+same KDF hash algorithm as that used to establish the original connection,
+and only if the client provides the same SNI value as in the original
+connection, as described in Section 3 of {{RFC6066}}.
+
+Note: Although the resumption master secret depends on the client's second
+flight, servers which do not request client authentication MAY compute
+the remainder of the transcript independently and then send a
+NewSessionTicket immediately upon sending its Finished rather than
+waiting for the client Finished.  This might be appropriate in cases
+where the client is expected to open multiple TLS connections in
+parallel and would benefit from the reduced overhead of a resumption
+handshake, for example.
+
+
+%%% Ticket Establishment
+
+       struct {
+           uint32 ticket_lifetime;
+           uint32 ticket_age_add;
+           opaque ticket_nonce<1..255>;
+           opaque ticket<1..2^16-1>;
+           Extension extensions<0..2^16-2>;
+       } NewSessionTicket;
+
+ticket_lifetime
+: Indicates the lifetime in seconds as a 32-bit unsigned integer in
+  network byte order from the time of ticket issuance.
+  Servers MUST NOT use any value greater than 604800 seconds (7 days).
+  The value of zero indicates that the ticket should be discarded
+  immediately. Clients MUST NOT cache tickets for longer than
+  7 days, regardless of the ticket_lifetime, and MAY delete the ticket
+  earlier based on local policy. A server MAY treat a ticket as valid
+  for a shorter period of time than what is stated in the
+  ticket_lifetime.
+
+ticket_age_add
+: A securely generated, random 32-bit value that is used to obscure the age of
+  the ticket that the client includes in the "pre_shared_key" extension.
+  The client-side ticket age is added to this value modulo 2^32 to
+  obtain the value that is transmitted by the client.
+  The server MUST generate a fresh value for each ticket it sends.
+
+ticket_nonce
+: A per-ticket value that is unique across all tickets issued on this connection.
+
+ticket
+: The value of the ticket to be used as the PSK identity.
+  The ticket itself is an opaque label. It MAY either be a database
+  lookup key or a self-encrypted and self-authenticated value. Section
+  4 of {{RFC5077}} describes a recommended ticket construction mechanism.
+
+extensions
+: A set of extension values for the ticket. The "Extension"
+  format is defined in {{extensions}}. Clients MUST ignore
+  unrecognized extensions.
+{:br }
+
+The sole extension currently defined for NewSessionTicket is
+"early_data", indicating that the ticket may be used to send 0-RTT data
+({{early-data-indication}})). It contains the following value:
+
+max_early_data_size
+: The maximum amount of 0-RTT data that the client is allowed to send when using
+  this ticket, in bytes. Only Application Data payload (i.e., plaintext but
+  not padding or the inner content type byte) is counted. A server
+  receiving more than max_early_data_size bytes of 0-RTT data
+  SHOULD terminate the connection with an "unexpected_message" alert.
+  Note that servers that reject early data due to lack of cryptographic material
+  will be unable to differentiate padding from content, so clients SHOULD NOT
+  depend on being able to send large quantities of padding in early data records.
+{:br }
+
+The PSK associated with the ticket is computed as:
+
+~~~~
+    HKDF-Expand-Label(resumption_master_secret,
+                     "resumption", ticket_nonce, Hash.length)
+~~~~
+
+Because the ticket_nonce value is distinct for each NewSessionTicket
+message, a different PSK will be derived for each ticket.
+
+Note that in principle it is possible to continue issuing new tickets
+which indefinitely extend the lifetime of the keying
+material originally derived from an initial non-PSK handshake (which
+was most likely tied to the peer's certificate). It is RECOMMENDED
+that implementations place limits on the total lifetime of such keying
+material; these limits should take into account the lifetime of the
+peer's certificate, the likelihood of intervening revocation,
+and the time since the peer's online CertificateVerify signature.
+
+### Post-Handshake Authentication
+
+When the client has sent the "post_handshake_auth" extension (see
+{{post_handshake_auth}}), a server MAY request client authentication at any time
+after the handshake has completed by sending a CertificateRequest message. The
+client MUST respond with the appropriate Authentication messages (see
+{{authentication-messages}}). If the client chooses to authenticate, it MUST
+send Certificate, CertificateVerify, and Finished. If it declines, it MUST send
+a Certificate message containing no certificates followed by Finished.
+All of the client's messages for a given response
+MUST appear consecutively on the wire with no intervening messages of other types.
+
+A client that receives a CertificateRequest message without having sent
+the "post_handshake_auth" extension MUST send an "unexpected_message" fatal
+alert.
+
+Note: Because client authentication could involve prompting the user, servers
+MUST be prepared for some delay, including receiving an arbitrary number of
+other messages between sending the CertificateRequest and receiving a
+response. In addition, clients which receive multiple CertificateRequests in
+close succession MAY respond to them in a different order than they were
+received (the certificate_request_context value allows the server to
+disambiguate the responses).
+
+
+### Key and IV Update {#key-update}
+
+%%% Updating Keys
+
+       enum {
+           update_not_requested(0), update_requested(1), (255)
+       } KeyUpdateRequest;
+
+       struct {
+           KeyUpdateRequest request_update;
+       } KeyUpdate;
+
+
+request_update
+: Indicates whether the recipient of the KeyUpdate should respond with its
+  own KeyUpdate. If an implementation receives any other value, it MUST
+  terminate the connection with an "illegal_parameter" alert.
+{:br }
+
+The KeyUpdate handshake message is used to indicate that the sender is
+updating its sending cryptographic keys. This message can be sent by
+either peer after it has sent a Finished message.
+Implementations that receive a KeyUpdate message prior to receiving a Finished message
+MUST terminate the connection with an "unexpected_message" alert.
+After sending a KeyUpdate message, the sender SHALL send all its traffic using the
+next generation of keys, computed as described in {{updating-traffic-keys}}.
+Upon receiving a KeyUpdate, the receiver MUST update its receiving keys.
+
+If the request_update field is set to "update_requested" then the receiver MUST
+send a KeyUpdate of its own with request_update set to "update_not_requested" prior
+to sending its next application data record. This mechanism allows either side to force an update to the
+entire connection, but causes an implementation which
+receives multiple KeyUpdates while it is silent to respond with
+a single update. Note that implementations may receive an arbitrary
+number of messages between sending a KeyUpdate with request_update set
+to update_requested and receiving the
+peer's KeyUpdate, because those messages may already be in flight.
+However, because send and receive keys are derived from independent
+traffic secrets, retaining the receive traffic secret does not threaten
+the forward secrecy of data sent before the sender changed keys.
+
+If implementations independently send their own KeyUpdates with
+request_update set to "update_requested", and they cross in flight, then each side
+will also send a response, with the result that each side increments
+by two generations.
+
+Both sender and receiver MUST encrypt their KeyUpdate
+messages with the old keys. Additionally, both sides MUST enforce that
+a KeyUpdate with the old key is received before accepting any messages
+encrypted with the new key. Failure to do so may allow message truncation
+attacks.
+
+
+#  Record Protocol
+
+The TLS record protocol takes messages to be transmitted, fragments
+the data into manageable blocks, protects the records, and transmits
+the result. Received data is verified, decrypted, reassembled, and
+then delivered to higher-level clients.
+
+TLS records are typed, which allows multiple higher-level protocols to
+be multiplexed over the same record layer. This document specifies
+three content types: handshake, application data, and alert.
+Implementations MUST NOT send record types not defined in this
+document unless negotiated by some extension. If a TLS implementation
+receives an unexpected record type, it MUST terminate the connection
+with an "unexpected_message" alert.  New record content type values are
+assigned by IANA in the TLS Content Type Registry as described in
+{{iana-considerations}}.
+
+
+## Record Layer
+
+The record layer fragments information blocks into TLSPlaintext
+records carrying data in chunks of 2^14 bytes or less. Message
+boundaries are handled differently depending on the underlying
+ContentType. Any future content types MUST specify appropriate
+rules.
+Note that these rules are stricter than what was enforced in TLS 1.2.
+
+Handshake messages MAY be coalesced into a single TLSPlaintext
+record or fragmented across several records, provided that:
+
+- Handshake messages MUST NOT be interleaved with other record
+  types. That is, if a handshake message is split over two or more
+  records, there MUST NOT be any other records between them.
+
+- Handshake messages MUST NOT span key changes. Implementations MUST verify that
+  all messages immediately preceding a key change align with a record boundary;
+  if not, then they MUST terminate the connection with an "unexpected_message"
+  alert. Because the ClientHello, EndOfEarlyData, ServerHello, Finished, and
+  KeyUpdate messages can immediately precede a key change, implementations MUST
+  send these messages in alignment with a record boundary.
+
+Implementations MUST NOT send zero-length fragments of Handshake
+types, even if those fragments contain padding.
+
+Alert messages ({{alert-protocol}}) MUST NOT be fragmented across
+records and multiple Alert messages MUST NOT be coalesced into a
+single TLSPlaintext record. In other words, a record with an Alert
+type MUST contain exactly one message.
+
+Application Data messages contain data that is opaque to
+TLS. Application Data messages are always protected. Zero-length
+fragments of Application Data MAY be sent as they are potentially
+useful as a traffic analysis countermeasure.
+
+
+%%% Record Layer
+
+       enum {
+           invalid(0),
            change_cipher_spec_RESERVED(20),
            alert(21),
            handshake(22),
-           application_data(23)
+           application_data(23),
            (255)
        } ContentType;
 
        struct {
            ContentType type;
-           ProtocolVersion record_version = { 3, 1 };    /* TLS v1.x */
+           ProtocolVersion legacy_record_version;
            uint16 length;
            opaque fragment[TLSPlaintext.length];
        } TLSPlaintext;
@@ -1026,275 +3853,322 @@ Alert messages {{alert-protocol}} MUST NOT be fragmented across records.
 type
 : The higher-level protocol used to process the enclosed fragment.
 
-record_version
-: The protocol version the current record is compatible with.
-  This value MUST be set to { 3, 1 } for all records.
+legacy_record_version
+: This value MUST be set to 0x0301 for all records generated by a
+  TLS 1.3 implementation.
   This field is deprecated and MUST be ignored for all purposes.
+  Previous versions of TLS would use other values in this field
+  under some circumstances.
 
 length
-: The length (in bytes) of the following TLSPlaintext.fragment.  The
-  length MUST NOT exceed 2^14.
+: The length (in bytes) of the following TLSPlaintext.fragment. The
+  length MUST NOT exceed 2^14 bytes. An endpoint that receives a record
+  that exceeds this length MUST terminate the connection with a
+  "record_overflow" alert.
 
 fragment
-: The application data.  This data is transparent and treated as an
+: The data being transmitted. This value is transparent and is treated as an
   independent block to be dealt with by the higher-level protocol
   specified by the type field.
 {:br }
 
-This document describes TLS Version 1.3, which uses the version { 3, 4 }.
-The version value 3.4 is historical, deriving from the use of { 3, 1 }
-for TLS 1.0 and { 3, 0 } for SSL 3.0. In order to maximize backwards
+This document describes TLS 1.3, which uses the version 0x0304.
+This version value is historical, deriving from the use of 0x0301
+for TLS 1.0 and 0x0300 for SSL 3.0. In order to maximize backwards
 compatibility, the record layer version identifies as simply TLS 1.0.
-Endpoints supporting other versions negotiate the version to use
+Endpoints supporting multiple versions negotiate the version to use
 by following the procedure and requirements in {{backward-compatibility}}.
-
-Implementations MUST NOT send zero-length fragments of Handshake or
-Alert types, even if those fragments contain padding. Zero-length
-fragments of Application data MAY be sent as they are potentially
-useful as a traffic analysis countermeasure.
 
 When record protection has not yet been engaged, TLSPlaintext
 structures are written directly onto the wire. Once record protection
 has started, TLSPlaintext records are protected and sent as
 described in the following section.
 
-###  Record Payload Protection
+## Record Payload Protection
 
 The record protection functions translate a TLSPlaintext structure into a
-TLSCiphertext. The deprotection functions reverse the process. In TLS 1.3
+TLSCiphertext. The deprotection functions reverse the process. In TLS 1.3,
 as opposed to previous versions of TLS, all ciphers are modeled as
 "Authenticated Encryption with Additional Data" (AEAD) {{RFC5116}}.
-AEAD functions provide a unified encryption and authentication
+AEAD functions provide an unified encryption and authentication
 operation which turns plaintext into authenticated ciphertext and
-back again.
-
-AEAD ciphers take as input a single key, a nonce, a plaintext, and "additional
-data" to be included in the authentication check, as described in Section 2.1
-of {{RFC5116}}. The key is either the client_write_key or the server_write_key
-and in TLS 1.3 the additional data input is empty (zero length).
+back again. Each encrypted record consists of a plaintext header followed
+by an encrypted body, which itself contains a type and optional padding.
 
 %%% Record Layer
+
        struct {
-           ContentType opaque_type = application_data(23); /* see fragment.type */
-           ProtocolVersion record_version = { 3, 1 };    /* TLS v1.x */
+           opaque content[TLSPlaintext.length];
+           ContentType type;
+           uint8 zeros[length_of_padding];
+       } TLSInnerPlaintext;
+
+       struct {
+           ContentType opaque_type = 23; /* application_data */
+           ProtocolVersion legacy_record_version = 0x0301; /* TLS v1.x */
            uint16 length;
-           aead-ciphered struct {
-              opaque content[TLSPlaintext.length];
-              ContentType type;
-              uint8 zeros[length_of_padding];
-           } fragment;
+           opaque encrypted_record[length];
        } TLSCiphertext;
 
-opaque_type
-: The outer opaque_type field of a TLSCiphertext record is always set to the
-  value 23 (application_data) for outward compatibility with
-  middleboxes used to parsing previous versions of TLS.  The
-  actual content type of the record is found in fragment.type after
-  decryption.
+content
+: The byte encoding of a handshake or an alert message, or the raw bytes of
+  the application's data to send.
 
-record_version
-: The record_version field is identical to TLSPlaintext.record_version and is always { 3, 1 }.
-  Note that the handshake protocol including the ClientHello and ServerHello messages authenticates
-  the protocol version, so this value is redundant.
+type
+: The content type of the record.
 
-length
-: The length (in bytes) of the following TLSCiphertext.fragment.  The length
-  MUST NOT exceed 2^14 + 256.  An endpoint that receives a record that exceeds
-  this length MUST generate a fatal "record_overflow" alert.
-
-fragment.content
-: The cleartext of TLSPlaintext.fragment.
-
-fragment.type
-: The actual content type of the record.
-
-fragment.zeros
+zeros
 : An arbitrary-length run of zero-valued bytes may
   appear in the cleartext after the type field.  This provides an
   opportunity for senders to pad any TLS record by a chosen amount as
   long as the total stays within record size limits.  See
   {{record-padding}} for more details.
 
-fragment
-: The AEAD encrypted form of TLSPlaintext.fragment + TLSPlaintext.type + zeros,
-  where "+" denotes concatenation.
+opaque_type
+: The outer opaque_type field of a TLSCiphertext record is always set to the
+  value 23 (application_data) for outward compatibility with
+  middleboxes accustomed to parsing previous versions of TLS.  The
+  actual content type of the record is found in TLSInnerPlaintext.type after
+  decryption.
+
+legacy_record_version
+: The legacy_record_version field is always 0x0301.  TLS 1.3 TLSCiphertexts
+  are not generated until after TLS 1.3 has been negotiated, so there are
+  no historical compatibility concerns where other values might be received.
+  Implementations MAY verify that the legacy_record_version field is 0x0301
+  and abort the connection if it is not.
+  Note that the handshake protocol including the ClientHello and ServerHello
+  messages authenticates the protocol version, so this value is redundant.
+
+length
+: The length (in bytes) of the following TLSCiphertext.encrypted_record, which
+  is the sum of the lengths of the content and the padding, plus one
+  for the inner content type, plus any expansion added by the AEAD algorithm.
+  The length MUST NOT exceed 2^14 + 256 bytes.
+  An endpoint that receives a record that exceeds this length MUST
+  terminate the connection with a "record_overflow" alert.
+
+encrypted_record
+: The AEAD-encrypted form of the serialized TLSInnerPlaintext structure.
 {:br }
 
 
-The length of the per-record nonce (iv_length) is set to max(8 bytes,
-N_MIN) for the AEAD algorithm (see {{RFC5116}} Section 4). An AEAD
-algorithm where N_MAX is less than 8 bytes MUST NOT be used with TLS.
-The per-record nonce for the AEAD construction is formed as follows:
+AEAD algorithms take as input a single key, a nonce, a plaintext, and "additional
+data" to be included in the authentication check, as described in Section 2.1
+of {{RFC5116}}. The key is either the client_write_key or the server_write_key,
+the nonce is derived from the sequence number (see {{nonce}}) and the
+client_write_iv or server_write_iv, and the additional data input is empty
+(zero length).  Derivation of traffic keys is defined in {{traffic-key-calculation}}.
 
-  1. The 64-bit record sequence number is padded to the left with zeroes
-     to iv_length.
+The plaintext input to the AEAD algorithm is the encoded TLSInnerPlaintext structure.
 
-  2. The padded sequence number is XORed with the static client_write_iv
-     or server_write_iv, depending on the role.
-
-The resulting quantity (of length iv_length) is used as the per-record
-nonce.
-
-Note: This is a different construction from that in TLS 1.2, which
-specified a partially explicit nonce.
-
-The plaintext is the concatenation of TLSPlaintext.fragment and TLSPlaintext.type.
-
-The AEAD output consists of the ciphertext output by the AEAD
-encryption operation. The length of the plaintext is greater than
-TLSPlaintext.length due to the inclusion of TLSPlaintext.type and
-however much padding is supplied by the sender.  The length of
-aead_output will generally be larger than the plaintext, but by an
-amount that varies with the AEAD cipher. Since the ciphers might
+The AEAD output consists of the ciphertext output from the AEAD
+encryption operation. The length of the plaintext is greater than the
+corresponding TLSPlaintext.length due to the inclusion of TLSInnerPlaintext.type and
+any padding supplied by the sender.  The length of the
+AEAD output will generally be larger than the plaintext, but by an
+amount that varies with the AEAD algorithm. Since the ciphers might
 incorporate padding, the amount of overhead could vary with different
 lengths of plaintext. Symbolically,
 
        AEADEncrypted =
-           AEAD-Encrypt(write_key, nonce, plaintext of fragment)
+           AEAD-Encrypt(write_key, nonce, plaintext)
 
 In order to decrypt and verify, the cipher takes as input the key,
 nonce, and the AEADEncrypted value. The output is either the plaintext
 or an error indicating that the decryption failed. There is no
 separate integrity check. That is:
 
-       plaintext of fragment =
-           AEAD-Decrypt(write_key, nonce, AEADEncrypted)
+       plaintext of encrypted_record =
+           AEAD-Decrypt(peer_write_key, nonce, AEADEncrypted)
 
-If the decryption fails, a fatal "bad_record_mac" alert MUST be generated.
+If the decryption fails, the receiver MUST terminate the connection
+with a "bad_record_mac" alert.
 
-An AEAD cipher MUST NOT produce an expansion of greater than 255
-bytes.  An endpoint that receives a record from its peer with
-TLSCipherText.length larger than 2^14 + 256 octets MUST generate a
-fatal "record_overflow" alert.  This limit is derived from the maximum
-TLSPlaintext length of 2^14 octets + 1 octet for ContentType + the
-maximum AEAD expansion of 255 octets.
+An AEAD algorithm used in TLS 1.3 MUST NOT produce an expansion greater than
+255 octets.  An endpoint that receives a record from its peer with
+TLSCiphertext.length larger than 2^14 + 256 octets MUST terminate
+the connection with a "record_overflow" alert.
+This limit is derived from the maximum TLSPlaintext length of
+2^14 octets + 1 octet for ContentType + the maximum AEAD expansion of 255 octets.
 
-### Record Padding
+
+## Per-Record Nonce {#nonce}
+
+A 64-bit sequence number is maintained separately for reading and writing
+records.  Each sequence number is set to zero at the beginning of a connection
+and whenever the key is changed.
+
+The appropriate sequence number is incremented by one after reading
+or writing each record. The first record transmitted under a particular
+traffic key MUST use sequence number 0.
+
+Because the size of sequence numbers is 64-bit, they should not
+wrap. If a TLS implementation would need to
+wrap a sequence number, it MUST either re-key ({{key-update}}) or
+terminate the connection.
+
+Each AEAD algorithm will specify a range of possible lengths for the
+per-record nonce, from N_MIN bytes to N_MAX bytes of input ({{RFC5116}}).
+The length of the TLS per-record nonce (iv_length) is set to the larger of
+8 bytes and N_MIN for the AEAD algorithm (see {{RFC5116}} Section 4).
+An AEAD algorithm where N_MAX is less than 8 bytes MUST NOT be used with TLS.
+The per-record nonce for the AEAD construction is formed as follows:
+
+  1. The 64-bit record sequence number is encoded in network byte order
+     and padded to the left with zeros to iv_length.
+
+  2. The padded sequence number is XORed with the static client_write_iv
+     or server_write_iv, depending on the role.
+
+The resulting quantity (of length iv_length) is used as the per-record nonce.
+
+Note: This is a different construction from that in TLS 1.2, which
+specified a partially explicit nonce.
+
+
+## Record Padding
 
 All encrypted TLS records can be padded to inflate the size of the
-TLSCipherText.  This allows the sender to hide the size of the
+TLSCiphertext.  This allows the sender to hide the size of the
 traffic from an observer.
 
-When generating a TLSCiphertext record, implementations MAY choose to
-pad.  An unpadded record is just a record with a padding length of
-zero.  Padding is a string of zero-valued bytes appended
-to the ContentType field before encryption.  Implementations MUST set
-the padding octets to all zeros before encrypting.
+When generating a TLSCiphertext record, implementations MAY choose to pad.
+An unpadded record is just a record with a padding length of zero.
+Padding is a string of zero-valued bytes appended to the ContentType
+field before encryption.  Implementations MUST set the padding octets
+to all zeros before encrypting.
 
-Application Data records may contain a zero-length fragment.content if
+Application Data records may contain a zero-length TLSInnerPlaintext.content if
 the sender desires.  This permits generation of plausibly-sized cover
 traffic in contexts where the presence or absence of activity may be
 sensitive.  Implementations MUST NOT send Handshake or Alert records
-that have a zero-length fragment.content.
+that have a zero-length TLSInnerPlaintext.content; if such a message
+is received, the receiving implementation MUST terminate the connection
+with an "unexpected_message" alert.
 
 The padding sent is automatically verified by the record protection
-mechanism: Upon successful decryption of a TLSCiphertext.fragment,
+mechanism; upon successful decryption of a TLSCiphertext.encrypted_record,
 the receiving implementation scans the field from the end toward the
 beginning until it finds a non-zero octet. This non-zero octet is the
 content type of the message.
-
-Implementations MUST limit their scanning to the cleartext returned
-from the AEAD decryption.  If a receiving implementation does not find
-a non-zero octet in the cleartext, it should treat the record as
-having an unexpected ContentType, sending an "unexpected_message"
-alert.
-
-The presence of padding does not change the overall record size
-limitations -- the full fragment plaintext may not exceed 2^14 octets.
-
-Versions of TLS prior to 1.3 had limited support for padding.  This
-padding scheme was selected because it allows padding of any encrypted
+This padding scheme was selected because it allows padding of any encrypted
 TLS record by an arbitrary size (from zero up to TLS record size
 limits) without introducing new content types.  The design also
 enforces all-zero padding octets, which allows for quick detection of
 padding errors.
 
+Implementations MUST limit their scanning to the cleartext returned
+from the AEAD decryption.  If a receiving implementation does not find
+a non-zero octet in the cleartext, it MUST terminate the
+connection with an "unexpected_message" alert.
+
+The presence of padding does not change the overall record size limitations
+- the full encoded TLSInnerPlaintext MUST not exceed 2^14 octets. If the maximum
+fragment length is reduced, as for example by the max_fragment_length extension
+from [RFC6066], then the reduced limit applies to the full plaintext,
+including the padding.
+
 Selecting a padding policy that suggests when and how much to pad is a
-complex topic, and is beyond the scope of this specification. If the
-application layer protocol atop TLS permits padding, it may be
+complex topic and is beyond the scope of this specification. If the
+application layer protocol on top of TLS has its own padding, it may be
 preferable to pad application_data TLS records within the application
 layer.  Padding for encrypted handshake and alert TLS records must
 still be handled at the TLS layer, though.  Later documents may define
-padding selection algorithms, or define a padding policy request
+padding selection algorithms or define a padding policy request
 mechanism through TLS extensions or some other means.
 
-#  The TLS Handshaking Protocols
 
-TLS has three subprotocols that are used to allow peers to agree upon security
-parameters for the record layer, to authenticate themselves, to instantiate
-negotiated security parameters, and to report error conditions to each other.
+## Limits on Key Usage
 
-The TLS Handshake Protocol is responsible for negotiating a session, which consists
-of the following items:
+There are cryptographic limits on the amount of plaintext which can be
+safely encrypted under a given set of keys.  {{AEAD-LIMITS}} provides
+an analysis of these limits under the assumption that the underlying
+primitive (AES or ChaCha20) has no weaknesses. Implementations SHOULD
+do a key update as described in {{key-update}} prior to reaching these limits.
 
-peer certificate
-: X509v3 {{RFC5280}} certificate of the peer.  This element of the state
-  may be null.
+For AES-GCM, up to 2^24.5 full-size records (about 24 million)
+may be encrypted on a given connection while keeping a safety
+margin of approximately 2^-57 for Authenticated Encryption (AE) security.
+For ChaCha20/Poly1305, the record sequence number would wrap before the
+safety limit is reached.
 
-cipher spec
-: Specifies the authentication and key establishment algorithms,
-  the hash for use with HKDF to generate keying
-  material, and the record protection algorithm (See
-  {{the-security-parameters}} for formal definition.)
+#  Alert Protocol
 
-resumption master secret
-: a secret shared between the client and server that can be used
-  as a PSK in future connections.
-{:br }
+One of the content types supported by the TLS record layer is the
+alert type.  Like other messages, alert messages are encrypted as
+specified by the current connection state.
 
-These items are then used to create security parameters for use by the record
-layer when protecting application data. Many connections can be instantiated
-using the same session using a PSK established in an initial handshake.
+Alert messages convey a description of the alert and a legacy field
+that conveyed the severity of the message in previous versions of
+TLS.  In TLS 1.3, the severity is implicit in the type of alert
+being sent, and the 'level' field can safely be ignored. The "close_notify" alert
+is used to indicate orderly closure of the connection.
+Upon receiving such an alert, the TLS implementation SHOULD
+indicate end-of-data to the application.
 
+Error alerts indicate abortive closure of the
+connection (see {{error-alerts}}). Upon receiving an error alert,
+the TLS implementation SHOULD indicate an error to the application and
+MUST NOT allow any further data to be sent or received on the
+connection.  Servers and clients MUST forget keys and secrets
+associated with a failed connection. Stateful implementations of
+tickets (as in many clients) SHOULD discard tickets associated
+with failed connections.
 
-##  Alert Protocol
+All the alerts listed in {{error-alerts}} MUST be sent as fatal and
+MUST be treated as fatal regardless of the AlertLevel in the
+message. Unknown alert types MUST be treated as fatal.
 
-One of the content types supported by the TLS record layer is the alert type.
-Alert messages convey the severity of the message (warning or fatal) and a
-description of the alert. Alert messages with a level of fatal result in the
-immediate termination of the connection. In this case, other connections
-corresponding to the session may continue, but the session identifier MUST be
-invalidated, preventing the failed session from being used to establish new
-connections. Like other messages, alert messages are encrypted
-as specified by the current connection state.
+Note: TLS defines two generic alerts (see {{alert-protocol}}) to use
+upon failure to parse a message. Peers which receive a message which
+cannot be parsed according to the syntax (e.g., have a length
+extending beyond the message boundary or contain an out-of-range
+length) MUST terminate the connection with a "decode_error"
+alert. Peers which receive a message which is syntactically correct
+but semantically invalid (e.g., a DHE share of p - 1, or an invalid
+enum) MUST terminate the connection with an "illegal_parameter" alert.
+
 
 %%% Alert Messages
+
        enum { warning(1), fatal(2), (255) } AlertLevel;
 
        enum {
            close_notify(0),
-           end_of_early_data(1),
-           unexpected_message(10),               /* fatal */
-           bad_record_mac(20),                   /* fatal */
-           decryption_failed_RESERVED(21),       /* fatal */
-           record_overflow(22),                  /* fatal */
-           decompression_failure_RESERVED(30),   /* fatal */
-           handshake_failure(40),                /* fatal */
-           no_certificate_RESERVED(41),          /* fatal */
+           unexpected_message(10),
+           bad_record_mac(20),
+           decryption_failed_RESERVED(21),
+           record_overflow(22),
+           decompression_failure_RESERVED(30),
+           handshake_failure(40),
+           no_certificate_RESERVED(41),
            bad_certificate(42),
            unsupported_certificate(43),
            certificate_revoked(44),
            certificate_expired(45),
            certificate_unknown(46),
-           illegal_parameter(47),                /* fatal */
-           unknown_ca(48),                       /* fatal */
-           access_denied(49),                    /* fatal */
-           decode_error(50),                     /* fatal */
-           decrypt_error(51),                    /* fatal */
-           export_restriction_RESERVED(60),      /* fatal */
-           protocol_version(70),                 /* fatal */
-           insufficient_security(71),            /* fatal */
-           internal_error(80),                   /* fatal */
-           inappropriate_fallback(86),           /* fatal */
+           illegal_parameter(47),
+           unknown_ca(48),
+           access_denied(49),
+           decode_error(50),
+           decrypt_error(51),
+           export_restriction_RESERVED(60),
+           protocol_version(70),
+           insufficient_security(71),
+           internal_error(80),
+           inappropriate_fallback(86),
            user_canceled(90),
-           no_renegotiation_RESERVED(100),       /* fatal */
-           missing_extension(109),               /* fatal */
-           unsupported_extension(110),           /* fatal */
+           no_renegotiation_RESERVED(100),
+           missing_extension(109),
+           unsupported_extension(110),
            certificate_unobtainable(111),
            unrecognized_name(112),
-           bad_certificate_status_response(113), /* fatal */
-           bad_certificate_hash_value(114),      /* fatal */
+           bad_certificate_status_response(113),
+           bad_certificate_hash_value(114),
            unknown_psk_identity(115),
+           certificate_required(116),
+           no_application_protocol(120),
            (255)
        } AlertDescription;
 
@@ -1303,25 +4177,16 @@ as specified by the current connection state.
            AlertDescription description;
        } Alert;
 
-###  Closure Alerts
+
+##  Closure Alerts
 
 The client and the server must share knowledge that the connection is ending in
-order to avoid a truncation attack. Failure to properly close a connection does
-not prohibit a session from being resumed.
+order to avoid a truncation attack.
 
 close_notify
 : This alert notifies the recipient that the sender will not send
   any more messages on this connection. Any data received after a
   closure MUST be ignored.
-
-end_of_early_data
-: This alert is sent by the client to indicate that all 0-RTT
-  application_data messages have been transmitted and that the
-  next message will be handshake message protected with the
-  1-RTT handshake keys. This alert MUST be at the warning level.
-  Servers MUST NOT send this alert and clients receiving this
-  alert MUST terminate the connection with an "unexpected_message"
-  alert.
 
 user_canceled
 : This alert notifies the recipient that the sender is canceling the
@@ -1332,7 +4197,7 @@ user_canceled
 {:br }
 
 Either party MAY initiate a close by sending a "close_notify" alert. Any data
-received after a closure alert is ignored. If a transport-level close is
+received after a closure alert MUST be ignored. If a transport-level close is
 received prior to a "close_notify", the receiver cannot know that all the
 data that was sent has been received.
 
@@ -1345,9 +4210,9 @@ read side of the connection.
 
 If the application protocol using TLS provides that any data may be carried
 over the underlying transport after the TLS connection is closed, the TLS
-implementation must receive the responding "close_notify" alert before indicating
+implementation MUST receive the responding "close_notify" alert before indicating
 to the application layer that the TLS connection has ended. If the application
-protocol will not transfer any additional data, but will only close the
+protocol will not transfer any additional data but will only close the
 underlying transport connection, then the implementation MAY choose to close
 the transport without waiting for the responding "close_notify". No part of this
 standard should be taken to dictate the manner in which a usage profile for TLS
@@ -1356,62 +4221,56 @@ manages its data transport, including when connections are opened or closed.
 Note: It is assumed that closing a connection reliably delivers pending data
 before destroying the transport.
 
-###  Error Alerts
 
-Error handling in the TLS Handshake Protocol is very simple. When an error is
-detected, the detecting party sends a message to its peer. Upon
-transmission or receipt of a fatal alert message, both parties immediately
-close the connection. Servers and clients MUST forget any session-identifiers,
-keys, and secrets associated with a failed connection. Thus, any connection
-terminated with a fatal alert MUST NOT be resumed.
+##  Error Alerts
 
-Whenever an implementation encounters a condition which is defined as a fatal
-alert, it MUST send the appropriate alert prior to closing the connection. For
-all errors where an alert level is not explicitly specified, the sending party
-MAY determine at its discretion whether to treat this as a fatal error or not.
-If the implementation chooses to send an alert but intends to close the
-connection immediately afterwards, it MUST send that alert at the fatal alert
-level.
+Error handling in the TLS Handshake Protocol is very simple. When an
+error is detected, the detecting party sends a message to its
+peer. Upon transmission or receipt of a fatal alert message, both
+parties MUST immediately close the connection.
 
-If an alert with a level of warning is sent and received, generally the
-connection can continue normally. If the receiving party decides not to proceed
-with the connection (e.g., after having received a "user_canceled" alert that
-it is not willing to accept), it SHOULD send a fatal alert to terminate the
-connection. Given this, the sending peer cannot, in general, know how the
-receiving party will behave. Therefore, warning alerts are not very useful when
-the sending party wants to continue the connection, and thus are sometimes
-omitted. For example, if a party decides to accept an expired certificate
-(perhaps after confirming this with the user) and wants to continue the
-connection, it would not generally send a "certificate_expired" alert.
+Whenever an implementation encounters a fatal error condition, it
+SHOULD send an appropriate fatal alert and MUST close the connection
+without sending or receiving any additional data. In the rest of this
+specification, when the phrases "terminate the connection" and "abort the
+handshake" are used without a specific alert it means that the
+implementation SHOULD send the alert indicated by the descriptions
+below. The phrases "terminate the connection with a X alert" and
+"abort the handshake with a X alert" mean that the implementation
+MUST send alert X if it sends any alert. All
+alerts defined in this section below, as well as all unknown alerts,
+are universally considered fatal as of TLS 1.3 (see {{alert-protocol}}).
+The implementation SHOULD provide a way to facilitate logging
+the sending and receiving of alerts.
 
 The following error alerts are defined:
 
 unexpected_message
-: An inappropriate message was received.  This alert is always fatal
-  and should never be observed in communication between proper
-  implementations.
+: An inappropriate message (e.g., the wrong handshake message, premature
+  application data, etc.) was received. This alert should never be
+  observed in communication between proper implementations.
 
 bad_record_mac
 : This alert is returned if a record is received which cannot be
   deprotected. Because AEAD algorithms combine decryption and
-  verification, this alert is used for all deprotection failures.
-  This alert is always fatal and should never be observed in
-  communication between proper implementations (except when messages
-  were corrupted in the network).
+  verification, and also to avoid side channel attacks,
+  this alert is used for all deprotection failures.
+  This alert should never be observed in communication between
+  proper implementations, except when messages were corrupted
+  in the network.
 
 record_overflow
 : A TLSCiphertext record was received that had a length more than
   2^14 + 256 bytes, or a record decrypted to a TLSPlaintext record
-  with more than 2^14 bytes.  This alert is always fatal and
-  should never be observed in communication between proper
-  implementations (except when messages were corrupted in the
-  network).
+  with more than 2^14 bytes.
+  This alert should never be observed in communication between
+  proper implementations, except when messages were corrupted
+  in the network.
 
 handshake_failure
-: Reception of a "handshake_failure" alert message indicates that the
+: Receipt of a "handshake_failure" alert message indicates that the
   sender was unable to negotiate an acceptable set of security
   parameters given the options available.
-  This alert is always fatal.
 
 bad_certificate
 : A certificate was corrupt, contained signatures that did not
@@ -1431,2263 +4290,315 @@ certificate_unknown
   certificate, rendering it unacceptable.
 
 illegal_parameter
-: A field in the handshake was out of range or inconsistent with
-  other fields.  This alert is always fatal.
+: A field in the handshake was incorrect or inconsistent with
+  other fields. This alert is used for errors which conform to
+  the formal protocol syntax but are otherwise incorrect.
 
 unknown_ca
 : A valid certificate chain or partial chain was received, but the
   certificate was not accepted because the CA certificate could not
-  be located or couldn't be matched with a known, trusted CA.  This
-  alert is always fatal.
+  be located or could not be matched with a known trust anchor.
 
 access_denied
 : A valid certificate or PSK was received, but when access control was
-  applied, the sender decided not to proceed with negotiation.  This
-  alert is always fatal.
+  applied, the sender decided not to proceed with negotiation.
 
 decode_error
 : A message could not be decoded because some field was out of the
-  specified range or the length of the message was incorrect.  This
-  alert is always fatal and should never be observed in
-  communication between proper implementations (except when messages
-  were corrupted in the network).
+  specified range or the length of the message was incorrect.
+  This alert is used for errors where the message does not conform
+  to the formal protocol syntax.
+  This alert should never be observed in communication between
+  proper implementations, except when messages were corrupted
+  in the network.
 
 decrypt_error
-: A handshake cryptographic operation failed, including being unable
-  to correctly verify a signature or validate a Finished message.
-  This alert is always fatal.
+: A handshake (not record-layer) cryptographic operation failed, including being unable
+  to correctly verify a signature or validate a Finished message
+  or a PSK binder.
 
 protocol_version
 : The protocol version the peer has attempted to negotiate is
-  recognized but not supported.  (For example, old protocol versions
-  might be avoided for security reasons.)  This alert is always
-  fatal.
+  recognized but not supported. (see {{backward-compatibility}})
 
 insufficient_security
 : Returned instead of "handshake_failure" when a negotiation has
-  failed specifically because the server requires ciphers more
-  secure than those supported by the client.  This alert is always
-  fatal.
+  failed specifically because the server requires parameters more
+  secure than those supported by the client.
 
 internal_error
 : An internal error unrelated to the peer or the correctness of the
   protocol (such as a memory allocation failure) makes it impossible
-  to continue.  This alert is always fatal.
+  to continue.
 
 inappropriate_fallback
 : Sent by a server in response to an invalid connection retry attempt
-  from a client. (see [RFC7507]) This alert is always fatal.
+  from a client (see {{!RFC7507}}).
 
 missing_extension
 : Sent by endpoints that receive a hello message not containing an
-  extension that is mandatory to send for the offered TLS version.
-  This message is always fatal.
-[[TODO: IANA Considerations.]]
+  extension that is mandatory to send for the offered TLS version
+  or other negotiated parameters.
 
 unsupported_extension
 : Sent by endpoints receiving any hello message containing an extension
-  known to be prohibited for inclusion in the given hello message, including
-  any extensions in a ServerHello not first offered in the corresponding
-  ClientHello. This alert is always fatal.
+  known to be prohibited for inclusion in the given hello message, or including
+  any extensions in a ServerHello or Certificate not first offered in the
+  corresponding ClientHello.
 
 certificate_unobtainable
 : Sent by servers when unable to obtain a certificate from a URL
   provided by the client via the "client_certificate_url" extension
-  [RFC6066].
+  (see {{RFC6066}}).
 
 unrecognized_name
 : Sent by servers when no server exists identified by the name
   provided by the client via the "server_name" extension
-  [RFC6066].
+  (see {{RFC6066}}).
 
 bad_certificate_status_response
 : Sent by clients when an invalid or unacceptable OCSP response is
   provided by the server via the "status_request" extension
-  [RFC6066]. This alert is always fatal.
+  (see {{RFC6066}}).
 
 bad_certificate_hash_value
 : Sent by servers when a retrieved object does not have the correct hash
   provided by the client via the "client_certificate_url" extension
-  [RFC6066]. This alert is always fatal.
+  (see {{RFC6066}}).
 
 unknown_psk_identity
-: Sent by servers when a PSK cipher suite is selected but no
+: Sent by servers when PSK key establishment is desired but no
  acceptable PSK identity is provided by the client. Sending this alert
  is OPTIONAL; servers MAY instead choose to send a "decrypt_error"
  alert to merely indicate an invalid PSK identity.
- [[TODO: This doesn't really make sense with the current PSK
- negotiation scheme where the client provides multiple PSKs in
- flight 1. https://github.com/tlswg/tls13-spec/issues/230]]
+
+certificate_required
+: Sent by servers when a client certificate is desired but none was provided by
+  the client.
+
+no_application_protocol
+: Sent by servers when a client
+  "application_layer_protocol_negotiation" extension advertises
+  protocols that the server does not support
+  (see {{RFC7301}}).
 {:br }
 
 New Alert values are assigned by IANA as described in {{iana-considerations}}.
 
 
-##  Handshake Protocol Overview
-
-The cryptographic parameters of the session state are produced by the
-TLS Handshake Protocol, which operates on top of the TLS record
-layer. When a TLS client and server first start communicating, they
-agree on a protocol version, select cryptographic algorithms,
-optionally authenticate each other, and establish shared secret keying
-material.
-
-TLS supports three basic key exchange modes:
-
-- Diffie-Hellman (of both the finite field and elliptic curve
-  varieties).
-
-- A pre-shared symmetric key (PSK)
-
-- A combination of a symmetric key and Diffie-Hellman
-
-Which mode is used depends on the negotiated cipher suite. Conceptually,
-the handshake establishes three secrets which are used to derive all the
-keys.
-
-Ephemeral Secret (ES): A secret which is derived from fresh (EC)DHE
-   shares for this connection. Keying material derived from ES is
-   intended to be forward secret (with the exception of pre-shared
-   key only modes).
-
-Static Secret (SS): A secret which may be derived from static or
-   semi-static keying material, such as a pre-shared key or the
-   server's semi-static (EC)DH share.
-   
-Master Secret (SS): A secret derived from both the static 
-   and the ephemeral secret.
-
-In some cases, as with the DH handshake shown in {{tls-full}}, 
-ephemeral and shared
-secrets are the same, but having both allows for a uniform key
-derivation scheme for all cipher modes.
-
-The basic TLS Handshake for DH is shown in {{tls-full}}:
-
-~~~
-       Client                                               Server
-
-Key  / ClientHello
-Exch \  + key_share              -------->
-                                                       ServerHello  \ Key
-                                                       + key_share  / Exch
-                                             {EncryptedExtensions}  ^
-                                             {CertificateRequest*}  | Server
-                                            {ServerConfiguration*}  v Params
-                                                    {Certificate*}  ^
-                                              {CertificateVerify*}  | Auth
-                                 <--------              {Finished}  v
-     ^ {Certificate*}
-Auth | {CertificateVerify*}
-     v {Finished}                -------->
-       [Application Data]        <------->      [Application Data]
-
-              +  Indicates extensions sent in the
-                 previously noted message.
-
-              *  Indicates optional or situation-dependent
-                 messages that are not always sent.
-
-              {} Indicates messages protected using keys
-                 derived from the ephemeral secret.
-
-              [] Indicates messages protected using keys
-                 derived from the master secret.
-~~~
-{: #tls-full title="Message flow for full TLS Handshake"}
-
-The handshake can be thought of as having three phases, indicated
-in the diagram above.
-
-Key Exchange: establish shared keying material and select the
-   cryptographic parameters. Everything after this phase is
-   encrypted.
-
-Server Parameters: establish other handshake parameters
-(whether the client is authenticated, support for 0-RTT, etc.)
-
-Authentication: authenticate the server (and optionally the client)
-   and provide key confirmation and handshake integrity.
-
-In the Key Exchange phase, the client sends the ClientHello ({{client-hello}})
-message, which contains
-a random nonce (ClientHello.random), its offered protocol version,
-cipher suite, and extensions, and one or more Diffie-Hellman key
-shares in the "key_share" extension {{key-share}}.
-
-The server processes the ClientHello and determines the appropriate
-cryptographic parameters for the connection. It then responds with
-its own ServerHello which indicates the negotiated connection parameters. [{{server-hello}}]
-If DH is in use, this will contain a "key_share" extension with the
-server's ephemeral Diffie-Hellman share which MUST be in the same group
-as one of the shares offered by the client. The server's KeyShare and
-the client's KeyShare corresponding to the negotiated key exchange
-are used together to derive the Static Secret and Ephemeral
-Secret (in this mode they are the same).  [{{key-share}}]
-
-
-The server then sends three messages to establish the Server Parameters:
-
-EncryptedExtensions
-: responses to any extensions which are not required in order to
-  determine the cryptographic parameters. [{{encrypted-extensions}}]
-
-CertificateRequest
-: if certificate-based client authentication is desired, the
-  desired parameters for that certificate. This message will
-  be omitted if client authentication is not desired.
-  [[OPEN ISSUE: See https://github.com/tlswg/tls13-spec/issues/184]].
-  [{{certificate-request}}]
-
-ServerConfiguration
-: supplies a configuration for 0-RTT handshakes (see {{zero-rtt-exchange}}).
-[{{server-configuration}}]
-
-
-Finally, the client and server exchange Authentication messages. TLS
-uses the same set of messages every time that authentication is needed.
-Specifically:
-
-Certificate
-: the certificate of the endpoint. This message is omitted if certificate
-  authentication is not being used. [{{certificate}}]
-
-CertificateVerify
-: a signature over the entire handshake using the public key
-  in the Certificate message. This message will be omitted if the
-  server is not authenticating via a certificate. [{{certificate-verify}}]
-
-Finished
-: a MAC over the entire handshake. This message provides key confirmation, binds the endpoint's identity
-  to the exchanged keys, and in some modes (0-RTT and PSK)
-  also authenticates the handshake using the the Static Secret. [{{finished}}]
-{:br }
-
-Upon receiving the server's messages, the client responds with its Authentication
-messages, namely Certificate and CertificateVerify (if requested), and Finished.
-
-At this point, the handshake is complete, and the client and server may exchange
-application layer data. Application data MUST NOT be sent prior to sending the
-Finished message. Note that while the server may send application data
-prior to receiving the client's Authentication messages, any data sent at
-that point is of course being sent to an unauthenticated peer.
-
-[[TODO: Move this elsewhere?
-Note that higher layers should not be overly reliant on whether TLS always
-negotiates the strongest possible connection between two endpoints. There are a
-number of ways in which a man-in-the-middle attacker can attempt to make two
-entities drop down to the least secure method they support
-(i.e., perform a downgrade attack). The TLS protocol has
-been designed to minimize this risk, but there are still attacks available: for
-example, an attacker could block access to the port a secure service runs on,
-or attempt to get the peers to negotiate an unauthenticated connection. The
-fundamental rule is that higher levels must be cognizant of what their security
-requirements are and never transmit information over a channel less secure than
-what they require. The TLS protocol is secure in that any cipher suite offers
-its promised level of security: if you negotiate AES-GCM {{GCM}} with
-a 255-bit ECDHE key exchange with a host whose certificate
-chain you have verified, you can expect that to be reasonably "secure"
-against algorithmic attacks, at least in the year 2015.]]
-
-
-### Incorrect DHE Share
-
-If the client has not provided an appropriate "key_share" extension (e.g. it
-includes only DHE or ECDHE groups unacceptable or unsupported by the
-server), the server corrects the mismatch with a HelloRetryRequest and
-the client will need to restart the handshake with an appropriate
-KeyShare extension, as shown in Figure 2:
-
-~~~
-         Client                                               Server
-
-         ClientHello
-           + key_share             -------->
-                                   <--------       HelloRetryRequest
-
-         ClientHello
-           + key_share             -------->
-                                                         ServerHello
-                                                         + key_share
-                                               {EncryptedExtensions}
-                                               {CertificateRequest*}
-                                              {ServerConfiguration*}
-                                                      {Certificate*}
-                                                {CertificateVerify*}
-                                   <--------              {Finished}
-         {Certificate*}
-         {CertificateVerify*}
-         {Finished}                -------->
-         [Application Data]        <------->     [Application Data]
-~~~
-{: #tls-restart title="Message flow for a full handshake with mismatched parameters"}
-
-[[OPEN ISSUE: Should we restart the handshake hash?
-https://github.com/tlswg/tls13-spec/issues/104.]]
-[[OPEN ISSUE: We need to make sure that this flow doesn't introduce
-downgrade issues. Potential options include continuing the handshake
-hashes (as long as clients don't change their opinion of the server's
-capabilities with aborted handshakes) and requiring the client to send
-the same ClientHello (as is currently done) and then checking you get
-the same negotiated parameters.]]
-
-If no common cryptographic parameters can be negotiated, the server
-will send a "handshake_failure" or "insufficient_security" fatal alert
-(see {{alert-protocol}}).
-
-TLS also allows several optimized variants of the basic handshake, as
-described below.
-
-### Zero-RTT Exchange
-
-TLS 1.3 supports a "0-RTT" mode in which the client can both
-authenticate and send application on its first flight, thus reducing
-handshake latency. In order to enable this functionality, the server
-provides a ServerConfiguration message containing a long-term (EC)DH
-share. On future connections to the same server, the client can use
-that share to protect the first-flight data.
-
-~~~
-         Client                                               Server
-
-         ClientHello
-           + key_share
-           + early_data
-      ^  (Certificate*)
-0-RTT |  (CertificateVerify*)
-Data  |  (Finished)
-      v  (Application Data*)
-         (end_of_early_data)        -------->
-                                                         ServerHello
-                                                        + early_data
-                                                         + key_share
-                                               {EncryptedExtensions}
-                                               {CertificateRequest*}
-                                              {ServerConfiguration*}
-                                                      {Certificate*}
-                                                {CertificateVerify*}
-                                   <--------              {Finished}
-         {Certificate*}
-         {CertificateVerify*}
-         {Finished}                -------->
-
-         [Application Data]        <------->      [Application Data]
-
-               *  Indicates optional or situation-dependent
-                  messages that are not always sent.
-
-               () Indicates messages protected using keys
-                  derived from the static secret.
-
-               {} Indicates messages protected using keys
-                  derived from the ephemeral secret.
-
-               [] Indicates messages protected using keys
-                  derived from the master secret.
-~~~
-{: #tls-0-rtt title="Message flow for a zero round trip handshake"}
-
-As shown in {{tls-0-rtt}}, the Zero-RTT data is just added
-to the 1-RTT handshake in the first flight. Specifically, the
-client sends its Authentication messages after the ClientHello,
-followed by any application data. The rest of the handshake
-messages are the same as with {{tls-full}}. This implies
-that the server can request client authentication even if the
-client offers a certificate on its first flight. This
-is consistent with the server being
-able to ask for client authentication after the handshake is
-complete. See {{post-handshake-authentication}}.
-When offering PSK support, the PreSharedKeyExtension will be used
-instead of (or in addition to) the KeyShare extension as specified
-above.
-
-Note: because sequence numbers continue to increment between the
-initial (early) application data and the application data sent
-after the handshake has completed, an attacker cannot remove
-early application data messages.
-
-IMPORTANT NOTE: The security properties for 0-RTT data (regardless of
-the cipher suite) are weaker than those for other kinds of TLS data.
-Specifically:
-
-1. This data is not forward secret, because it is encrypted solely
-with the server's semi-static (EC)DH share.
-
-2. There are no guarantees of non-replay between connections.
-Unless the server takes special measures outside those provided by TLS (See
-{{replay-properties}}), the server has no guarantee that the same
-0-RTT data was not transmitted on multiple 0-RTT connections.
-This is especially relevant if the data is authenticated either
-with TLS client authentication or inside the application layer
-protocol. However, 0-RTT data cannot be duplicated within a connection (i.e., the server
-will not process the same data twice for the same connection) and also
-cannot be sent as if it were ordinary TLS data.
-
-3. If the server key is compromised, then the attacker can tamper with
-the 0-RTT data without detection. If the client's ephemeral share
-is compromised and client authentication is used, then the attacker
-can impersonate the client on subsequent connections.
-
-
-### Resumption and PSK
-
-Finally, TLS provides a pre-shared key (PSK) mode which allows a
-client and server who share an existing secret (e.g., a key
-established out of band) to establish a connection authenticated by
-that key. PSKs can also be established in a previous session and
-then reused ("session resumption"). Once a handshake has completed, the server can
-send the client a PSK identity which corresponds to a key derived from
-the initial handshake (See {{new-session-ticket-message}}). The client
-can then use that PSK identity in future handshakes to negotiate use
-of the PSK; if the server accepts it, then the security context of the
-original connection is tied to the new connection. In TLS 1.2 and
-below, this functionality was provided by "session resumption" and
-"session tickets" {{RFC5077}}. Both mechanisms are obsoleted in TLS
-1.3.
-
-PSK cipher suites can either use PSK in combination with
-an (EC)DHE exchange in order to provide forward secrecy in combination
-with shared keys, or can use PSKs alone, at the cost of losing forward
-secrecy.
-
-{{tls-resumption-psk}} shows a pair of handshakes in which the first establishes
-a PSK and the second uses it:
-
-~~~
-       Client                                               Server
-
-
-Initial Handshake:
-       ClientHello
-        + key_share              -------->
-                                                       ServerHello
-                                                       + key_share
-                                             {EncryptedExtensions}
-                                             {CertificateRequest*}
-                                            {ServerConfiguration*}
-                                                    {Certificate*}
-                                              {CertificateVerify*}
-                                 <--------              {Finished}
-       {Certificate*}
-       {CertificateVerify*}
-       {Finished}                -------->
-                                 <--------      [NewSessionTicket]
-       [Application Data]        <------->      [Application Data]
-
-
-Subsequent Handshake:
-       ClientHello
-         + key_share
-         + pre_shared_key        -------->
-                                                       ServerHello
-                                                  + pre_shared_key
-                                             {EncryptedExtensions}
-                                 <--------              {Finished}
-       {Finished}                -------->
-       [Application Data]        <------->      [Application Data]
-~~~
-{: #tls-resumption-psk title="Message flow for resumption and PSK"}
-
-As the server is authenticating via a PSK, it does not send a
-Certificate or a CertificateVerify. PSK-based resumption cannot be
-used to provide a new ServerConfiguration. Note that the client
-supplies a KeyShare to the server as well, which allows the
-server to decline resumption and fall back to a full handshake.
-
-The contents and significance of each message will be presented in detail in
-the following sections.
-
-
-##  Handshake Protocol
-
-The TLS Handshake Protocol is one of the defined higher-level clients of the
-TLS Record Protocol. This protocol is used to negotiate the secure attributes
-of a session. Handshake messages are supplied to the TLS record layer, where
-they are encapsulated within one or more TLSPlaintext or TLSCiphertext structures, which are
-processed and transmitted as specified by the current active session state.
-
-%%% Handshake Protocol
-       enum {
-           hello_request_RESERVED(0),
-           client_hello(1),
-           server_hello(2),
-           session_ticket(4),
-           hello_retry_request(6),
-           encrypted_extensions(8),
-           certificate(11),
-           server_key_exchange_RESERVED(12),
-           certificate_request(13),
-           server_hello_done_RESERVED(14),
-           certificate_verify(15),
-           client_key_exchange_RESERVED(16),
-           server_configuration(17),
-           finished(20),
-           key_update(24),
-           (255)
-       } HandshakeType;
-
-       struct {
-           HandshakeType msg_type;    /* handshake type */
-           uint24 length;             /* bytes in message */
-           select (HandshakeType) {
-               case client_hello:        ClientHello;
-               case server_hello:        ServerHello;
-               case hello_retry_request: HelloRetryRequest;
-               case encrypted_extensions: EncryptedExtensions;
-               case certificate_request: CertificateRequest;
-               case server_configuration:ServerConfiguration;
-               case certificate:         Certificate;
-               case certificate_verify:  CertificateVerify;
-               case finished:            Finished;
-               case session_ticket:      NewSessionTicket;
-               case key_update:          KeyUpdate;
-           } body;
-       } Handshake;
-
-The TLS Handshake Protocol messages are presented below in the order they
-MUST be sent; sending handshake messages in an unexpected order
-results in an "unexpected_message" fatal error. Unneeded handshake
-messages can be omitted, however.
-
-New handshake message types are assigned by IANA as described in
-{{iana-considerations}}.
-
-### Key Exchange Messages
-
-The key exchange messages are used to exchange security capabilities
-between the client and server and to establish the traffic keys used to protect
-the handshake and the data.
-
-####  Client Hello
-
-When this message will be sent:
-
-> When a client first connects to a server, it is required to send the
-ClientHello as its first message. The client will also send a
-ClientHello when the server has responded to its ClientHello with a
-ServerHello that selects cryptographic parameters that don't match the
-client's "key_share" extension. In that case, the client MUST send the same
-ClientHello (without modification) except including a new KeyShareEntry
-as the lowest priority share (i.e., appended to the list of shares in
-the KeyShare message). [[OPEN ISSUE: New random values? See:
-https://github.com/tlswg/tls13-spec/issues/185]]
-If a server receives a ClientHello at any other time, it MUST send
-a fatal "unexpected_message" alert and close the connection.
-
-Structure of this message:
-
-> The ClientHello message includes a random structure, which is used later in
-the protocol.
-
-%%% Key Exchange Messages
-       struct {
-           opaque random_bytes[32];
-       } Random;
-
-random_bytes
-: 32 bytes generated by a secure random number generator.
-  See {{implementation-notes}} for additional information.
-{:br }
-
-TLS 1.3 server implementations which respond to a ClientHello with a
-client_version indicating TLS 1.2 or below MUST set the first eight
-bytes of their Random value to the bytes:
-
-      44 4F 57 4E 47 52 44 01
-
-TLS 1.2 server implementations which respond to a ClientHello with a
-client_version indicating TLS 1.1 or below SHOULD set the first eight
-bytes of their Random value to the bytes:
-
-      44 4F 57 4E 47 52 44 00
-
-
-TLS 1.3 clients receiving a TLS 1.2 or below ServerHello MUST check
-that the top eight octets are not equal to either of these values. TLS
-1.2 clients SHOULD also perform this check if the ServerHello
-indicates TLS 1.1 or below. If a match is found the client MUST abort
-the handshake with a fatal "illegal_parameter" alert. This mechanism
-provides limited protection against downgrade attacks over and above
-that provided by the Finished exchange: because the ServerKeyExchange
-includes a signature over both random values, it is not possible for
-an active attacker to modify the randoms without detection as long as
-ephemeral ciphers are used. It does not provide downgrade protection
-when static RSA is used.
-
-Note: This is an update to TLS 1.2 so in practice many TLS 1.2 clients
-and servers will not behave as specified above.
-
-Note: Versions of TLS prior to TLS 1.3 used the top 32 bits of
-the Random value to encode the time since the UNIX epoch. The
-sentinel value above was selected to avoid conflicting with any
-valid TLS 1.2 Random value and to have a low (2^{-64})
-probability of colliding with randomly selected Random
-values.
-
-The cipher suite list, passed from the client to the server in the ClientHello
-message, contains the combinations of cryptographic algorithms supported by the
-client in order of the client's preference (favorite choice first). Each cipher
-suite defines a key exchange algorithm, a record protection algorithm (including
-secret key length) and a hash to be used with HKDF. The server will select a cipher
-suite or, if no acceptable choices are presented, return a "handshake_failure"
-alert and close the connection. If the list contains cipher suites the server
-does not recognize, support, or wish to use, the server MUST ignore those
-cipher suites, and process the remaining ones as usual.
-
-%%% Key Exchange Messages
-       uint8 CipherSuite[2];    /* Cryptographic suite selector */
-
-       struct {
-           ProtocolVersion client_version = { 3, 4 };    /* TLS v1.3 */
-           Random random;
-           opaque legacy_session_id<0..32>;
-           CipherSuite cipher_suites<2..2^16-2>;
-           opaque legacy_compression_methods<1..2^8-1>;
-           Extension extensions<0..2^16-1>;
-       } ClientHello;
-
-TLS allows extensions to follow the compression_methods field in an extensions
-block. The presence of extensions can be detected by determining whether there
-are bytes following the compression_methods at the end of the ClientHello. Note
-that this method of detecting optional data differs from the normal TLS method
-of having a variable-length field, but it is used for compatibility with TLS
-before extensions were defined.
-
-client_version
-: The version of the TLS protocol by which the client wishes to
-  communicate during this session.  This SHOULD be the latest
-  (highest valued) version supported by the client.  For this
-  version of the specification, the version will be { 3, 4 }. (See
-  {{backward-compatibility}} for details about backward compatibility.)
-
-random
-: A client-generated random structure.
-
-legacy_session_id
-: Versions of TLS before TLS 1.3 supported a session resumption
-  feature which has been merged with Pre-Shared Keys in this version
-  (see {{resumption-and-psk}}).
-  This field MUST be ignored by a server negotiating TLS 1.3 and
-  SHOULD be set as a zero length vector (i.e., a single zero byte
-  length field) by clients which do not have a cached session ID
-  set by a pre-TLS 1.3 server.
-
-cipher_suites
-: This is a list of the cryptographic options supported by the
-  client, with the client's first preference first.
-  Values are defined in {{cipher-suites}}.
-
-legacy_compression_methods
-: Versions of TLS before 1.3 supported compression and the list of
-  compression methods was supplied in this field. For any TLS 1.3
-  ClientHello, this vector MUST contain exactly one byte set to
-  zero, which corresponds to the "null" compression method in
-  prior versions of TLS. If a TLS 1.3 ClientHello is
-  received with any other value in this field, the server MUST
-  generate a fatal "illegal_parameter" alert. Note that TLS 1.3
-  servers might receive TLS 1.2 or prior ClientHellos which contain
-  other compression methods and MUST follow the procedures for
-  the appropriate prior version of TLS.
-
-extensions
-: Clients MAY request extended functionality from servers by sending
-  data in the extensions field.  The actual "Extension" format is
-  defined in {{hello-extensions}}.
-{:br }
-
-In the event that a client requests additional functionality using extensions,
-and this functionality is not supplied by the server, the client MAY abort the
-handshake. A server MUST accept ClientHello messages both with and without the
-extensions field, and (as for all other messages) it MUST check that the amount
-of data in the message precisely matches one of these formats; if not, then it
-MUST send a fatal "decode_error" alert.
-
-After sending the ClientHello message, the client waits for a ServerHello
-or HelloRetryRequest message.
-
-####  Server Hello
-
-When this message will be sent:
-
-> The server will send this message in response to a ClientHello message when
-it was able to find an acceptable set of algorithms and the client's
-KeyShare extension was acceptable. If the client proposed groups are not
-acceptable by the server, it will respond with a "handshake_failure" fatal alert.
-
-Structure of this message:
-
-%%% Key Exchange Messages
-       struct {
-           ProtocolVersion server_version;
-           Random random;
-           CipherSuite cipher_suite;
-           select (extensions_present) {
-               case false:
-                   struct {};
-               case true:
-                   Extension extensions<0..2^16-1>;
-           };
-       } ServerHello;
-
-The presence of extensions can be detected by determining whether there are
-bytes following the cipher_suite field at the end of the ServerHello.
-
-server_version
-: This field will contain the lower of that suggested by the client
-  in the ClientHello and the highest supported by the server.  For
-  this version of the specification, the version is { 3, 4 }.  (See
-  {{backward-compatibility}} for details about backward compatibility.)
-
-random
-: This structure is generated by the server and MUST be
-  generated independently of the ClientHello.random.
-
-cipher_suite
-: The single cipher suite selected by the server from the list in
-  ClientHello.cipher_suites.  For resumed sessions, this field is
-  the value from the state of the session being resumed.
-  [[TODO: interaction with PSK.]]
-
-extensions
-: A list of extensions.  Note that only extensions offered by the
-  client can appear in the server's list. In TLS 1.3 as opposed to
-  previous versions of TLS, the server's extensions are split between
-  the ServerHello and the EncryptedExtensions {{encrypted-extensions}}
-  message. The ServerHello MUST only include extensions which are
-  required to establish the cryptographic context. Currently the only
-  such extensions are "key_share", "pre_shared_key", and "early_data".
-  Clients MUST check the ServerHello for the presence of any forbidden
-  extensions and if any are found MUST terminate the handshake with a
-  "illegal_parameter" alert.
-{:br }
-
-####  Hello Retry Request
-
-When this message will be sent:
-
-> Servers send this message in response to a ClientHello
-message when it was able to find an acceptable set of algorithms and
-groups that are mutually supported, but
-the client's KeyShare did not contain an acceptable
-offer. If it cannot find such a match, it will respond with a
-fatal "handshake_failure" alert.
-
-Structure of this message:
-
-%%% Key Exchange Messages
-       struct {
-           ProtocolVersion server_version;
-           CipherSuite cipher_suite;
-           NamedGroup selected_group;
-           Extension extensions<0..2^16-1>;
-       } HelloRetryRequest;
-
-[[OPEN ISSUE: Merge in DTLS Cookies?]]
-
-selected_group
-: The mutually supported group the server intends to negotiate and
-  is requesting a retried ClientHello/KeyShare for.
-{:br }
-
-The server_version, cipher_suite, and extensions fields have the
-same meanings as their corresponding values in the ServerHello. The
-server SHOULD send only the extensions necessary for the client to
-generate a correct ClientHello pair. As with ServerHello, a
-HelloRetryRequest MUST NOT contain any extensions that were not first
-offered by the client in its ClientHello.
-
-Upon receipt of a HelloRetryRequest, the client MUST first verify that
-the selected_group field corresponds to a group which was provided
-in the "supported_groups" extension in the original ClientHello.  It
-MUST then verify that the selected_group field does not correspond
-to a group which was provided in the "key_share" extension in the
-original ClientHello. If either of these checks fails, then the client
-MUST abort the handshake with a fatal "handshake_failure"
-alert. Clients SHOULD also abort with "handshake_failure" in response
-to any second HelloRetryRequest which was sent in the same connection
-(i.e., where the ClientHello was itself in response to a
-HelloRetryRequest).
-
-Otherwise, the client MUST send a ClientHello with an updated KeyShare
-extension to the server. The client MUST append a new KeyShareEntry
-for the group indicated in the selected_group field to the groups
-in its original KeyShare.
-
-Upon re-sending the ClientHello and receiving the
-server's ServerHello/KeyShare, the client MUST verify that
-the selected CipherSuite and NamedGroup match that supplied in
-the HelloRetryRequest. If either of these values differ, the client
-MUST abort the connection with a fatal "handshake_failure" alert.
-
-[[OPEN ISSUE: https://github.com/tlswg/tls13-spec/issues/104]]
-
-###  Hello Extensions
-
-The extension format is:
-
-%%% Key Exchange Messages
-       struct {
-           ExtensionType extension_type;
-           opaque extension_data<0..2^16-1>;
-       } Extension;
-
-       enum {
-           supported_groups(10),
-           signature_algorithms(13),
-           early_data(TBD),
-           pre_shared_key(TBD),
-           key_share(TBD),
-           (65535)
-       } ExtensionType;
-
-Here:
-
--  "extension_type" identifies the particular extension type.
-
--  "extension_data" contains information specific to the particular
-  extension type.
-
-The initial set of extensions is defined in {{RFC6066}}.
-The list of extension types is maintained by IANA as described in
-{{iana-considerations}}.
-
-An extension type MUST NOT appear in the ServerHello or HelloRetryRequest
-unless the same extension type appeared in the corresponding ClientHello.
-If a client receives an extension type in ServerHello or HelloRetryRequest
-that it did not request in the associated ClientHello, it MUST abort the
-handshake with an "unsupported_extension" fatal alert.
-
-Nonetheless, "server-oriented" extensions may be provided in the future within
-this framework. Such an extension (say, of type x) would require the client to
-first send an extension of type x in a ClientHello with empty extension_data to
-indicate that it supports the extension type. In this case, the client is
-offering the capability to understand the extension type, and the server is
-taking the client up on its offer.
-
-When multiple extensions of different types are present in the ClientHello or
-ServerHello messages, the extensions MAY appear in any order. There MUST NOT be
-more than one extension of the same type.
-
-Finally, note that extensions can be sent both when starting a new session and
-when requesting session resumption or 0-RTT mode. Indeed, a client that requests session
-resumption does not in general know whether the server will accept this
-request, and therefore it SHOULD send the same extensions as it would send if
-it were not attempting resumption.
-
-In general, the specification of each extension type needs to describe the
-effect of the extension both during full handshake and session resumption. Most
-current TLS extensions are relevant only when a session is initiated: when an
-older session is resumed, the server does not process these extensions in
-ClientHello, and does not include them in ServerHello. However, some
-extensions may specify different behavior during session resumption.
-[[TODO: update this and the previous paragraph to cover PSK-based resumption.]]
-
-There are subtle (and not so subtle) interactions that may occur in this
-protocol between new features and existing features which may result in a
-significant reduction in overall security. The following considerations should
-be taken into account when designing new extensions:
-
-- Some cases where a server does not agree to an extension are error
-  conditions, and some are simply refusals to support particular features. In
-  general, error alerts should be used for the former, and a field in the
-  server extension response for the latter.
-
-- Extensions should, as far as possible, be designed to prevent any attack that
-  forces use (or non-use) of a particular feature by manipulation of handshake
-  messages. This principle should be followed regardless of whether the feature
-  is believed to cause a security problem.
-  Often the fact that the extension fields are included in the inputs to the
-  Finished message hashes will be sufficient, but extreme care is needed when
-  the extension changes the meaning of messages sent in the handshake phase.
-  Designers and implementors should be aware of the fact that until the
-  handshake has been authenticated, active attackers can modify messages and
-  insert, remove, or replace extensions.
-
-- It would be technically possible to use extensions to change major aspects
-  of the design of TLS; for example the design of cipher suite negotiation.
-  This is not recommended; it would be more appropriate to define a new version
-  of TLS --- particularly since the TLS handshake algorithms have specific
-  protection against version rollback attacks based on the version number, and
-  the possibility of version rollback should be a significant consideration in
-  any major design change.
-
-####  Signature Algorithms
-
-The client uses the "signature_algorithms" extension to indicate to the server
-which signature/hash algorithm pairs may be used in digital signatures.
-
-Clients which offer one or more cipher suites which use certificate authentication
-(i.e., any non-PSK cipher suite) MUST send the "signature_algorithms" extension.
-If this extension is not provided and no alternative cipher suite is available,
-the server MUST close the connection with a fatal "missing_extension" alert.
-(see {{mti-extensions}})
-
-The "extension_data" field of this extension contains a
-"supported_signature_algorithms" value:
-
-%%% Signature Algorithm Extension
-       enum {
-           none(0),
-           md5_RESERVED(1),
-           sha1(2),
-           sha224_RESERVED(3),
-           sha256(4), sha384(5), sha512(6),
-           (255)
-       } HashAlgorithm;
-
-       enum {
-           anonymous_RESERVED(0),
-           rsa(1),
-           dsa(2),
-           ecdsa(3),
-           rsapss(4),
-           eddsa(5),
-           (255)
-       } SignatureAlgorithm;
-
-       struct {
-           HashAlgorithm hash;
-           SignatureAlgorithm signature;
-       } SignatureAndHashAlgorithm;
-
-       SignatureAndHashAlgorithm
-         supported_signature_algorithms<2..2^16-2>;
-
-[[TODO: IANA considerations for new SignatureAlgorithm value]]
-
-Each SignatureAndHashAlgorithm value lists a single hash/signature pair that
-the client is willing to verify. The values are indicated in descending order
-of preference.
-
-Note: Because not all signature algorithms and hash algorithms may be accepted
-by an implementation (e.g., ECDSA with SHA-256, but not SHA-384), algorithms here
-are listed in pairs.
-
-hash
-: This field indicates the hash algorithms which may be used.  The
-  values indicate support for unhashed data, SHA-1, SHA-256, SHA-384,
-  and SHA-512 {{SHS}}, respectively. The "none" value is provided for
-  signature algorithms which do not require hashing before signing,
-  such as EdDSA.
-
-  Previous versions of TLS
-  supported MD5, SHA-1, and SHA-224.  These algorithms are now deprecated.
-  MD5 and SHA-224 MUST NOT be offered by TLS 1.3 implementations; SHA-1 SHOULD
-  NOT be offered.
-
-  Clients MAY offer support for SHA-1 for backwards compatibility,
-  either with TLS 1.2 servers or for servers that have certification
-  paths with signatures based on SHA-1.
-
-signature
-: This field indicates the signature algorithm that may be used.
-  The values indicate RSASSA-PKCS1-v1_5 {{RFC3447}},
-  DSA {{DSS}}, ECDSA {{ECDSA}}, RSASSA-PSS {{RFC3447}}, and
-  EdDSA {{I-D.irtf-cfrg-eddsa}} respectively. Because all RSA signatures
-  used in signed TLS handshake messages (see {{digital-signing}}),
-  as opposed to those in certificates, are RSASSA-PSS, the "rsa"
-  value refers solely to signatures which appear in certificates.
-  The use of DSA and anonymous is deprecated. Previous versions
-  of TLS supported DSA. DSA is deprecated as of TLS 1.3 and
-  SHOULD NOT be offered or negotiated by any implementation.
-{:br }
-
-The semantics of this extension are somewhat complicated because the cipher
-suite indicates permissible signature algorithms but not hash algorithms.
-{{server-certificate-selection}} and {{key-share}} describe the
-appropriate rules.
-
-Clients offering support for SHA-1 for backwards compatibility MUST do so by listing
-those hash/signature pairs as the lowest priority (listed after all other
-pairs in the supported_signature_algorithms vector). TLS 1.3 servers MUST NOT
-offer a SHA-1 signed certificate unless no valid certificate chain can be
-produced without it (see {{server-certificate-selection}}).
-
-The signatures on certificates that are self-signed or certificates that are
-trust anchors are not validated since they begin a certification path (see
-{{RFC5280}}, Section 3.2).  A certificate that begins a certification
-path MAY use a hash or signature algorithm that is not advertised as being
-supported in the "signature_algorithms" extension.
-
-Note: TLS 1.3 servers might receive TLS 1.2 ClientHellos which do not contain
-this extension. If those servers are willing to negotiate TLS 1.2, they MUST
-behave in accordance with the requirements of {{RFC5246}} when negotiating
-that version.
-
-#### Negotiated Groups
-
-When sent by the client, the "supported_groups" extension indicates
-the named groups which the client supports, ordered from most
-preferred to least preferred.
-
-Note: In versions of TLS prior to TLS 1.3, this extension was named
-"elliptic_curves" and only contained elliptic curve groups. See
-{{RFC4492}} and {{I-D.ietf-tls-negotiated-ff-dhe}}.
-
-Clients which offer one or more (EC)DHE cipher suites MUST send at least one
-supported NamedGroup value and servers MUST NOT negotiate any of these
-cipher suites unless a supported value was provided.
-If this extension is not provided and no alternative cipher suite is available,
-the server MUST close the connection with a fatal "missing_extension" alert.
-(see {{mti-extensions}})
-If the extension is provided, but no compatible group is offered, the
-server MUST NOT negotiate a cipher suite of the relevant type. For
-instance, if a client supplies only ECDHE groups, the server MUST NOT
-negotiate finite field Diffie-Hellman. If no acceptable group can be
-selected across all cipher suites, then the server MUST generate a
-fatal "handshake_failure" alert.
-
-The "extension_data" field of this extension contains a
-"NamedGroupList" value:
-
-%%% Named Group Extension
-       enum {
-           // Elliptic Curve Groups.
-           obsolete_RESERVED (1..22),
-           secp256r1 (23), secp384r1 (24), secp521r1 (25),
-
-           // ECDH functions.
-           ecdh_x25519 (29), ecdh_x448 (30),
-
-           // Signature curves.
-           eddsa_ed25519 (31), eddsa_ed448 (32),
-
-           // Finite Field Groups.
-           ffdhe2048 (256), ffdhe3072 (257), ffdhe4096 (258),
-           ffdhe6144 (259), ffdhe8192 (260),
-
-           // Reserved Code Points.
-           ffdhe_private_use (0x01FC..0x01FF),
-           ecdhe_private_use (0xFE00..0xFEFF),
-           obsolete_RESERVED (0xFF01..0xFF02),
-           (0xFFFF)
-       } NamedGroup;
-
-       struct {
-           NamedGroup named_group_list<1..2^16-1>;
-       } NamedGroupList;
-
-secp256r1, etc.
-: Indicates support of the corresponding named curve.
-  Note that some curves are also recommended in ANSI
-  X9.62 {{X962}} and FIPS 186-4 {{DSS}}.
-  Values 0xFE00 through 0xFEFF are reserved for private use.
-
-ecdh_x25519 and ecdh_x448
-: Indicates support of the corresponding ECDH functions X25519 and X448.
-
-eddsa_ed25519 and eddsa_ed448
-: Indicates support of the corresponding curve for
-  signatures.
-
-ffdhe2048, etc.
-: Indicates support of the corresponding finite field
-  group, defined in {{I-D.ietf-tls-negotiated-ff-dhe}}.
-  Values 0x01FC through 0x01FF are reserved for private use.
-{:br }
-
-Items in named_group_list are ordered according to the client's
-preferences (most preferred choice first).
-
-As an example, a client that only supports secp256r1 (aka NIST P-256;
-value 23 = 0x0017) and secp384r1 (aka NIST P-384; value 24 = 0x0018)
-and prefers to use secp256r1 would include a TLS extension consisting
-of the following octets.  Note that the first two octets indicate the
-extension type ("supported_groups" extension):
-
-       00 0A 00 06 00 04 00 17 00 18
-
-NOTE: A server participating in an ECDHE-ECDSA key exchange may use
-different curves for (i) the ECDSA or EdDSA key in its certificate,
-and (ii) the ephemeral ECDH key in its "key_share" extension.  The server
-must consider the supported groups in both cases.
-
-[[TODO: IANA Considerations.]]
-
-
-#### Key Share
-
-The "key_share" extension contains the endpoint's cryptographic parameters
-for non-PSK key establishment methods (currently DHE or ECDHE).
-
-Clients which offer one or more (EC)DHE cipher suites MUST send this
-extension and SHOULD send at least one supported KeyShareEntry value.
-Servers MUST NOT negotiate any of these cipher suites unless a supported
-value was provided.
-If this extension is not provided in a ServerHello or ClientHello,
-and the peer is offering (EC)DHE cipher suites, then the endpoint MUST close
-the connection with a fatal "missing_extension" alert.
-(see {{mti-extensions}})
-Clients MAY send an empty client_shares vector in order to request
-group selection from the server at the cost of an additional round trip.
-(see {{hello-retry-request}})
-
-%%% Key Exchange Messages
-       struct {
-           NamedGroup group;
-           opaque key_exchange<1..2^16-1>;
-       } KeyShareEntry;
-
-group
-: The named group for the key being exchanged.
-  Finite Field Diffie-Hellman {{DH}} parameters are described in
-  {{ffdhe-param}}; Elliptic Curve Diffie-Hellman parameters are
-  described in {{ecdhe-param}}. Signature-only curves, currently
-  eddsa_ed25519 (31) and eddsa_ed448 (32), MUST NOT be used for
-  key exchange.
-
-key_exchange
-: Key exchange information.  The contents of this field are
-  determined by the specified group and its corresponding
-  definition.  Endpoints MUST NOT send empty or otherwise
-  invalid key_exchange values for any reason.
-{:br }
-
-The "extension_data" field of this extension contains a
-"KeyShare" value:
-
-%%% Key Exchange Messages
-       struct {
-           select (role) {
-               case client:
-                   KeyShareEntry client_shares<4..2^16-1>;
-
-               case server:
-                   KeyShareEntry server_share;
-           }
-       } KeyShare;
-
-client_shares
-: A list of offered KeyShareEntry values in descending order of client preference.
-  This vector MAY be empty if the client is requesting a HelloRetryRequest.
-  The ordering of values here SHOULD match that of the ordering of offered support
-  in the "supported_groups" extension.
-
-server_share
-: A single KeyShareEntry value for the negotiated cipher suite.
-{:br }
-
-Servers offer exactly one KeyShareEntry value, which corresponds to the
-key exchange used for the negotiated cipher suite.
-
-Clients offer an arbitrary number of KeyShareEntry values, each representing
-a single set of key exchange parameters. For instance, a client might
-offer shares for several elliptic curves or multiple integer DH groups.
-The key_exchange values for each KeyShareEntry MUST by generated independently.
-Clients MUST NOT offer multiple KeyShareEntry values for the same parameters.
-Clients and servers MUST NOT offer any KeyShareEntry values for groups not
-listed in the client's "supported_groups" extension.
-Servers MUST NOT offer a KeyShareEntry value for a group not offered by the
-client in its corresponding KeyShare.
-Implementations receiving any KeyShare containing any of these prohibited
-values MUST abort the connection with a fatal "illegal_parameter" alert.
-
-If the server selects an (EC)DHE cipher suite and no mutually
-supported group is available between the two endpoints' KeyShare
-offers, yet there is a mutually supported group that can be found via
-the "supported_groups" extension, then the server MUST reply with a
-HelloRetryRequest.  If there is no mutually supported group at all,
-the server MUST NOT negotiate an (EC)DHE cipher suite.
-
-[[TODO: Recommendation about what the client offers.
-Presumably which integer DH groups and which curves.]]
-
-#####  Diffie-Hellman Parameters {#ffdhe-param}
-
-Diffie-Hellman {{DH}} parameters for both clients and servers are encoded in
-the opaque key_exchange field of a KeyShareEntry in a KeyShare structure.
-The opaque value contains the
-Diffie-Hellman public value (dh_Y = g^X mod p),
-encoded as a big-endian integer.
-
-%%% Key Exchange Messages
-       opaque dh_Y<1..2^16-1>;
-
-##### ECDHE Parameters {#ecdhe-param}
-
-ECDHE parameters for both clients and servers are encoded in the
-the opaque key_exchange field of a KeyShareEntry in a KeyShare structure.
-The opaque value conveys the Elliptic
-Curve Diffie-Hellman public value (ecdh_Y) represented as a byte
-string ECPoint.point.
-
-%%% Key Exchange Messages
-       opaque point <1..2^8-1>;
-
-point
-: For secp256r1, secp384r1 and secp521r1, this is the byte string
-  representation of an elliptic curve point following the conversion
-  routine in Section 4.3.6 of ANSI X9.62 {{X962}}.
-
-  For ecdh_x25519 and ecdh_x448, this is raw opaque octet-string
-  representation of point (in the format those functions use), 32 octets
-  for ecdh_x25519(29) and 56 octets for ecdh_x448(30).
-{:br }
-
-Although X9.62 supports multiple point formats, any given curve
-MUST specify only a single point format. All curves currently
-specified in this document MUST only be used with the uncompressed
-point format (the format for all ECDH functions is considered
-uncompressed).
-
-Note: Versions of TLS prior to 1.3 permitted point negotiation;
-TLS 1.3 removes this feature in favor of a single point format
-for each curve.
-
-#### Pre-Shared Key Extension
-
-The "pre_shared_key" extension is used to indicate the identity of the
-pre-shared key to be used with a given handshake in association
-with a PSK or (EC)DHE-PSK cipher suite (see {{RFC4279}} for background).
-
-Clients which offer one or more PSK cipher suites
-MUST send at least one supported psk_identity value and
-servers MUST NOT negotiate any of these cipher suites unless a supported
-value was provided.
-If this extension is not provided and no alternative cipher suite is available,
-the server MUST close the connection with a fatal "missing_extension" alert.
-(see {{mti-extensions}})
-
-The "extension_data" field of this extension contains a
-"PreSharedKeyExtension" value:
-
-%%% Key Exchange Messages
-
-       opaque psk_identity<0..2^16-1>;
-
-       struct {
-           select (Role) {
-               case client:
-                   psk_identity identities<2..2^16-1>;
-
-               case server:
-                   psk_identity identity;
-           }
-       } PreSharedKeyExtension;
-
-identity
-: An opaque label for the pre-shared key.
-{: br}
-
-If no suitable identity is provided, the server MUST NOT negotiate
-a PSK cipher suite and MAY respond with an "unknown_psk_identity"
-alert message. Sending this alert is OPTIONAL; servers MAY instead
-choose to send a "decrypt_error" alert to merely indicate an
-invalid PSK identity or instead negotiate use of a non-PSK cipher
-suite, if available.
-
-If the server selects a PSK cipher suite, it MUST send a
-"pre_shared_key" extension with the identity that it selected.
-The client MUST verify that the server has selected one of
-the identities that the client supplied. If any other identity
-is returned, the client MUST generate a fatal
-"unknown_psk_identity" alert and close the connection.
-
-
-#### Early Data Indication
-
-In cases where TLS clients have previously interacted with the
-server and the server has supplied a ServerConfiguration ({{server-configuration}}), the client
-can send application data and its Certificate/CertificateVerify
-messages (if client authentication is required). If the client
-opts to do so, it MUST supply an "early_data" extension.
-
-The "extension_data" field of this extension contains an
-"EarlyDataIndication" value:
-
-%%% Key Exchange Messages
-       struct {
-           select (Role) {
-               case client:
-                   opaque configuration_id<1..2^16-1>;
-                   CipherSuite cipher_suite;
-                   Extension extensions<0..2^16-1>;
-                   opaque context<0..255>;
-
-               case server:
-                  struct {};
-           }
-       } EarlyDataIndication;
-
-configuration_id
-: The label for the configuration in question.
-
-cipher_suite
-: The cipher suite which the client is using to encrypt the early data.
-
-extensions
-: The extensions required to define the cryptographic configuration
-  for the clients early data (see below for details).
-
-context
-: An optional context value that can be used for anti-replay
-  (see below).
-{:br }
-
-The client specifies the cryptographic configuration for the 0-RTT
-data using the "configuration", "cipher_suite", and "extensions"
-values. For configurations received in-band (in a previous TLS connection)
-the client MUST:
-
-- Send the same cryptographic determining parameters (Section
-{{cryptographic-determining-parameters}}) with the previous
-connection. If a 0-RTT handshake is being used with a PSK
-that was negotiated via a non-PSK handshake,
-then the client MUST use the same symmetric cipher parameters
-as were negotiated on that handshake but with a PSK cipher
-suite.
-
-- Indicate the same parameters as the server indicated in that connection.
-
-0-RTT messages sent in the first flight have the same content types
-as their corresponding messages sent in other flights (handshake,
-application_data, and alert respectively) but are protected under
-different keys. After all the 0-RTT application data messages (if
-any) have been sent, a "end_of_early_data" alert of type
-"warning" is sent to indicate the end of the flight.
-Clients which do 0-RTT MUST always send "end_of_early_data" even
-if the ServerConfiguration indicates that no application
-data is allowed (EarlyDataType of "client_authentication"),
-though in that case it MUST NOT send any non-empty data records
-(i.e., those which consist of anything other than padding).
-
-A server which receives an "early_data" extension
-can behave in one of two ways:
-
-- Ignore the extension and return no response. This indicates that the
-  server has ignored any early data and an ordinary 1-RTT handshake is
-  required.
-
-- Return an empty extension, indicating that it intends to
-  process the early data. It is not possible for the server
-  to accept only a subset of the early data messages.
-
-Prior to accepting the "early_data" extension, the server
-MUST perform the following checks:
-
-- The configuration_id matches a known server configuration.
-- The client's cryptographic determining parameters match the
-  parameters that the server has negotiated based on the
-  rest of the ClientHello.
-
-If any of these checks fail, the server MUST NOT respond
-with the extension and must discard all the remaining first
-flight data (thus falling back to 1-RTT). If the client attempts
-a 0-RTT handshake but the server rejects it, it will generally
-not have the 0-RTT record protection keys and will instead
-trial decrypt each record with the 1-RTT handshake keys
-until it finds one that decrypts properly, and then pick up
-the handshake from that point.
-
-[[TODO: How does the client behave if the indication is rejected.]]
-
-[[OPEN ISSUE: This just specifies the signaling for 0-RTT but
-not the the 0-RTT cryptographic transforms, including:
-
-- What is in the handshake hash (including potentially some
-  speculative data from the server).
-- What is signed in the client's CertificateVerify.
-- Whether we really want the Finished to not include the
-  server's data at all.
-
-What's here now needs a lot of cleanup before it is clear
-and correct.]]
-
-
-
-##### Cryptographic Determining Parameters
-
-In order to allow the server to decrypt 0-RTT data, the client
-needs to provide enough information to allow the server to
-decrypt the traffic without negotiation. This is accomplished
-by having the client indicate the "cryptographic determining
-parameters" in its ClientHello, which are necessary to decrypt
-the client's packets (i.e., those present in the ServerHello).
-This includes the following
-values:
-
-- The cipher suite identifier.
-
-- "key_share" if (EC)DHE is being used.
-
-- If PSK is being used, the server's version of the
-  "pre_shared_key" (indicating the PSK the client is
-  using).
-
-##### Replay Properties
-
-As noted in {{zero-rtt-exchange}}, TLS does not provide any
-inter-connection mechanism for replay protection for data sent by the
-client in the first flight.  As a special case, implementations where
-the server configuration, is delivered out of band (as has been
-proposed for DTLS-SRTP {{RFC5763}}), MAY use a unique server
-configuration identifier for each connection, thus preventing
-replay. Implementations are responsible for ensuring uniqueness of the
-identifier in this case.
-
-### Server Parameters
-
-####  Encrypted Extensions
-
-When this message will be sent:
-
-> The EncryptedExtensions message MUST be sent immediately after the
-ServerHello message. This is the first message that is encrypted
-under keys derived from ES.
-
-Meaning of this message:
-
-> The EncryptedExtensions message simply contains any extensions
-which should be protected, i.e., any which are not needed to
-establish the cryptographic context. The same extension types
-MUST NOT appear in both the ServerHello and EncryptedExtensions.
-If the same extension appears in both locations, the client
-MUST rely only on the value in the EncryptedExtensions block.
-All server-sent extensions other than those explicitly
-listed in {{server-hello}} or designated in the IANA registry
-MUST only appear in EncryptedExtensions. Extensions which
-are designated to appear in ServerHello MUST NOT appear in
-EncryptedExtensions. Clients MUST check EncryptedExtensions
-for the presence of any forbidden extensions and if
-any are found MUST terminate the handshake with
-a "illegal_parameter" alert.
-
-Structure of this message:
-
-%%% Server Parameters Messages
-       struct {
-           Extension extensions<0..2^16-1>;
-       } EncryptedExtensions;
-
-extensions
-: A list of extensions.
-{:br }
-
-####  Certificate Request
-
-When this message will be sent:
-
-> A non-anonymous server can optionally request a certificate from the client,
-if appropriate for the selected cipher suite. This message, if sent, will
-follow EncryptedExtensions.
-
-Structure of this message:
-
-%%% Server Parameters Messages
-       opaque DistinguishedName<1..2^16-1>;
-
-       struct {
-           opaque certificate_extension_oid<1..2^8-1>;
-           opaque certificate_extension_values<0..2^16-1>;
-       } CertificateExtension;
-
-       struct {
-           opaque certificate_request_context<0..2^8-1>;
-           SignatureAndHashAlgorithm
-             supported_signature_algorithms<2..2^16-2>;
-           DistinguishedName certificate_authorities<0..2^16-1>;
-           CertificateExtension certificate_extensions<0..2^16-1>;
-       } CertificateRequest;
-
-certificate_request_context
-: An opaque string which identifies the certificate request and
-  which will be echoed in the client's Certificate message. The
-  certificate_request_context MUST be unique within the scope
-  of this connection (thus preventing replay of client
-  CertificateVerify messages).
-
-supported_signature_algorithms
-: A list of the hash/signature algorithm pairs that the server is
-  able to verify, listed in descending order of preference. Any
-  certificates provided by the client MUST be signed using a
-  hash/signature algorithm pair found in
-  supported_signature_algorithms.
-
-certificate_authorities
-: A list of the distinguished names {{X501}} of acceptable
-  certificate_authorities, represented in DER-encoded {{X690}} format.  These
-  distinguished names may specify a desired distinguished name for a
-  root CA or for a subordinate CA; thus, this message can be used to
-  describe known roots as well as a desired authorization space.  If
-  the certificate_authorities list is empty, then the client MAY
-  send any certificate that meets the rest of the selection criteria
-  in the CertificateRequest, unless there is some external arrangement
-  to the contrary.
-
-certificate_extensions
-: A list of certificate extension OIDs {{RFC5280}} with their allowed
-  values, represented in DER-encoded {{X690}} format. Some certificate
-  extension OIDs allow multiple values (e.g. Extended Key Usage).
-  If the server has included a non-empty certificate_extensions list,
-  the client certificate MUST contain all of the specified extension
-  OIDs that the client recognizes. For each extension OID recognized
-  by the client, all of the specified values MUST be present in the
-  client certificate (but the certificate MAY have other values as
-  well). However, the client MUST ignore and skip any unrecognized
-  certificate extension OIDs. If the client has ignored some of the
-  required certificate extension OIDs, and supplied a certificate
-  that does not satisfy the request, the server MAY at its discretion
-  either continue the session without client authentication, or
-  terminate the session with a fatal unsupported_certificate alert.
-
-  PKIX RFCs define a variety of certificate extension OIDs and their
-  corresponding value types. Depending on the type, matching
-  certificate extension values are not necessarily bitwise-equal. It
-  is expected that TLS implementations will rely on their PKI
-  libraries to perform certificate selection using certificate
-  extension OIDs.
-
-  This document defines matching rules for two standard certificate
-  extensions defined in {{RFC5280}}:
-
-  - The Key Usage extension in a certificate matches the request when
-  all key usage bits asserted in the request are also asserted in the
-  Key Usage certificate extension.
-
-  - The Extended Key Usage extension in a certificate matches the
-  request when all key purpose OIDs present in the request are also
-  found in the Extended Key Usage certificate extension. The special
-  anyExtendedKeyUsage OID MUST NOT be used in the request.
-
-  Separate specifications may define matching rules for other certificate
-  extensions.
-{:br }
-
-Note: It is a fatal "handshake_failure" alert for an anonymous server to request
-client authentication.
-
-
-#### Server Configuration
-
-When this message will be sent:
-
-> This message is used to provide a server configuration which
-the client can use in the future to skip handshake negotiation and
-(optionally) to allow 0-RTT handshakes. The ServerConfiguration
-message is sent as the last message before the CertificateVerify.
-
-Structure of this Message:
-
-%%% Server Parameters Messages
-          enum { (65535) } ConfigurationExtensionType;
-          
-          enum { client_authentication(1), early_data(2),
-                 client_authentication_and_data(3), (255) } EarlyDataType;
-                 
-          struct {
-              ConfigurationExtensionType extension_type;
-              opaque extension_data<0..2^16-1>;
-          } ConfigurationExtension;
-
-          struct {
-              opaque configuration_id<1..2^16-1>;
-              uint32 expiration_date;
-              NamedGroup group;
-              opaque server_key<1..2^16-1>;
-              EarlyDataType early_data_type;
-              ConfigurationExtension extensions<0..2^16-1>;
-          } ServerConfiguration;
-
-
-configuration_id
-: The configuration identifier to be used in 0-RTT mode.
-
-group
-: The group for the long-term DH key that is being established
-for this configuration.
-
-expiration_date
-: The last time when this configuration is expected to be valid
-(in seconds since the Unix epoch). Servers MUST NOT use any value
-more than 604800 seconds (7 days) in the future. Clients MUST
-NOT cache configurations for longer than 7 days, regardless of
-the expiration_date. [[OPEN ISSUE: Is this the right value?
-The idea is just to minimize exposure.]]
-
-server_key
-: The long-term DH key that is being established for this configuration.
-
-early_data_type
-: The type of 0-RTT handshake that this configuration is to be used
-for (see {{early-data-indication}}). If "client_authentication"
-or "client_authentication_and_data", then the client MUST select
-the certificate for future handshakes based on the CertificateRequest
-parameters supplied in this handshake. The server MUST NOT send
-either of these two options unless it also requested a certificate
-on this handshake.
-[[OPEN ISSUE: Should we relax this?]]
-
-extensions
-: This field is a placeholder for future extensions to the
-ServerConfiguration format.
-{:br }
-
-The semantics of this message are to establish a shared state between
-the client and server for use with the "known_configuration" extension
-with the key specified in key and with the handshake parameters negotiated
-by this handshake.
-
-When the ServerConfiguration message is sent, the server MUST also
-send a Certificate message and a CertificateVerify message, even
-if the "known_configuration" extension was used for this handshake,
-thus requiring a signature over the configuration before it can
-be used by the client. Clients MUST NOT rely on the
-ServerConfiguration message until successfully receiving and
-processing the server's Certificate, CertificateVerify, and
-Finished. If there is a failure in processing those messages, the
-client MUST discard the ServerConfiguration.
-
-### Authentication Messages
-
-As discussed in {{handshake-protocol-overview}}, TLS uses a common
-set of messages for authentication, key confirmation, and handshake
-integrity: Certificate, CertificateVerify, and Finished. These
-messages are always sent as the last messages in their handshake
-flight. The Certificate and CertificateVerify messages are only
-sent under certain circumstances, as defined below. The Finished
-message is always sent as part of the Authentication block.
-
-The computations for the Authentication messages all uniformly
-take the following inputs:
-
-- The certificate and signing key to be used.
-- A Handshake Context based on the handshake hash (see {{the-handshake-hash}}).
-- A base key to be used to compute a MAC key.
-
-Based on these inputs, the messages then contain:
-
-Certificate
-: The certificate to be used for authentication and any
-supporting certificates in the chain.
-
-CertificateVerify
-: A signature over Handshake Context + Certificate.
-
-Finished
-: A MAC over Handshake Context + Certificate + CertificateVerify using
-  a MAC key derived from the base key.
-{:br}
-
-Because the CertificateVerify signs the Handshake Context +
-Certificate and the Finished MACs the Handshake Context + Certificate
-+ CertificateVerify, this is mostly equivalent to keeping a running hash
-of the handshake messages (exactly so in the pure 1-RTT cases). Note,
-however, the subsequent post-handshake authentications do not include
-each other, just the messages through the end of the main handshake.
-
-The following table defines the Handshake Context and MAC Key
-for each scenario:
-
-| Mode | Handshake Context | Base Key |
-|------|-------------------|----------|
-| 0-RTT | ClientHello + ServerConfiguration + Server Certificate + CertificateRequest (where ServerConfiguration, etc. are from the previous handshake) | xSS |
-| 1-RTT (Server) | ClientHello ... ServerConfiguration | master secret |
-| 1-RTT (Client) | ClientHello ... ServerFinished     | master secret |
-| Post-Handshake | ClientHello ... ClientFinished + CertificateRequest | master secret |
-
-Note 1:
-
-: The ServerConfiguration, CertificateRequest, and Server Certificate in the
-  0-RTT case are the messages from the handshake where the ServerConfiguration
-  was established.
-
-Note 2:
-
-: The Handshake Context for the last three rows does not include any 0-RTT
-  handshake messages, regardless of whether 0-RTT is used.
-
-
-
-####  Certificate
-
-When this message will be sent:
-
-> The server MUST send a Certificate message whenever the agreed-upon
-key exchange method uses certificates for authentication (this
-includes all key exchange methods defined in this document except PSK).
-
-> The client MUST send a Certificate message whenever the server has
-requested client authentication via a CertificateRequest message
-({{certificate-request}}) or when the EarlyDataType provided with the
-server configuration indicates a need for client authentication.  This
-message is only sent if the server requests a certificate via one of
-these mechanisms. If no suitable certificate is available, the client
-MUST send a Certificate message containing no certificates (i.e., with
-the "certificate_list" field having length 0).
-
-Meaning of this message:
-
-> This message conveys the endpoint's certificate chain to the peer.
-
-> The certificate MUST be appropriate for the negotiated cipher suite's key
-exchange algorithm and any negotiated extensions.
-
-Structure of this message:
-
-%%% Authentication Messages
-       opaque ASN1Cert<1..2^24-1>;
-
-       struct {
-           opaque certificate_request_context<0..255>;
-           ASN1Cert certificate_list<0..2^24-1>;
-       } Certificate;
-
-certificate_request_context:
-: If this message is in response to a CertificateRequest, the
-  value if certificate_request_context in that message. Otherwise,
-  in the case of server authentication or client authentication
-  in 0-RTT, this field SHALL be zero length.
-
-certificate_list
-: This is a sequence (chain) of certificates. The sender's
-  certificate MUST come first in the list. Each following
-  certificate SHOULD directly certify one preceding it. Because
-  certificate validation requires that trust anchors be distributed
-  independently, a certificate that specifies a
-  trust anchor MAY be omitted from the chain, provided that
-  supported peers are known to possess any omitted certificates.
-{:br }
-
-Note: Prior to TLS 1.3, "certificate_list" ordering required each certificate
-to certify the one immediately preceding it,
-however some implementations allowed some flexibility. Servers sometimes send
-both a current and deprecated intermediate for transitional purposes, and others
-are simply configured incorrectly, but these cases can nonetheless be validated
-properly. For maximum compatibility, all implementations SHOULD be prepared to
-handle potentially extraneous certificates and arbitrary orderings from any TLS
-version, with the exception of the end-entity certificate which MUST be first.
-
-The server's certificate list MUST always be non-empty. A client will
-MAY send an empty certificate list if it does not have an appropriate
-certificate to send in response to the server's authentication
-request.
-
-##### Server Certificate Selection
-
-The following rules apply to the certificates sent by the server:
-
-- The certificate type MUST be X.509v3 {{RFC5280}}, unless explicitly negotiated
-  otherwise (e.g., {{RFC5081}}).
-
-- The server's end-entity certificate's public key (and associated
-  restrictions) MUST be compatible with the selected key exchange
-  algorithm.
-
-| Key Exchange Alg.    | Certificate Key Type       |
-|----------------------|----------------------------|
-| DHE_RSA or ECDHE_RSA | RSA public key             |
-| ECDHE_ECDSA          | ECDSA or EdDSA public key  |
-
-- The certificate MUST allow the key to be used for signing (i.e., the
-  digitalSignature bit MUST be set if the key usage extension is present) with
-  a signature scheme and hash algorithm pair indicated in the client's
-  "signature_algorithms" extension.
-
-- An ECDSA or EdDSA public key MUST use a curve and point format supported by the
-  client, as described in [RFC4492].
-
-- The "server_name" and "trusted_ca_keys" extensions {{RFC6066}} are used to
-  guide certificate selection. As servers MAY require the presence of the "server_name"
-  extension, clients SHOULD send this extension.
-
-All certificates provided by the server MUST be signed by a
-hash/signature algorithm pair that appears in the "signature_algorithms"
-extension provided by the client, if they are able to provide such
-a chain (see {{signature-algorithms}}).
-Certificates that are self-signed
-or certificates that are expected to be trust anchors are not validated as
-part of the chain and therefore MAY be signed with any algorithm.
-
-If the server cannot produce a certificate chain that is signed only via the
-indicated supported pairs, then it SHOULD continue the handshake by sending
-the client a certificate chain of its choice that may include algorithms
-that are not known to be supported by the client. This fallback chain MAY
-use the deprecated SHA-1 hash algorithm only if the "signature_algorithms"
-extension provided by the client permits it.
-If the client cannot construct an acceptable chain using the provided
-certificates and decides to abort the handshake, then it MUST send an
-"unsupported_certificate" alert message and close the connection.
-
-If the server has multiple certificates, it chooses one of them based on the
-above-mentioned criteria (in addition to other criteria, such as transport
-layer endpoint, local configuration and preferences).
-
-As cipher suites that specify new key exchange methods are specified for the
-TLS protocol, they will imply the certificate format and the required encoded
-keying information.
-
-
-##### Client Certificate Selection
-
-The following rules apply to certificates sent by the client:
-
-In particular:
-
-- The certificate type MUST be X.509v3 {{RFC5280}}, unless explicitly negotiated
-  otherwise (e.g., {{RFC5081}}).
-
-- If the certificate_authorities list in the certificate request
-  message was non-empty, one of the certificates in the certificate
-  chain SHOULD be issued by one of the listed CAs.
-
-- The certificates MUST be signed using an acceptable hash/
-  signature algorithm pair, as described in {{certificate-request}}.  Note
-  that this relaxes the constraints on certificate-signing
-  algorithms found in prior versions of TLS.
-
-- If the certificate_extensions list in the certificate request message
-  was non-empty, the end-entity certificate MUST match the extension OIDs
-  recognized by the client, as described in {{certificate-request}}.
-
-Note that, as with the server certificate, there are certificates that use
-algorithm combinations that cannot be currently used with TLS.
-
-
-##### Receiving a Certificate Message
-
-In general, detailed certificate validation procedures are out of scope for
-TLS (see {{RFC5280}}). This section provides TLS-specific requirements.
-
-If server supplies an empty Certificate message, the client MUST terminate
-the handshake with a fatal "decode_error" alert.
-
-If the client does not send any certificates,
-the server MAY at its discretion either continue the handshake without client
-authentication, or respond with a fatal "handshake_failure" alert. Also, if some
-aspect of the certificate chain was unacceptable (e.g., it was not signed by a
-known, trusted CA), the server MAY at its discretion either continue the
-handshake (considering the client unauthenticated) or send a fatal alert.
-
-Any endpoint receiving any certificate signed using any signature algorithm
-using an MD5 hash MUST send a "bad_certificate" alert message and close
-the connection.
-
-SHA-1 is deprecated and therefore NOT RECOMMENDED.
-Endpoints that reject certification paths due to use of a deprecated hash MUST send
-a fatal "bad_certificate" alert message before closing the connection.
-All endpoints are RECOMMENDED to transition to SHA-256 or better as soon
-as possible to maintain interoperability with implementations
-currently in the process of phasing out SHA-1 support.
-
-Note that a certificate containing a key for one signature algorithm
-MAY be signed using a different signature algorithm (for instance,
-an RSA key signed with a ECDSA key).
-
-
-####  Certificate Verify
-
-When this message will be sent:
-
-> This message is used to provide explicit proof that an endpoint
-possesses the private key corresponding to its certificate
-and also provides integrity for the handshake up
-to this point. Servers MUST send this message when using
-a cipher suite which is authenticated via a certificate.
-Clients MUST send this
-message whenever authenticating via a Certificate (i.e., when
-the Certificate message is non-empty). When sent, this message MUST appear immediately
-after the Certificate Message and immediately prior to the Finished
-message.
-
-Structure of this message:
-
-%%% Authentication Messages
-       struct {
-            digitally-signed struct {
-               opaque handshake_hash[hash_length];
-            };
-       } CertificateVerify;
-
-> Where handshake_hash is as described in {{the-handshake-hash}} and
-includes the messages sent or received, starting at ClientHello and up
-to, but not including, this message, including the type and length
-fields of the handshake messages. This is a digest of the
-concatenation of all the Handshake structures (as defined in
-{{handshake-protocol}}) exchanged thus far. The digest MUST be the
-Hash used as the basis for HKDF.
-
-> The context string for a server signature is "TLS 1.3, server CertificateVerify"
-and for a client signature is "TLS 1.3, client CertificateVerify". A
-hash of the handshake messages is signed rather than the messages themselves
-because the digitally-signed format requires padding and context bytes at the
-beginning of the input. Thus, by signing a digest of the messages, an
-implementation need only maintain one running hash per hash type for
-CertificateVerify, Finished and other messages.
-
-> If sent by a server, the signature algorithm and hash algorithm MUST be a pair offered in the
-client's "signature_algorithms" extension unless no valid certificate chain can be
-produced without unsupported algorithms (see {{signature-algorithms}}). Note that
-there is a possibility for inconsistencies here. For instance, the client might
-offer ECDHE_ECDSA key exchange but omit any ECDSA and EdDSA pairs from its
-"signature_algorithms" extension. In order to negotiate correctly, the server
-MUST check any candidate cipher suites against the "signature_algorithms"
-extension before selecting them. This is somewhat inelegant but is a compromise
-designed to minimize changes to the original cipher suite design.
-
-> If sent by a server, the hash and signature algorithms used in the
-signature MUST be one of those present in the
-supported_signature_algorithms field of the CertificateRequest
-message.
-
-> In addition, the hash and signature algorithms MUST be compatible with the key
-in the sender's end-entity certificate. RSA keys MAY be used with any permitted
-hash algorithm, subject to restrictions in the certificate, if any.
-RSA signatures MUST be based on RSASSA-PSS, regardless of whether
-RSASSA-PKCS-v1_5 appears in "signature_algorithms".
-SHA-1 MUST NOT be used in any signatures in CertificateVerify,
-regardless of whether SHA-1 appears in "signature_algorithms".
-
-Note: when used with non-certificate-based handshakes (e.g., PSK), the
-client's signature does not cover the server's certificate directly,
-although it does cover the server's Finished message, which
-transitively includes the server's certificate when the PSK derives
-from a certificate-authenticated handshake.  {{PSK-FINISHED}}
-describes a concrete attack on this mode if the Finished is omitted
-from the signature. It is unsafe to use certificate-based client
-authentication when the client might potentially share the same
-PSK/key-id pair with two different endpoints. In order to ensure
-this, implementations MUST NOT mix certificate-based client
-authentication with pure PSK modes.
-
-
-####  Finished
-
-When this message will be sent:
-
-> The Finished message is the final message in the authentication
-block. It is essential for providing authentication of the handshake
-and of the computed keys.
-
-Meaning of this message:
-
-> Recipients of Finished messages MUST verify that the contents are
-correct. Once a side has sent its Finished message and received and
-validated the Finished message from its peer, it may begin to send and
-receive application data over the connection. This data will be
-protected under keys derived from the ephemeral secret (see
-{{cryptographic-computations}}).
-
-The key used to compute the finished message is computed from the
-Base key defined in {{authentication-messages}} using HKDF (see
-{{key-schedule}}). Specifically:
-
-~~~
-client_finished_key =
-    HKDF-Expand-Label(BaseKey, "client finished", "", L)
-
-server_finished_key =
-    HKDF-Expand-Label(BaseKey, "server finished", "", L)
-~~~
-
-Structure of this message:
-
-%%% Authentication Messages
-
-       struct {
-           opaque verify_data[verify_data_length];
-       } Finished;
-
-
-The verify_data value is computed as follows:
-
-       verify_data =
-           HMAC(finished_key, Hash(
-                  Handshake Context + Certificate* + CertificateVerify*
-               ))
-
-       * Only included if present.
-
-Where HMAC {{RFC2104}} uses the Hash algorithm for the handshake.
-As noted above: the HMAC input can generally be implemented by a running
-hash, i.e., just the handshake hash at this point.
-
-In previous versions of TLS, the verify_data was always 12 octets long. In
-the current version of TLS, it is the size of the HMAC output for the
-Hash used for the handshake.
-
-Note: Alerts and any other record types are not handshake messages
-and are not included in the hash computations.
-
-### Post-Handshake Messages
-
-TLS also allows other messages to be sent after the main handshake.
-These message use a handshake content type and are encrypted under the application
-traffic key.
-
-#### New Session Ticket Message
-
-After the server has received the client Finished message, it MAY send
-a NewSessionTicket message.  This message creates a pre-shared key
-(PSK) binding between the resumption master secret and the ticket
-label. The client MAY use this PSK for future handshakes by including
-it in the "pre_shared_key" extension in its ClientHello
-({{pre-shared-key-extension}}) and supplying a suitable PSK cipher
-suite.
-
-%%% Ticket Establishment
-      struct {
-          uint32 ticket_lifetime_hint;
-          opaque ticket<0..2^16-1>;
-      } NewSessionTicket;
-
-ticket_lifetime_hint
-: Indicates the lifetime
-  in seconds as a 32-bit unsigned integer in network byte order from
-  the time of ticket issuance. A value of zero is reserved to indicate
-  that the lifetime of the ticket is unspecified.
-
-ticket
-: The value of the ticket to be used as the PSK identifier.
-{:br }
-
-The ticket lifetime hint is informative only.
-A client SHOULD delete the ticket and associated
-state when the time expires.  It MAY delete the ticket earlier based
-on local policy.  A server MAY treat a ticket as valid for a shorter
-or longer period of time than what is stated in the
-ticket_lifetime_hint.
-
-The ticket itself is an opaque label. It MAY either be a database
-lookup key or a self-encrypted and self-authenticated value. Section
-4 of {{RFC5077}} describes a recommended ticket construction mechanism.
-
-[[TODO: Should we require that tickets be bound to the existing
-symmetric cipher suite. See the TODO above about early_data and
-PSK.??]
-
-
-#### Post-Handshake Authentication
-
-The server is permitted to request client authentication at any time
-after the handshake has completed by sending a CertificateRequest
-message. The client SHOULD respond with the appropriate Authentication
-messages. If the client chooses to authenticate, it MUST send
-Certificate, CertificateVerify, and Finished. If it declines, it
-MUST send a Certificate message containing no certificates followed by Finished.
-Note: Because there may already be application data messages in
-flight, the server MUST be prepared to receive an arbitrary number
-of such messages before receiving the Authentication messages.
-
-
-#### Key and IV Update {#key-update}
-
-struct {} KeyUpdate;
-
-The KeyUpdate handshake message is used to indicate that the sender is
-updating its sending cryptographic keys. This message can be sent by
-the server after sending its first flight and the client after sending
-its second flight. Implementations that receive a KeyUpdate message
-prior to receiving a Finished message as part of the 1-RTT handshake
-MUST generate a fatal "unexpected_message" alert.  After sending a
-KeyUpdate message, the sender SHALL send all its traffic using the
-next generation of keys, computed as described in
-{{updating-traffic-keys}}. Upon receiving a KeyUpdate, the receiver
-MUST update their receiving keys and if they have not already updated
-their sending state up to or past the then current receiving
-generation MUST send their own KeyUpdate prior to sending any other
-messages.  This mechanism allows either side to force an update to the
-entire connection. Note that implementations may receive an arbitrary
-number of messages between sending a KeyUpdate and receiving the
-peer's KeyUpdate because those messages may already be in flight.
-
-Note that if implementations independently send their own
-KeyUpdates and they cross in flight, this only results in an
-update of one generation; when each side receives the other
-side's update it just updates its receive keys and notes that
-the generations match and thus no send update is needed.
-
-Note that the side which sends its KeyUpdate first needs to retain
-the traffic keys (though not the traffic secret) for the previous
-generation of keys until it receives the KeyUpdate from the other
-side.
-
-
 #  Cryptographic Computations
 
-In order to begin connection protection, the TLS Record Protocol
-requires specification of a suite of algorithms, a master secret, and
-the client and server random values. The authentication, key
-exchange, and record protection algorithms are determined by the
-cipher_suite selected by the server and revealed in the ServerHello
-message. The random values are exchanged in the hello messages. All
-that remains is to calculate the key schedule.
+The TLS handshake establishes one or more input secrets which
+are combined to create the actual working keying material, as detailed
+below. The key derivation process incorporates both the input secrets
+and the handshake transcript. Note that because the handshake
+transcript includes the random values from the Hello messages,
+any given handshake will have different traffic secrets, even
+if the same input secrets are used, as is the case when
+the same PSK is used for multiple connections
+
 
 ## Key Schedule
 
-The TLS handshake establishes secret keying material which is then used
-to protect traffic. This keying material is derived from the two
-input secret values: Static Secret (SS) and Ephemeral Secret (ES).
+The key derivation process makes use of the HKDF-Extract and HKDF-Expand
+functions as defined for HKDF {{RFC5869}}, as well as the functions
+defined below:
 
-The exact source of each of these secrets depends on the operational
-mode (DHE, ECDHE, PSK, etc.) and is summarized in the table below:
+~~~~
+    HKDF-Expand-Label(Secret, Label, HashValue, Length) =
+         HKDF-Expand(Secret, HkdfLabel, Length)
 
-| Key Exchange | Static Secret (SS) | Ephemeral Secret (ES) |
-|--------------|-------------------:|----------------------:|
-| (EC)DHE (full handshake) | Client ephemeral w/ server ephemeral | Client ephemeral w/ server ephemeral |
-| (EC)DHE (w/ 0-RTT) | Client ephemeral w/ server static | Client ephemeral w/ server ephemeral |
-| PSK | Pre-Shared Key  | Pre-shared key |
-| PSK + (EC)DHE | Pre-Shared Key | Client ephemeral w/ server ephemeral |
+    Where HkdfLabel is specified as:
 
-These shared secret values are used to generate cryptographic keys as
-shown below.
+    struct {
+        uint16 length = Length;
+        opaque label<7..255> = "tls13 " + Label;
+        opaque hash_value<0..255> = HashValue;
+    } HkdfLabel;
 
-The derivation process is as follows, where L denotes the length of
-the underlying hash function for HKDF {{RFC5869}}. SS and ES denote
-the sources from the table above.
+    Derive-Secret(Secret, Label, Messages) =
+         HKDF-Expand-Label(Secret, Label,
+                           Transcript-Hash(Messages), Hash.length)
+~~~~
 
-~~~
-  HKDF-Expand-Label(Secret, Label, HashValue, Length) =
-       HKDF-Expand(Secret, HkdfLabel, Length)
+The Hash function used by Transcript-Hash and HKDF is the cipher suite hash
+algorithm.
+Hash.length is its output length in bytes. Messages are the concatenation of the
+indicated handshake messages, including the handshake message type
+and length fields, but not including record layer headers. Note that
+in some cases a zero-length HashValue (indicated by "") is passed to
+HKDF-Expand-Label.
 
-  Where HkdfLabel is specified as:
+Note: with common hash functions, any label longer than 12 characters
+requires an additional iteration of the hash function to compute.
+The labels in this specification have all been chosen to fit within
+this limit.
 
-  struct HkdfLabel {
-    uint16 length;
-    opaque label<9..255>;
-    opaque hash_value<0..255>;
-  };
+Given a set of n InputSecrets, the final "master secret" is computed
+by iteratively invoking HKDF-Extract with InputSecret_1, InputSecret_2,
+etc.  The initial secret is simply a string of Hash.length zero bytes.
+Concretely, for the present version of TLS 1.3, secrets are
+added in the following order:
 
-  Where:
-  - HkdfLabel.length is Length
-  - HkdfLabel.label is "TLS 1.3, " + Label
-  - HkdfLabel.hash_value is HashValue.
+- PSK (a pre-shared key established externally or derived from
+  the resumption_master_secret value from a previous connection)
+- (EC)DHE shared secret ({{ecdhe-shared-secret-calculation}})
 
-  1. xSS = HKDF-Extract(0, SS). Note that HKDF-Extract always
-     produces a value the same length as the underlying hash
-     function.
+This produces a full key derivation schedule shown in the diagram below.
+In this diagram, the following formatting conventions apply:
 
-  2. xES = HKDF-Extract(0, ES)
+- HKDF-Extract is drawn as taking the Salt argument from the top and the IKM argument
+  from the left.
+- Derive-Secret's Secret argument is indicated by the incoming
+  arrow. For instance, the Early Secret is the Secret for
+  generating the client_early_traffic_secret.
 
-  3. mSS = HKDF-Expand-Label(xSS, "expanded static secret",
-                             handshake_hash, L)
+~~~~
+                 0
+                 |
+                 v
+   PSK ->  HKDF-Extract = Early Secret
+                 |
+                 +-----> Derive-Secret(.,
+                 |                     "ext binder" |
+                 |                     "res binder",
+                 |                     "")
+                 |                     = binder_key
+                 |
+                 +-----> Derive-Secret(., "c e traffic",
+                 |                     ClientHello)
+                 |                     = client_early_traffic_secret
+                 |
+                 +-----> Derive-Secret(., "e exp master",
+                 |                     ClientHello)
+                 |                     = early_exporter_master_secret
+                 v
+           Derive-Secret(., "derived", "")
+                 |
+                 v
+(EC)DHE -> HKDF-Extract = Handshake Secret
+                 |
+                 +-----> Derive-Secret(., "c hs traffic",
+                 |                     ClientHello...ServerHello)
+                 |                     = client_handshake_traffic_secret
+                 |
+                 +-----> Derive-Secret(., "s hs traffic",
+                 |                     ClientHello...ServerHello)
+                 |                     = server_handshake_traffic_secret
+                 v
+           Derive-Secret(., "derived", "")
+                 |
+                 v
+      0 -> HKDF-Extract = Master Secret
+                 |
+                 +-----> Derive-Secret(., "c ap traffic",
+                 |                     ClientHello...server Finished)
+                 |                     = client_application_traffic_secret_0
+                 |
+                 +-----> Derive-Secret(., "s ap traffic",
+                 |                     ClientHello...server Finished)
+                 |                     = server_application_traffic_secret_0
+                 |
+                 +-----> Derive-Secret(., "exp master",
+                 |                     ClientHello...server Finished)
+                 |                     = exporter_master_secret
+                 |
+                 +-----> Derive-Secret(., "res master",
+                                       ClientHello...client Finished)
+                                       = resumption_master_secret
+~~~~
 
-  4. mES = HKDF-Expand-Label(xES, "expanded ephemeral secret",
-                             handshake_hash, L)
+The general pattern here is that the secrets shown down the left side
+of the diagram are just raw entropy without context, whereas the
+secrets down the right side include handshake context and therefore
+can be used to derive working keys without additional context.
+Note that the different
+calls to Derive-Secret may take different Messages arguments,
+even with the same secret. In a 0-RTT exchange, Derive-Secret is
+called with four distinct transcripts; in a 1-RTT-only exchange
+with three distinct transcripts.
 
+If a given secret is not available, then the 0-value consisting of
+a string of Hash.length zero bytes is used.  Note that this does not mean skipping
+rounds, so if PSK is not in use Early Secret will still be
+HKDF-Extract(0, 0). For the computation of the binder_secret, the label is
+"ext binder" for external PSKs (those provisioned outside of TLS)
+and "res binder" for resumption PSKs (those provisioned as the resumption
+master secret of a previous handshake). The different labels prevent
+the substitution of one type of PSK for the other.
 
-  5. master_secret = HKDF-Extract(mSS, mES)
+There are multiple potential Early Secret values depending on
+which PSK the server ultimately selects. The client will need to compute
+one for each potential PSK; if no PSK is selected, it will then need to
+compute the early secret corresponding to the zero PSK.
 
-
-  6. traffic_secret_0 = HKDF-Expand-Label(master_secret,
-                                          "traffic secret",
-                                          handshake_hash, L)
-
-  Where handshake_hash includes all messages up through the
-  server CertificateVerify message, but not including any
-  0-RTT handshake messages (the server's Finished is not
-  included because the master_secret is need to compute
-  the finished key). [[OPEN ISSUE: Should we be including
-  0-RTT handshake messages here and below?]]
-
-  7. resumption_secret = HKDF-Expand-Label(master_secret,
-                                           "resumption master secret"
-                                           session_hash, L)
-
-  8. exporter_secret = HKDF-Expand-Label(master_secret,
-                                         "exporter master secret",
-                                         session_hash, L)
-
-  
-  Where session_hash is the session hash as defined in
-  {{the-handshake-hash}}. I.e., the entire handshake up to
-  and including the client's Finished, but not including
-  any 0-RTT handshake messages.
-~~~
-
-The traffic keys are computed from xSS, xES, and the traffic_secret
-as described in {{traffic-key-calculation}} below. The traffic_secret
-may be updated throughout the connection as described in {{updating-traffic-keys}}.
-
-Note: although the steps above are phrased as individual HKDF-Extract
-and HKDF-Expand operations, because each HKDF-Expand operation is
-paired with an HKDF-Extract, it is possible to implement this key
-schedule with a black-box HKDF API, albeit at some loss of efficiency
-as some HKDF-Extract operations will be repeated.
+Once all the values which are to be derived from a given secret have
+been computed, that secret SHOULD be erased.
 
 
 ## Updating Traffic Keys and IVs {#updating-traffic-keys}
 
 Once the handshake is complete, it is possible for either side to
 update its sending traffic keys using the KeyUpdate handshake message
-{{key-update}}.  The next generation of traffic keys is computed by
-generating traffic_secret_N+1 from traffic_secret_N as described in
+defined in {{key-update}}.  The next generation of traffic keys is computed by
+generating client_/server_application_traffic_secret_N+1 from
+client_/server_application_traffic_secret_N as described in
 this section then re-deriving the traffic keys as described in
 {{traffic-key-calculation}}.
 
-The next-generation traffic_secret is computed as:
+The next-generation application_traffic_secret is computed as:
 
-  traffic_secret_N+1 = HKDF-Expand-Label(traffic_secret_N,
-                                       "traffic secret", "", L)
+~~~~
+    application_traffic_secret_N+1 =
+        HKDF-Expand-Label(application_traffic_secret_N,
+                          "traffic upd", "", Hash.length)
+~~~~
 
-Once traffic_secret_N+1 and its associated traffic keys have been computed,
-implementations SHOULD delete traffic_secret_N. Once the directional
-keys are no longer needed, they SHOULD be deleted as well.
+Once client/server_application_traffic_secret_N+1 and its associated
+traffic keys have been computed, implementations SHOULD delete
+client_/server_application_traffic_secret_N and its associated traffic keys.
 
 
 ## Traffic Key Calculation
 
 The traffic keying material is generated from the following input values:
 
-* A secret value
-* A phase value indicating the phase of the protocol the keys are
-  being generated for.
-* A purpose value indicating the specific value being generated
-* The length of the key.
-* The handshake context which is used to generate the keys.
+- A secret value
+- A purpose value indicating the specific value being generated
+- The length of the key
 
-The keying material is computed using:
+The traffic keying material is generated from an input traffic secret value using:
 
-       key = HKDF-Expand-Label(Secret,
-                               phase + ", " + purpose,
-                               handshake_context,
-                               key_length)
+~~~~
+    [sender]_write_key = HKDF-Expand-Label(Secret, "key", "", key_length)
+    [sender]_write_iv  = HKDF-Expand-Label(Secret, "iv" , "", iv_length)
+~~~~
 
-The following table describes the inputs to the key calculation for
-each class of traffic keys:
+\[sender] denotes the sending side. The Secret value for each record type
+is shown in the table below.
 
-| Record Type | Secret | Label | Handshake Context |
-|:------------|--------|-------|------------------:|
-| 0-RTT Handshake   | xSS | "early handshake key expansion" | ClientHello + ServerConfiguration + Server Certificate |
-| 0-RTT Application | xSS | "early application data key expansion" | ClientHello + ServerConfiguration + Server Certificate |
-| Handshake         | xES | "handshake key expansion" | ClientHello... ServerHello |
-| Application Data  | traffic secret | "application data key expansion" | ClientHello... Server Finished |
+| Record Type | Secret |
+|:------------|--------|
+| 0-RTT Application | client_early_traffic_secret |
+| Handshake         | \[sender]_handshake_traffic_secret |
+| Application Data  | \[sender]_application_traffic_secret_N |
 
-The following table indicates the purpose values for each type of key:
-
-| Key Type         | Purpose            |
-|:-----------------|:-------------------|
-| Client Write Key | "client write key" |
-| Server Write Key | "server write key" |
-| Client Write IV  | "client write IV"  |
-| Server Write IV  | "server write IV"  |
-
-All the traffic keying material is recomputed, whenever the
+All the traffic keying material is recomputed whenever the
 underlying Secret changes (e.g., when changing from the handshake to
 application data keys or upon a key update).
 
-###  The Handshake Hash
 
-The handshake hash is defined as the hash of all handshake messages
-sent or received, starting at ClientHello up to the present time,
-with the exception of the client's 0-RTT authentication messages
-(Certificate, CertificateVerify, and Finished) including the type and
-length fields of the handshake messages. This is the concatenation
-the exchanged Handshake structures in plaintext form (even if
-they were encrypted on the wire).
-[[OPEN ISSUE: See https://github.com/tlswg/tls13-spec/issues/351
-for the question of whether the 0-RTT handshake messages are
-hashed.]]
+## (EC)DHE Shared Secret Calculation {#ecdhe-shared-secret-calculation}
 
-This final value of the handshake hash is referred to as the "session
-hash" because it contains all the handshake messages involved in
-establishing the session, up to and including the client's Finished.
+###  Finite Field Diffie-Hellman
 
-###  Diffie-Hellman
+For finite field groups, a conventional Diffie-Hellman computation is performed.
+The negotiated key (Z) is converted to a byte string by encoding in big-endian and
+padded with zeros up to the size of the prime. This byte string is used as the
+shared secret in the key schedule as specified above.
 
-A conventional Diffie-Hellman computation is performed. The negotiated key (Z)
-is used as the shared secret, and is used in the key schedule as
-specified above. Leading bytes of Z that contain all zero bits are stripped
-before it is used as the input to HKDF.
+Note that this construction differs from previous versions of TLS which remove
+leading zeros.
 
 ### Elliptic Curve Diffie-Hellman
 
@@ -3708,211 +4619,479 @@ other than for computing other secrets.)
 
 ECDH functions are used as follows:
 
-* The public key to put into ECPoint.point structure is the result of applying
-  the ECDH function to the secret key of appropriate length (into scalar
-  input) and the standard public basepoint (into u-coordinate point input).
-* The ECDH shared secret is the result of applying ECDH function to the secret
-  key (into scalar input) and the peer's public key (into u-coordinate point
-  input). The output is used raw, with no processing.
+- The public key to put into the KeyShareEntry.key_exchange structure is the
+  result of applying the ECDH scalar multiplication function to the secret key
+  of appropriate length (into scalar input) and the standard public basepoint
+  (into u-coordinate point input).
 
-For X25519 and X448, see {{I-D.irtf-cfrg-curves}}.
+- The ECDH shared secret is the result of applying the ECDH scalar multiplication
+  function to the secret key (into scalar input) and the peer's public key
+  (into u-coordinate point input). The output is used raw, with no processing.
+
+For X25519 and X448, implementations SHOULD use the approach specified
+in {{RFC7748}} to calculate the Diffie-Hellman shared secret.
+Implementations MUST check whether the computed Diffie-Hellman
+shared secret is the all-zero value and abort if so, as described in
+Section 6 of {{RFC7748}}. If implementers use an alternative
+implementation of these elliptic curves, they SHOULD perform the
+additional checks specified in Section 7 of {{RFC7748}}.
 
 
-#  Mandatory Algorithms
+## Exporters
 
-##  MTI Cipher Suites
+{{!RFC5705}} defines keying material exporters for TLS in terms of the TLS
+pseudorandom function (PRF). This document replaces the PRF with HKDF, thus
+requiring a new construction. The exporter interface remains the same.
+
+The exporter value is computed as:
+
+    HKDF-Expand-Label(Derive-Secret(Secret, label, ""),
+                      "exporter", Hash(context_value), key_length)
+
+Where Secret is either the early_exporter_master_secret or the
+exporter_master_secret.  Implementations MUST use the exporter_master_secret unless
+explicitly specified by the application. The early_exporter_master_secret is
+defined for use in settings where an exporter is needed for 0-RTT data.
+A separate interface for the early exporter is RECOMMENDED, especially
+on a server where a single interface can make the early exporter
+inaccessible.
+
+If no context is provided, the context_value is zero-length. Consequently,
+providing no context computes the same value as providing an empty context.
+This is a change from previous versions of TLS where an empty context produced a
+different output to an absent context. As of this document's publication, no
+allocated exporter label is used both with and without a context. Future
+specifications MUST NOT define a use of exporters that permit both an empty
+context and no context with the same label. New uses of exporters SHOULD provide
+a context in all exporter computations, though the value could be empty.
+
+Requirements for the format of exporter labels are defined in section 4
+of {{RFC5705}}.
+
+
+# 0-RTT and Anti-Replay {#anti-replay}
+
+As noted in {{zero-rtt-data}} and {{replay-0rtt}}, TLS does not provide inherent replay
+protections for 0-RTT data. There are two potential threats to be
+concerned with:
+
+- Network attackers who mount a replay attack by simply duplicating a
+  flight of 0-RTT data.
+
+- Network attackers who take advantage of client retry behavior
+  to arrange for the server to receive multiple copies of an application
+  message. This threat already exists
+  to some extent because clients that value robustness respond to network errors by
+  attempting to retry requests. However, 0-RTT adds an additional
+  dimension for any server system which does not maintain globally
+  consistent server state. Specifically, if a server system has
+  multiple zones where tickets from zone A will not be accepted in
+  zone B, then an attacker can duplicate a ClientHello and early
+  data intended for A to both A and B. At A, the data will
+  be accepted in 0-RTT, but at B the server will reject 0-RTT
+  data and instead force a full handshake. If the attacker blocks
+  the ServerHello from A, then the client will complete the
+  handshake with B and probably retry the request, leading to duplication on
+  the server system as a whole.
+
+The first class of attack can be prevented by the mechanism described
+in this section.  Servers need not permit 0-RTT at all, but those
+which do SHOULD implement either the single-use tickets or
+ClientHello recording techniques described in the following two
+sections.
+
+The second class of attack cannot be prevented at the TLS layer and
+MUST be dealt with by any application. Note that any application whose
+clients implement any kind of retry behavior already needs to
+implement some sort of anti-replay defense.
+
+In normal operation, clients will not know which, if any, of these
+mechanisms servers actually implement and therefore MUST only send
+early data which they are willing to have subject to the attacks
+described in {{replay-0rtt}}.
+
+
+## Single-Use Tickets
+
+The simplest form of anti-replay defense is for the server to only
+allow each session ticket to be used once. For instance, the server
+can maintain a database of all outstanding valid tickets; deleting each
+ticket from the database as it is used. If an unknown ticket is
+provided, the server would then fall back to a full handshake.
+
+If the tickets are not self-contained but rather are database keys,
+and the corresponding PSKs are deleted upon use, then connections established
+using one PSK enjoy forward security. This improves security for
+all 0-RTT data and PSK usage when PSK is used without (EC)DHE.
+
+Because this mechanism requires sharing the session database between
+server nodes in environments with multiple distributed servers,
+it may be hard to achieve high rates of successful PSK 0-RTT
+connections when compared to self-encrypted tickets. Unlike
+session databases, session tickets can successfully do PSK-based
+session establishment even without consistent storage, though when
+0-RTT is allowed they still require consistent storage for anti-replay
+of 0-RTT data, as detailed in the following
+section.
+
+## Client Hello Recording
+
+An alternative form of anti-replay is to record a unique value derived
+from the ClientHello (generally either the random value or the PSK
+binder) and reject duplicates. Recording all ClientHellos causes state
+to grow without bound, but a server can instead record ClientHellos within
+a given time window and use the "obfuscated_ticket_age" to ensure that
+tickets aren't reused outside that window.
+
+In order to implement this, when a ClientHello is received, the server
+first verifies the PSK binder as described
+{{pre-shared-key-extension}}. It then computes the
+expected_arrival_time as described in the next section and rejects
+0-RTT if it is outside the recording window, falling back to the
+1-RTT handshake.
+
+If the expected arrival time is in the window, then the server
+checks to see if it has recorded a matching ClientHello. If one
+is found, it either aborts the handshake with an "illegal_parameter" alert
+or accepts the PSK but reject 0-RTT. If no matching ClientHello
+is found, then it accepts 0-RTT and then stores the ClientHello for
+as long as the expected_arrival_time is inside the window.
+Servers MAY also implement data stores with false positives, such as
+Bloom filters, in which case they MUST respond to apparent replay by
+rejecting 0-RTT but MUST NOT abort the handshake.
+
+The server MUST derive the storage key only from validated sections
+of the ClientHello. If the ClientHello contains multiple
+PSK identities, then an attacker can create multiple ClientHellos
+with different binder values for the less-preferred identity on the
+assumption that the server will not verify it, as recommended
+by {{pre-shared-key-extension}}.
+I.e., if the
+client sends PSKs A and B but the server prefers A, then the
+attacker can change the binder for B without affecting the binder
+for A. This will cause the ClientHello to be accepted, and may
+cause side effects such as replay cache pollution, although any
+0-RTT data will not be decryptable because it will use different
+keys. If the validated binder or the ClientHello.random
+are used as the storage key, then this attack is not possible.
+
+Because this mechanism does not require storing all outstanding
+tickets, it may be easier to implement in distributed systems with
+high rates of resumption and 0-RTT, at the cost of potentially
+weaker anti-replay defense because of the difficulty of reliably
+storing and retrieving the received ClientHello messages.
+In many such systems, it is impractical to have globally
+consistent storage of all the received ClientHellos.
+In this case, the best anti-replay protection is provided by
+having a single storage zone be
+authoritative for a given ticket and refusing 0-RTT for that
+ticket in any other zone. This approach prevents simple
+replay by the attacker because only one zone will accept
+0-RTT data. A weaker design is to implement separate storage for
+each zone but allow 0-RTT in any zone. This approach limits
+the number of replays to once per zone. Application message
+duplication of course remains possible with either design.
+
+When implementations are freshly started, they SHOULD
+reject 0-RTT as long as any portion of their recording window overlaps
+the startup time. Otherwise, they run the risk of accepting
+replays which were originally sent during that period.
+
+Note: If the client's clock is running much faster than the server's
+then a ClientHello may be received that is outside the window in the
+future, in which case it might be accepted for 1-RTT, causing a client retry,
+and then acceptable later for 0-RTT. This is another variant of
+the second form of attack described above.
+
+
+
+## Freshness Checks
+
+Because the ClientHello indicates the time at which the client sent
+it, it is possible to efficiently determine whether a ClientHello was
+likely sent reasonably recently and only accept 0-RTT for such a
+ClientHello, otherwise falling back to a 1-RTT handshake.
+This is necessary for the ClientHello storage mechanism
+described in {{client-hello-recording}} because otherwise the server
+needs to store an unlimited number of ClientHellos and is a useful optimization for
+single-use tickets because it allows efficient rejection of ClientHellos
+which cannot be used for 0-RTT.
+
+In order to implement this mechanism, a server needs to store the time
+that the server generated the session ticket, offset by an estimate of
+the round trip time between client and server. I.e.,
+
+~~~~
+    adjusted_creation_time = creation_time + estimated_RTT
+~~~~
+
+This value can be encoded in the ticket, thus avoiding the need to
+keep state for each outstanding ticket. The server can determine the
+client's view of the age of the ticket by subtracting the ticket's
+"ticket_age_add value" from the "obfuscated_ticket_age" parameter in
+the client's "pre_shared_key" extension. The server can determine the
+"expected arrival time" of the ClientHello as:
+
+~~~~
+    expected_arrival_time = adjusted_creation_time + clients_ticket_age
+~~~~
+
+When a new ClientHello is received, the expected_arrival_time is then
+compared against the current server wall clock time and if they differ
+by more than a certain amount, 0-RTT is rejected, though the 1-RTT
+handshake can be allowed to complete.
+
+There are several potential sources of error that might cause
+mismatches between the expected arrival time and the measured
+time. Variations in client and server clock
+rates are likely to be minimal, though potentially with gross time
+corrections.  Network propagation delays are the most likely causes of
+a mismatch in legitimate values for elapsed time.  Both the
+NewSessionTicket and ClientHello messages might be retransmitted and
+therefore delayed, which might be hidden by TCP. For clients
+on the Internet, this implies windows
+on the order of ten seconds to account for errors in clocks and
+variations in measurements; other deployment scenarios
+may have different needs. Clock skew distributions are not
+symmetric, so the optimal tradeoff may involve an asymmetric range
+of permissible mismatch values.
+
+Note that freshness checking alone is not sufficient to prevent
+replays because it does not detect them during the error window,
+which, depending on bandwidth and system capacity could include
+billions of replays in real-world settings.  In addition, this
+freshness checking is only done at the time the ClientHello is
+received, and not when later early application data records are
+received. After early data is accepted, records may continue to be
+streamed to the server over a longer time period.
+
+#  Compliance Requirements
+
+##  Mandatory-to-Implement Cipher Suites
 
 In the absence of an application profile standard specifying otherwise, a
-TLS-compliant application MUST implement the following cipher suites:
+TLS-compliant application MUST implement the TLS_AES_128_GCM_SHA256 [GCM]
+cipher suite and SHOULD implement the TLS_AES_256_GCM_SHA384 [GCM] and
+TLS_CHACHA20_POLY1305_SHA256 [RFC7539] cipher suites.  (see
+{{cipher-suites}})
 
-~~~~
-    TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
-    TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
-~~~~
+A TLS-compliant application MUST support digital signatures with
+rsa_pkcs1_sha256 (for certificates), rsa_pss_sha256 (for
+CertificateVerify and certificates), and ecdsa_secp256r1_sha256. A
+TLS-compliant application MUST support key exchange with secp256r1
+(NIST P-256) and SHOULD support key exchange with X25519 {{RFC7748}}.
 
-These cipher suites MUST support both digital signatures and key exchange
-with secp256r1 (NIST P-256) and SHOULD support key exchange with X25519
-{{I-D.irtf-cfrg-curves}}.
 
-A TLS-compliant application SHOULD implement the following cipher suites:
-
-~~~~
-    TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
-    TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256
-    TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
-    TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
-~~~~
-
-##  MTI Extensions
+##  Mandatory-to-Implement Extensions {#mti-extensions}
 
 In the absence of an application profile standard specifying otherwise, a
 TLS-compliant application MUST implement the following TLS extensions:
 
-  * Signature Algorithms ("signature_algorithms"; {{signature-algorithms}})
-  * Negotiated Groups ("supported_groups"; {{negotiated-groups}})
-  * Key Share ("key_share"; {{key-share}})
-  * Pre-Shared Key Extension ("pre_shared_key"; {{pre-shared-key-extension}})
+  * Supported Versions     ("supported_versions"; {{supported-versions}})
+  * Cookie                 ("cookie"; {{cookie}})
+  * Signature Algorithms   ("signature_algorithms"; {{signature-algorithms}})
+  * Negotiated Groups      ("supported_groups"; {{negotiated-groups}})
+  * Key Share              ("key_share"; {{key-share}})
   * Server Name Indication ("server_name"; Section 3 of {{RFC6066}})
 
 All implementations MUST send and use these extensions when offering
-applicable cipher suites:
+applicable features:
 
-  * "signature_algorithms" is REQUIRED for certificate authenticated cipher suites
-  * "supported_groups" and "key_share" are REQUIRED for DHE or ECDHE cipher suites
-  * "pre_shared_key" is REQUIRED for PSK cipher suites
+  * "supported_versions"   is REQUIRED for all ClientHello messages.
+  * "signature_algorithms" is REQUIRED for certificate authentication.
+  * "supported_groups"     is REQUIRED for ClientHello messages using
+                            DHE or ECDHE key exchange.
+  * "key_share"            is REQUIRED for DHE or ECDHE key exchange.
+  * "pre_shared_key"       is REQUIRED for PSK key agreement.
 
-When negotiating use of applicable cipher suites, endpoints MUST abort the
-connection with a "missing_extension" alert if the required extension was
-not provided. Any endpoint that receives any invalid combination of cipher
-suites and extensions MAY abort the connection with a "missing_extension"
-alert, regardless of negotiated parameters.
+A client is considered to be attempting to negotiate using this
+specification if the ClientHello contains a "supported_versions"
+extension 0x0304 the highest version number contained in its body.
+Such a ClientHello message MUST meet the following requirements:
+
+ - If not containing a "pre_shared_key" extension, it MUST contain both
+   a "signature_algorithms" extension and a "supported_groups" extension.
+ - If containing a "supported_groups" extension, it MUST also contain a
+   "key_share" extension, and vice versa. An empty KeyShare.client_shares
+   vector is permitted.
+
+Servers receiving a ClientHello which does not conform to these
+requirements MUST abort the handshake with a "missing_extension"
+alert.
 
 Additionally, all implementations MUST support use of the "server_name"
 extension with applications capable of using it.
 Servers MAY require clients to send a valid "server_name" extension.
 Servers requiring this extension SHOULD respond to a ClientHello
-lacking a "server_name" extension with a fatal "missing_extension" alert.
-
-Some of these extensions exist only for the client to provide additional data
-to the server in a backwards-compatible way and thus have no meaning when sent
-from a server. The client-only extensions defined in this document
-are: "signature_algorithms" & "supported_groups".
-Servers MUST NOT send these extensions. Clients receiving any of these
-extensions MUST respond with a fatal "unsupported_extension" alert
-and close the connection.
-
-
-#  Application Data Protocol
-
-Application data messages are carried by the record layer and are fragmented
-and encrypted based on the current connection state. The messages
-are treated as transparent data to the record layer.
+lacking a "server_name" extension by terminating the connection with a
+"missing_extension" alert.
 
 
 #  Security Considerations
 
-Security issues are discussed throughout this memo, especially in Appendices B,
-C, and D.
+Security issues are discussed throughout this memo, especially in
+{{implementation-notes}}, {{backward-compatibility}}, and {{security-analysis}}.
 
 
 #  IANA Considerations
 
-[[TODO: Rename "RSA" in TLS SignatureAlgorithm Registry
-to RSASSA-PKCS1-v1_5 ]]
-
 This document uses several registries that were originally created in
-{{RFC4346}}. IANA has updated these to reference this document. The registries
-and their allocation policies are below:
+{{RFC4346}}. IANA has updated these to reference this document.
+The registries and their allocation policies are below:
 
-- TLS Cipher Suite Registry: Values with the first byte in the range
-  0-254 (decimal) are assigned via Specification Required {{RFC2434}}.
+- TLS Cipher Suite Registry: values with the first byte in the range
+  0-254 (decimal) are assigned via Specification Required {{RFC5226}}.
   Values with the first byte 255 (decimal) are reserved for Private
-  Use {{RFC2434}}. IANA [SHALL add/has added] a "Recommended" column
-  to the cipher suite registry. All cipher suites listed in
-  {{cipher-suites}} are marked as "Yes". All other cipher suites are
-  marked as "No". IANA [SHALL add/has added] add a note to this column
-  reading:
+  Use {{RFC5226}}.
 
-  > Cipher suites marked as "Yes" are those allocated via
-    Standards Track RFCs. Cipher suites marked as "No" are not;
-    cipher suites marked "No" range from "good" to "bad" from a
-    cryptographic standpoint.
+  IANA \[SHALL add/has added] the cipher suites listed in {{cipher-suites}} to
+  the registry. The "Value" and "Description" columns are taken from the table.
+  The "DTLS-OK" and "Recommended" columns are both marked as "Yes" for each new
+  cipher suite. \[\[This assumes {{?I-D.ietf-tls-iana-registry-updates}} has been
+  applied.]]
 
--  TLS ContentType Registry: Future values are allocated via
-  Standards Action {{RFC2434}}.
+- TLS ContentType Registry: Future values are allocated via
+  Standards Action {{RFC5226}}.
 
--  TLS Alert Registry: Future values are allocated via Standards
-  Action {{RFC2434}}.
+- TLS Alert Registry: Future values are allocated via Standards
+  Action {{RFC5226}}. IANA \[SHALL update/has updated] this registry
+  to include values for "missing_extension" and "certificate_required".
 
--  TLS HandshakeType Registry: Future values are allocated via
-  Standards Action {{RFC2434}}.
+- TLS HandshakeType Registry: Future values are allocated via
+  Standards Action {{RFC5226}}. IANA \[SHALL update/has updated] this registry
+  to rename item 4 from "NewSessionTicket" to "new_session_ticket"
+  and to add the "hello_retry_request", "encrypted_extensions",
+  "end_of_early_data", "key_update", and "handshake_hash" values.
 
-This document also uses a registry originally created in {{RFC4366}}. IANA has
-updated it to reference this document. The registry and its allocation policy
-is listed below:
+This document also uses the TLS ExtensionType Registry originally created in
+{{RFC4366}}. IANA has updated it to reference this document. The registry and
+its allocation policy is listed below:
 
-- TLS ExtensionType Registry: Values with the first byte in the range
-   0-254 (decimal) are assigned via Specification Required {{RFC2434}}.
-   Values with the first byte 255 (decimal) are reserved for Private
-   Use {{RFC2434}}. IANA [SHALL update/has updated]
-   this registry to include the "key_share", "pre_shared_key", and
-   "early_data" extensions as defined in this document.
+- IANA \[SHALL update/has updated] this registry to include the
+  "key_share", "pre_shared_key", "psk_key_exchange_modes",
+  "early_data", "cookie", "supported_versions",
+  "certificate_authorities", "oid_filters", and "post_handshake_auth"
+  extensions with the values defined in this document and the Recommended value of "Yes".
 
-   IANA [shall update/has updated] this registry to include a "TLS
-   1.3" column with the following four values: "Client", indicating
-   that the server shall not send them. "Clear", indicating
-   that they shall be in the ServerHello. "Encrypted", indicating that
-   they shall be in the EncryptedExtensions block, and "No" indicating
-   that they are not used in TLS 1.3. This column [shall be/has been]
-   initially populated with the values in this document.
-   IANA [shall update/has updated] this registry to add a
-   "Recommended" column. IANA [shall be/has been] initially populated
-   with the values in the table below. This column has been generated
-   by marking Standards Track RFCs as "Yes" and all others as
-   "No".
-
-| Extension                                | Recommended |  TLS 1.3  |
-|:-----------------------------------------|------------:|----------:|
-| server_name [RFC6066]                    |         Yes | Encrypted |
-| max_fragment_length [RFC6066]            |         Yes | Encrypted |
-| client_certificate_url [RFC6066]         |         Yes | Encrypted |
-| trusted_ca_keys [RFC6066]                |         Yes | Encrypted |
-| truncated_hmac [RFC6066]                 |         Yes |        No |
-| status_request [RFC6066]                 |         Yes |        No |
-| user_mapping [RFC4681]                   |         Yes | Encrypted |
-| client_authz [RFC5878]                   |          No | Encrypted |
-| server_authz [RFC5878]                   |          No | Encrypted |
-| cert_type [RFC6091]                      |         Yes | Encrypted |
-| supported_groups [RFC-ietf-tls-negotiated-ff-dhe] | Yes |   Client |
-| ec_point_formats [RFC4492]               |         Yes |        No |
-| srp [RFC5054]                            |          No |        No |
-| signature_algorithms [RFC5246]           |         Yes |    Client |
-| use_srtp [RFC5764]                       |         Yes | Encrypted |
-| heartbeat [RFC6520]                      |         Yes | Encrypted |
-| application_layer_protocol_negotiation[RFC7301] |  Yes | Encrypted |
-| status_request_v2 [RFC6961]              |         Yes | Encrypted |
-| signed_certificate_timestamp [RFC6962]   |          No | Encrypted |
-| client_certificate_type [RFC7250]        |         Yes | Encrypted |
-| server_certificate_type [RFC7250]        |         Yes | Encrypted |
-| padding [RFC7685]                        |         Yes |    Client |
-| encrypt_then_mac [RFC7366]               |         Yes |        No |
-| extended_master_secret [RFC7627]         |         Yes |        No |
-| SessionTicket TLS [RFC4507]              |         Yes |        No |
-| renegotiation_info [RFC5746]             |         Yes |        No |
-| key_share [[this document]]              |         Yes |     Clear |
-| pre_shared_key [[this document]]         |         Yes |     Clear |
-| early_data [[this document]]             |         Yes |     Clear |
-
-
-This document reuses two registries defined in {{RFC5246}}.
-
--  TLS SignatureAlgorithm Registry: The registry has been initially
-  populated with the values described in {{signature-algorithms}}.  Future
-  values in the range 0-63 (decimal) inclusive are assigned via
-  Standards Action {{RFC2434}}.  Values in the range 64-223 (decimal)
-  inclusive are assigned via Specification Required {{RFC2434}}.
-  Values from 224-255 (decimal) inclusive are reserved for Private
-  Use {{RFC2434}}.
-
--  TLS HashAlgorithm Registry: The registry has been initially
-  populated with the values described in {{signature-algorithms}}.  Future
-  values in the range 0-63 (decimal) inclusive are assigned via
-  Standards Action {{RFC2434}}.  Values in the range 64-223 (decimal)
-  inclusive are assigned via Specification Required {{RFC2434}}.
-  Values from 224-255 (decimal) inclusive are reserved for Private
-  Use {{RFC2434}}.
+- IANA \[SHALL update/has updated] this registry to include a "TLS
+  1.3" column which lists the messages in which the extension may
+  appear. This column \[SHALL be/has been]
+  initially populated from the table in {{extensions}}
+  with any extension not listed there marked as "-" to indicate that
+  it is not used by TLS 1.3.
 
 In addition, this document defines a new registry to be maintained
-by IANA.
+by IANA:
 
-- TLS ConfigurationExtensionType Registry: Values with the first byte in the range
-  0-254 (decimal) are assigned via Specification Required {{RFC2434}}.
-  Values with the first byte 255 (decimal) are reserved for Private
-  Use {{RFC2434}}. This registry SHALL have a "Recommended" column.
-  The registry [shall be/ has been] initially populated with the values described in
-  {{server-configuration}}, with all values marked with "Recommended" value
-  "Yes".
+- TLS SignatureScheme Registry: Values with the first byte in the range
+  0-253 (decimal) are assigned via Specification Required {{RFC5226}}.
+  Values with the first byte 254 or 255 (decimal) are reserved for Private
+  Use {{RFC5226}}. Values with the first byte in the range 0-6 or with the
+  second byte in the range 0-3 that are not currently allocated are reserved for
+  backwards compatibility.
+  This registry SHALL have a "Recommended" column.
+  The registry \[shall be/ has been] initially populated with the values described in
+  {{signature-algorithms}}. The following values SHALL be marked as
+  "Recommended": ecdsa_secp256r1_sha256, ecdsa_secp384r1_sha384,
+  rsa_pss_sha256, rsa_pss_sha384, rsa_pss_sha512, ed25519.
+
 --- back
+
+
+# State Machine
+
+This section provides a summary of the legal state transitions for the
+client and server handshakes.  State names (in all capitals, e.g.,
+START) have no formal meaning but are provided for ease of
+comprehension.  Actions which are taken only in certain circumstances are
+indicated in []. The notation "K_{send,recv} = foo" means "set the send/recv
+key to the given key".
+
+## Client
+
+~~~~
+                           START <----+
+            Send ClientHello |        | Recv HelloRetryRequest
+       [K_send = early data] |        |
+                             v        |
+        /                 WAIT_SH ----+
+        |                    | Recv ServerHello
+        |                    | K_recv = handshake
+    Can |                    V
+   send |                 WAIT_EE
+  early |                    | Recv EncryptedExtensions
+   data |           +--------+--------+
+        |     Using |                 | Using certificate
+        |       PSK |                 v
+        |           |            WAIT_CERT_CR
+        |           |        Recv |       | Recv CertificateRequest
+        |           | Certificate |       v
+        |           |             |    WAIT_CERT
+        |           |             |       | Recv Certificate
+        |           |             v       v
+        |           |              WAIT_CV
+        |           |                 | Recv CertificateVerify
+        |           +> WAIT_FINISHED <+
+        |                  | Recv Finished
+        \                  | [Send EndOfEarlyData]
+                           | K_send = handshake
+                           | [Send Certificate [+ CertificateVerify]]
+ Can send                  | Send Finished
+ app data   -->            | K_send = K_recv = application
+ after here                v
+                       CONNECTED
+~~~~
+
+Note that with the transitions as shown above, clients may send alerts
+that derive from post-ServerHello messages in the clear or with the
+early data keys. If clients need to send such alerts, they SHOULD
+first rekey to the handshake keys if possible.
+
+
+## Server
+
+~~~~
+                             START <-----+
+              Recv ClientHello |         | Send HelloRetryRequest
+                               v         |
+                            RECVD_CH ----+
+                               | Select parameters
+                               v
+                            NEGOTIATED
+                               | Send ServerHello
+                               | K_send = handshake
+                               | Send EncryptedExtensions
+                               | [Send CertificateRequest]
+Can send                       | [Send Certificate + CertificateVerify]
+app data                       | Send Finished
+after   -->                    | K_send = application
+here                  +--------+--------+
+             No 0-RTT |                 | 0-RTT
+   K_recv = handshake |                 | K_recv = early_data
+[Skip decrypt errors] |             WAIT_EOED <---+
+                      |            Recv |   |     | Recv
+                      |  EndOfEarlyData |   |     | Early data
+                      |        K_recv = |   +-----+
+                      |       handshake |
+                      |                 |
+                      +> WAIT_FLIGHT2 <-+
+                               |
+                      +--------+--------+
+              No auth |                 | Client auth
+                      |                 |
+                      |                 v
+                      |             WAIT_CERT
+                      |        Recv |       | Recv Certificate
+                      |       empty |       v
+                      | Certificate |    WAIT_CV
+                      |             |       | Recv
+                      |             v       | CertificateVerify
+                      +-> WAIT_FINISHED <---+
+                               | Recv Finished
+                               | K_recv = application
+                               v
+                           CONNECTED
+~~~~
 
 
 # Protocol Data Structures and Constant Values
@@ -3926,10 +5105,12 @@ might receive them from older TLS implementations.
 %%## Alert Messages
 %%## Handshake Protocol
 %%### Key Exchange Messages
+%%#### Version Extension
+%%#### Cookie Extension
 %%#### Signature Algorithm Extension
-%%#### Named Group Extension
+%%#### Supported Groups Extension
 
-Values within "obsolete_RESERVED" ranges were used in previous versions
+Values within "obsolete_RESERVED" ranges are used in previous versions
 of TLS and MUST NOT be offered or negotiated by TLS 1.3 implementations.
 The obsolete curves have various known/theoretical weaknesses or have
 had very little usage, in some cases only due to unintentional
@@ -3938,214 +5119,113 @@ for general use and should be assumed to be potentially unsafe. The set
 of curves specified here is sufficient for interoperability with all
 currently deployed and properly configured TLS implementations.
 
-#### Deprecated Extensions
-
-The following extensions are no longer applicable to TLS 1.3, although
-TLS 1.3 clients MAY send them if they are willing to negotiate them
-with prior versions of TLS. TLS 1.3 servers MUST ignore these
-extensions if they are negotiating TLS 1.3:
-truncated_hmac {{RFC6066}},
-srp {{RFC5054}},
-encrypt_then_mac {{RFC7366}},
-extended_master_secret {{RFC7627}},
-SessionTicket {{RFC5077}},
-and renegotiation_info {{RFC5746}}.
-
 %%### Server Parameters Messages
 %%### Authentication Messages
 %%### Ticket Establishment
+%%### Updating Keys
+
 
 ## Cipher Suites
 
-A cipher suite defines a cipher specification supported in TLS and negotiated
-via hello messages in the TLS handshake.
-Cipher suite names follow a general naming convention composed of a series
-of component algorithm names separated by underscores:
+A symmetric cipher suite defines the pair of the AEAD algorithm and hash
+algorithm to be used with HKDF.
+Cipher suite names follow the naming convention:
 
 ~~~
-   CipherSuite TLS_KEA_SIGN_WITH_CIPHER_HASH = VALUE;
+   CipherSuite TLS_AEAD_HASH = VALUE;
 ~~~
 
 | Component | Contents |
 |:----------|:---------|
 | TLS       | The string "TLS" |
-| KEA       | The key exchange algorithm |
-| SIGN      | The signature algorithm |
-| WITH      | The string "WITH" |
-| CIPHER    | The symmetric cipher used for record protection |
+| AEAD      | The AEAD algorithm used for record protection |
 | HASH      | The hash algorithm used with HKDF |
 | VALUE     | The two byte ID assigned for this cipher suite |
 
-The "CIPHER" component commonly has sub-components used to designate
-the cipher name, bits, and mode, if applicable. For example, "AES_256_GCM"
-represents 256-bit AES in the GCM mode of operation. Cipher suite names that
-lack a "HASH" value that are defined for use with TLS 1.2 or later use the
-SHA-256 hash algorithm by default.
+This specification defines the following cipher suites for use with TLS 1.3.
 
-The primary key exchange algorithm used in TLS is Ephemeral Diffie-Hellman
-{{DH}}. The finite field based version is denoted "DHE" and the elliptic
-curve based version is denoted "ECDHE". Prior versions of TLS supported
-non-ephemeral key exchanges, however these are not supported by TLS 1.3.
+|          Description            |    Value    |
+|:--------------------------------|:------------|
+| TLS_AES_128_GCM_SHA256          | {0x13,0x01} |
+| TLS_AES_256_GCM_SHA384          | {0x13,0x02} |
+| TLS_CHACHA20_POLY1305_SHA256    | {0x13,0x03} |
+| TLS_AES_128_CCM_SHA256          | {0x13,0x04} |
+| TLS_AES_128_CCM_8_SHA256        | {0x13,0x05} |
 
-See the definitions of each cipher suite in its specification document for
-the full details of each combination of algorithms that is specified.
+The corresponding AEAD algorithms AEAD_AES_128_GCM, AEAD_AES_256_GCM, and
+AEAD_AES_128_CCM are defined in {{RFC5116}}. AEAD_CHACHA20_POLY1305 is defined
+in {{RFC7539}}. AEAD_AES_128_CCM_8 is defined in {{RFC6655}}. The corresponding
+hash algorithms are defined in {{SHS}}.
 
-The following is a list of standards track server-authenticated (and optionally
-client-authenticated) cipher suites which are currently available in TLS 1.3:
-
-|              Cipher Suite Name                |    Value    | Specification |
-|:----------------------------------------------|:------------|:--------------|
-| TLS_DHE_RSA_WITH_AES_128_GCM_SHA256           | {0x00,0x9E} | [RFC5288]     |
-| TLS_DHE_RSA_WITH_AES_256_GCM_SHA384           | {0x00,0x9F} | [RFC5288]     |
-| TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256       | {0xC0,0x2B} | [RFC5289]     |
-| TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384       | {0xC0,0x2C} | [RFC5289]     |
-| TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256         | {0xC0,0x2F} | [RFC5289]     |
-| TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384         | {0xC0,0x30} | [RFC5289]     |
-| TLS_DHE_RSA_WITH_AES_128_CCM                  | {0xC0,0x9E} | [RFC6655]     |
-| TLS_DHE_RSA_WITH_AES_256_CCM                  | {0xC0,0x9F} | [RFC6655]     |
-| TLS_DHE_RSA_WITH_AES_128_CCM_8                | {0xC0,0xA2} | [RFC6655]     |
-| TLS_DHE_RSA_WITH_AES_256_CCM_8                | {0xC0,0xA3} | [RFC6655]     |
-| TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256   | {TBD,TBD}   | [I-D.ietf-tls-chacha20-poly1305] |
-| TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256 | {TBD,TBD}   | [I-D.ietf-tls-chacha20-poly1305] |
-| TLS_DHE_RSA_WITH_CHACHA20_POLY1305_SHA256     | {TBD,TBD}   | [I-D.ietf-tls-chacha20-poly1305] |
-
-[[TODO: CHACHA20_POLY1305_SHA256 cipher suite IDs are TBD.]]
-
-Note: ECDHE AES GCM was not yet standards track prior to the publication of
-this specification. This document promotes it to Standards Track.
-
-All cipher suites in this section are specified for use with both TLS 1.2
-and TLS 1.3, as well as the corresponding versions of DTLS.
-(see {{backward-compatibility}})
+Although TLS 1.3 uses the same cipher suite space as previous versions
+of TLS, TLS 1.3 cipher suites are defined differently, only specifying
+the symmetric ciphers, and cannot be used for TLS 1.2. Similarly,
+TLS 1.2 and lower cipher suites cannot be used with TLS 1.3.
 
 New cipher suite values are assigned by IANA as described in
 {{iana-considerations}}.
-
-### Unauthenticated Operation
-
-Previous versions of TLS offered explicitly unauthenticated cipher suites
-based on anonymous Diffie-Hellman. These cipher suites have been deprecated
-in TLS 1.3. However, it is still possible to negotiate cipher suites
-that do not provide verifiable server authentication by several methods,
-including:
-
-- Raw public keys {{RFC7250}}.
-- Using a public key contained in a certificate but without
-  validation of the certificate chain or any of its contents.
-
-Either technique used alone is are vulnerable to man-in-the-middle attacks
-and therefore unsafe for general use. However, it is also possible to
-bind such connections to an external authentication mechanism via
-out-of-band validation of the server's public key, trust on first
-use, or channel bindings {{RFC5929}}. [[NOTE: TLS 1.3 needs a new
-channel binding definition that has not yet been defined.]]
-If no such mechanism is used, then the connection has no protection
-against active man-in-the-middle attack; applications MUST NOT use TLS
-in such a way absent explicit configuration or a specific application
-profile.
-
-## The Security Parameters
-
-These security parameters are determined by the TLS Handshake Protocol and
-provided as parameters to the TLS record layer in order to initialize a
-connection state. SecurityParameters includes:
-
-%%! Security Parameters
-
-
-## Changes to RFC 4492
-
-RFC 4492 {{RFC4492}} adds Elliptic Curve cipher suites to TLS. This document
-changes some of the structures used in that document. This section details the
-required changes for implementors of both RFC 4492 and TLS 1.2. Implementors of
-TLS 1.2 who are not implementing RFC 4492 do not need to read this section.
-
-This document adds an "algorithm" field to the digitally-signed
-element in order to identify the signature and digest algorithms used to create
-a signature. This change applies to digital signatures formed using ECDSA as
-well, thus allowing ECDSA signatures to be used with digest algorithms other
-than SHA-1, provided such use is compatible with the certificate and any
-restrictions imposed by future revisions of {{RFC5280}}.
-
-As described in {{server-certificate-selection}}, the restrictions on the signature
-algorithms used to sign certificates are no longer tied to the cipher suite.
-Thus, the restrictions on the algorithm used to sign certificates specified in
-Sections 2 and 3 of RFC 4492 are also relaxed. As in this document, the
-restrictions on the keys in the end-entity certificate remain.
 
 
 # Implementation Notes
 
 The TLS protocol cannot prevent many common security mistakes. This section
 provides several recommendations to assist implementors.
-
+{{?I-D.ietf-tls-tls13-vectors}} provides test vectors for TLS 1.3 handshakes.
 
 ## Random Number Generation and Seeding
 
-TLS requires a cryptographically secure pseudorandom number generator (PRNG).
-Care must be taken in designing and seeding PRNGs. PRNGs based on secure hash
-operations, most notably SHA-256, are acceptable, but cannot provide more
-security than the size of the random number generator state.
-
-To estimate the amount of seed material being produced, add the number of bits
-of unpredictable information in each seed byte. For example, keystroke timing
-values taken from a PC compatible 18.2 Hz timer provide 1 or 2 secure bits
-each, even though the total size of the counter value is 16 bits or more.
-Seeding a 128-bit PRNG would thus require approximately 100 such timer values.
-
-{{RFC4086}} provides guidance on the generation of random values.
+TLS requires a cryptographically secure pseudorandom number generator (CSPRNG).
+In most cases, the operating system provides an appropriate facility such
+as /dev/urandom, which should be used absent other (performance) concerns.
+It is RECOMMENDED to use an existing CSPRNG implementation in
+preference to crafting a new one. Many adequate cryptographic libraries
+are already available under favorable license terms.  Should those prove
+unsatisfactory, {{RFC4086}} provides guidance on the generation of random values.
 
 
 ## Certificates and Authentication
 
 Implementations are responsible for verifying the integrity of certificates and
-should generally support certificate revocation messages. Certificates should
+should generally support certificate revocation messages. Absent a specific
+indication from an application profile, Certificates should
 always be verified to ensure proper signing by a trusted Certificate Authority
-(CA). The selection and addition of trusted CAs should be done very carefully.
-Users should be able to view information about the certificate and root CA.
-
-
-## Cipher Suite Support
-
-TLS supports a range of key sizes and security levels, including some that
-provide no or minimal security. A proper implementation will probably not
-support many cipher suites. Applications SHOULD also enforce minimum and
-maximum key sizes. For example, certification paths containing keys or
-signatures weaker than 2048-bit RSA or 224-bit ECDSA are not appropriate
-for secure applications.
-See also {{backwards-compatibility-security-restrictions}}.
+(CA). The selection and addition of trust anchors should be done very carefully.
+Users should be able to view information about the certificate and trust anchor.
+Applications SHOULD also enforce minimum and maximum key sizes. For example,
+certification paths containing keys or signatures weaker than 2048-bit RSA or
+224-bit ECDSA are not appropriate for secure applications.
 
 
 ## Implementation Pitfalls
 
 Implementation experience has shown that certain parts of earlier TLS
-specifications are not easy to understand, and have been a source of
+specifications are not easy to understand and have been a source of
 interoperability and security problems. Many of these areas have been clarified
-in this document, but this appendix contains a short list of the most important
+in this document but this appendix contains a short list of the most important
 things that require special attention from implementors.
 
 TLS protocol issues:
 
--  Do you correctly handle handshake messages that are fragmented to
-  multiple TLS records (see {{fragmentation}})? Including corner cases
+- Do you correctly handle handshake messages that are fragmented to
+  multiple TLS records (see {{record-layer}})? Including corner cases
   like a ClientHello that is split to several small fragments? Do
   you fragment handshake messages that exceed the maximum fragment
-  size? In particular, the certificate and certificate request
+  size? In particular, the Certificate and CertificateRequest
   handshake messages can be large enough to require fragmentation.
 
--  Do you ignore the TLS record layer version number in all TLS
+- Do you ignore the TLS record layer version number in all unencrypted TLS
   records? (see {{backward-compatibility}})
 
--  Have you ensured that all support for SSL, RC4, EXPORT ciphers, and
-  MD5 (via the "signature_algorithm" extension) is completely removed from
+- Have you ensured that all support for SSL, RC4, EXPORT ciphers, and
+  MD5 (via the "signature_algorithms" extension) is completely removed from
   all possible configurations that support TLS 1.3 or later, and that
   attempts to use these obsolete capabilities fail correctly?
   (see {{backward-compatibility}})
 
--  Do you handle TLS extensions in ClientHello correctly, including
-  omitting the extensions field completely?
+- Do you handle TLS extensions in ClientHello correctly, including
+  unknown extensions?
 
--  When the server has requested a client certificate, but no
+- When the server has requested a client certificate, but no
   suitable certificate is available, do you correctly send an empty
   Certificate message, instead of omitting the whole message (see
   {{client-certificate-selection}})?
@@ -4155,25 +5235,73 @@ TLS protocol issues:
   past the start of the cleartext in the event that the peer has sent
   a malformed plaintext of all-zeros?
 
+- Do you properly ignore unrecognized cipher suites
+  ({{client-hello}}), hello extensions ({{extensions}}), named groups
+  ({{negotiated-groups}}), key shares {{key-share}},
+  supported versions {{supported-versions}},
+  and signature algorithms ({{signature-algorithms}}) in the
+  ClientHello?
+
+- As a server, do you send a HelloRetryRequest to clients which
+  support a compatible (EC)DHE group but do not predict it in the
+  "key_share" extension? As a client, do you correctly handle a
+  HelloRetryRequest from the server?
+
 Cryptographic details:
 
--  What countermeasures do you use to prevent timing attacks against
-  RSA signing operations {{TIMING}}?
+- What countermeasures do you use to prevent timing attacks {{TIMING}}?
 
-- When verifying RSA signatures, do you accept both NULL and missing parameters
-  (see {{cryptographic-attributes}})? Do you verify that the RSA padding
-  doesn't have additional data after the hash value? {{FI06}}
+- When using Diffie-Hellman key exchange, do you correctly preserve
+  leading zero bytes in the negotiated key (see {{finite-field-diffie-hellman}})?
 
--  When using Diffie-Hellman key exchange, do you correctly strip
-  leading zero bytes from the negotiated key (see {{diffie-hellman}})?
-
--  Does your TLS client check that the Diffie-Hellman parameters sent
-  by the server are acceptable (see
-  {{diffie-hellman-key-exchange-with-authentication}})?
+- Does your TLS client check that the Diffie-Hellman parameters sent
+  by the server are acceptable, (see {{ffdhe-param}})?
 
 - Do you use a strong and, most importantly, properly seeded random number
-  generator (see {{random-number-generation-and-seeding}}) Diffie-Hellman
+  generator (see {{random-number-generation-and-seeding}}) when generating Diffie-Hellman
   private values, the ECDSA "k" parameter, and other security-critical values?
+  It is RECOMMENDED that implementations implement "deterministic ECDSA"
+  as specified in {{!RFC6979}}.
+
+- Do you zero-pad Diffie-Hellman public key values to the group size (see
+  {{ffdhe-param}})?
+
+- Do you verify signatures after making them to protect against RSA-CRT
+  key leaks? {{FW15}}
+
+
+## Client Tracking Prevention
+
+Clients SHOULD NOT reuse a ticket for multiple connections. Reuse
+of a ticket allows passive observers to correlate different connections.
+Servers that issue tickets SHOULD offer at least as many tickets
+as the number of connections that a client might use; for example, a web browser
+using HTTP/1.1 {{RFC7230}} might open six connections to a server. Servers SHOULD
+issue new tickets with every connection. This ensures that clients are
+always able to use a new ticket when creating a new connection.
+
+
+## Unauthenticated Operation
+
+Previous versions of TLS offered explicitly unauthenticated cipher suites based
+on anonymous Diffie-Hellman. These modes have been deprecated in TLS 1.3.
+However, it is still possible to negotiate parameters that do not provide
+verifiable server authentication by several methods, including:
+
+- Raw public keys {{RFC7250}}.
+- Using a public key contained in a certificate but without
+  validation of the certificate chain or any of its contents.
+
+Either technique used alone is vulnerable to man-in-the-middle attacks
+and therefore unsafe for general use. However, it is also possible to
+bind such connections to an external authentication mechanism via
+out-of-band validation of the server's public key, trust on first
+use, or a mechanism such as channel bindings (though the
+channel bindings described in {{RFC5929}} are not defined for
+TLS 1.3). If no such mechanism is used, then the connection has no protection
+against active man-in-the-middle attack; applications MUST NOT use TLS
+in such a way absent explicit configuration or a specific application
+profile.
 
 
 # Backward Compatibility
@@ -4187,10 +5315,14 @@ remains compatible and the client supports the highest protocol version availabl
 in the server.
 
 Prior versions of TLS used the record layer version number for various
-purposes. (TLSPlaintext.record_version & TLSCiphertext.record_version)
-As of TLS 1.3, this field is deprecated and its value MUST be ignored by all
-implementations. Version negotiation is performed using only the handshake versions.
-(ClientHello.client_version & ServerHello.server_version)
+purposes. (TLSPlaintext.legacy_record_version and TLSCiphertext.legacy_record_version)
+As of TLS 1.3, this field is deprecated. The value of
+TLSPlaintext.legacy_record_version MUST be ignored by all implementations.
+The value of TLSCiphertext.legacy_record_version MAY be ignored,
+or MAY be validated to match the fixed constant value.
+Version negotiation is performed using only the handshake versions
+(ClientHello.legacy_version,
+ClientHello "supported_versions" extension, and ServerHello.version).
 In order to maximize interoperability with older endpoints, implementations
 that negotiate the use of TLS 1.0-1.2 SHOULD set the record layer
 version number to the negotiated version for the ServerHello and all
@@ -4201,54 +5333,84 @@ deployments, all implementations SHOULD support validation of certification path
 based on the expectations in this document, even when handling prior TLS versions'
 handshakes. (see {{server-certificate-selection}})
 
+TLS 1.2 and prior supported an "Extended Master Secret" {{RFC7627}} extension
+which digested large parts of the handshake transcript into the master secret.
+Because TLS 1.3 always hashes in the transcript up to the server CertificateVerify,
+implementations which support both TLS 1.3 and earlier versions SHOULD
+indicate the use of the Extended Master Secret extension in their APIs
+whenever TLS 1.3 is used.
+
+
 ## Negotiating with an older server
 
-A TLS 1.3 client who wishes to negotiate with such older servers will send a
-normal TLS 1.3 ClientHello containing { 3, 4 } (TLS 1.3) in
-ClientHello.client_version. If the server does not support this version it
+A TLS 1.3 client who wishes to negotiate with servers that do not
+support TLS 1.3 will send a
+normal TLS 1.3 ClientHello containing 0x0303 (TLS 1.2) in
+ClientHello.legacy_version but with the correct version in the
+"supported_versions" extension. If the server does not support TLS 1.3 it
 will respond with a ServerHello containing an older version number. If the
 client agrees to use this version, the negotiation will proceed as appropriate
-for the negotiated protocol. A client resuming a session SHOULD initiate the
+for the negotiated protocol. A client using a ticket for resumption SHOULD initiate the
 connection using the version that was previously negotiated.
 
-If the version chosen by the server is not supported by the client (or not
-acceptable), the client MUST send a "protocol_version" alert message and close
-the connection.
+Note that 0-RTT data is not compatible with older servers and SHOULD NOT
+be sent absent knowledge that the server supports TLS 1.3.
+See {{zero-rtt-backwards-compatibility}}.
 
-If a TLS server receives a ClientHello containing a version number greater than
-the highest version supported by the server, it MUST reply according to the
-highest version supported by the server.
+If the version chosen by the server is not supported by the client (or not
+acceptable), the client MUST abort the handshake with a "protocol_version" alert.
 
 Some legacy server implementations are known to not implement the TLS
 specification properly and might abort connections upon encountering
-TLS extensions or versions which it is not aware of. Interoperability
+TLS extensions or versions which they are not aware of. Interoperability
 with buggy servers is a complex topic beyond the scope of this document.
 Multiple connection attempts may be required in order to negotiate
-a backwards compatible connection, however this practice is vulnerable
+a backwards compatible connection; however, this practice is vulnerable
 to downgrade attacks and is NOT RECOMMENDED.
 
 
 ## Negotiating with an older client
 
-A TLS server can also receive a ClientHello containing a version number smaller
-than the highest supported version. If the server wishes to negotiate with old
-clients, it will proceed as appropriate for the highest version supported by
-the server that is not greater than ClientHello.client_version. For example, if
-the server supports TLS 1.0, 1.1, and 1.2, and client_version is TLS 1.0, the
-server will proceed with a TLS 1.0 ServerHello. If the server only supports
-versions greater than client_version, it MUST send a "protocol_version"
-alert message and close the connection.
+A TLS server can also receive a ClientHello indicating a version number smaller
+than its highest supported version. If the "supported_versions" extension
+is present, the server MUST negotiate using that extension as described in
+{{supported-versions}}. If the "supported_versions" extension is not
+present, the server MUST negotiate the minimum of ClientHello.legacy_version
+and TLS 1.2. For example, if the server supports TLS 1.0, 1.1, and 1.2,
+and legacy_version is TLS 1.0, the server will proceed with a TLS 1.0 ServerHello.
+If the "supported_versions" extension is absent and the server only supports
+versions greater than ClientHello.legacy_version, the server MUST abort the handshake
+with a "protocol_version" alert.
 
 Note that earlier versions of TLS did not clearly specify the record layer
-version number value in all cases (TLSPlaintext.record_version). Servers
-will receive various TLS 1.x versions in this field, however its value
+version number value in all cases (TLSPlaintext.legacy_record_version). Servers
+will receive various TLS 1.x versions in this field, but its value
 MUST always be ignored.
+
+
+## Zero-RTT backwards compatibility
+
+0-RTT data is not compatible with older servers. An older server will respond
+to the ClientHello with an older ServerHello, but it will not correctly skip
+the 0-RTT data and will fail to complete the handshake. This can cause issues when
+a client attempts to use 0-RTT, particularly against multi-server deployments. For
+example, a deployment could deploy TLS 1.3 gradually with some servers
+implementing TLS 1.3 and some implementing TLS 1.2, or a TLS 1.3 deployment
+could be downgraded to TLS 1.2.
+
+A client that attempts to send 0-RTT data MUST fail a connection if it receives
+a ServerHello with TLS 1.2 or older.  A client that attempts to repair this
+error SHOULD NOT send a TLS 1.2 ClientHello, but instead send a TLS 1.3
+ClientHello without 0-RTT data.
+
+To avoid this error condition, multi-server deployments SHOULD ensure a uniform
+and stable deployment of TLS 1.3 without 0-RTT prior to enabling 0-RTT.
 
 
 ## Backwards Compatibility Security Restrictions
 
-If an implementation negotiates use of TLS 1.2, then negotiation of cipher
-suites also supported by TLS 1.3 SHOULD be preferred, if available.
+Implementations negotiating use of older versions of TLS SHOULD prefer
+forward secret and AEAD cipher suites, when available.
 
 The security of RC4 cipher suites is considered insufficient for the reasons
 cited in {{RFC7465}}. Implementations MUST NOT offer or negotiate RC4 cipher suites
@@ -4258,6 +5420,9 @@ Old versions of TLS permitted the use of very low strength ciphers.
 Ciphers with a strength less than 112 bits MUST NOT be offered or
 negotiated for any version of TLS for any reason.
 
+The security of SSL 3.0 {{SSL3}} is considered insufficient for the reasons enumerated
+in {{RFC7568}}, and MUST NOT be negotiated for any reason.
+
 The security of SSL 2.0 {{SSL2}} is considered insufficient for the reasons enumerated
 in {{RFC6176}}, and MUST NOT be negotiated for any reason.
 
@@ -4266,163 +5431,484 @@ Implementations MUST NOT negotiate TLS 1.3 or later using an SSL version 2.0 com
 CLIENT-HELLO. Implementations are NOT RECOMMENDED to accept an SSL version 2.0 compatible
 CLIENT-HELLO in order to negotiate older versions of TLS.
 
-Implementations MUST NOT send or accept any records with a version less than { 3, 0 }.
+Implementations MUST NOT send a ClientHello.legacy_version or ServerHello.version
+set to 0x0300 or less. Any endpoint receiving a Hello message with
+ClientHello.legacy_version or ServerHello.version set to 0x0300 MUST
+abort the handshake with a "protocol_version" alert.
 
-The security of SSL 3.0 {{SSL3}} is considered insufficient for the reasons enumerated
-in {{RFC7568}}, and MUST NOT be negotiated for any reason.
-
-Implementations MUST NOT send a ClientHello.client_version or ServerHello.server_version
-set to { 3, 0 } or less. Any endpoint receiving a Hello message with
-ClientHello.client_version or ServerHello.server_version set to { 3, 0 } MUST respond
-with a "protocol_version" alert message and close the connection.
+Implementations MUST NOT send any records with a version less than 0x0300.
+Implementations SHOULD NOT accept any records with a version less than 0x0300
+(but may inadvertently do so if the record version number is ignored completely).
 
 Implementations MUST NOT use the Truncated HMAC extension, defined in
-Section 7 of [RFC6066], as it is not applicable to AEAD ciphers and has
+Section 7 of [RFC6066], as it is not applicable to AEAD algorithms and has
 been shown to be insecure in some scenarios.
 
 
-#  Security Analysis
+#  Overview of Security Properties {#security-analysis}
 
-[[TODO: The entire security analysis needs a rewrite.]]
+A complete security analysis of TLS is outside the scope of this document.
+In this section, we provide an informal description the desired properties
+as well as references to more detailed work in the research literature
+which provides more formal definitions.
 
-The TLS protocol is designed to establish a secure connection between a client
-and a server communicating over an insecure channel. This document makes
-several traditional assumptions, including that attackers have substantial
-computational resources and cannot obtain secret information from sources
-outside the protocol. Attackers are assumed to have the ability to capture,
-modify, delete, replay, and otherwise tamper with messages sent over the
-communication channel. This appendix outlines how TLS has been designed to
-resist a variety of attacks.
+We cover properties of the handshake separately from those of the record layer.
 
 
-## Handshake Protocol
+## Handshake {#security-handshake}
 
-The TLS Handshake Protocol is responsible for selecting a cipher spec and
-generating a master secret, which together comprise the primary cryptographic
-parameters associated with a secure session. The TLS Handshake Protocol can also
-optionally authenticate parties who have certificates signed by a trusted
-certificate authority.
+The TLS handshake is an Authenticated Key Exchange (AKE) protocol which
+is intended to provide both one-way authenticated (server-only) and
+mutually authenticated (client and server) functionality. At the completion
+of the handshake, each side outputs its view of the following values:
 
-###  Authentication and Key Exchange
+- A set of "session keys" (the various secrets derived from the master secret)
+  from which can be derived a set of working keys.
+- A set of cryptographic parameters (algorithms, etc.)
+- The identities of the communicating parties.
 
-TLS supports three authentication modes: authentication of both parties, server
-authentication with an unauthenticated client, and total anonymity. Whenever
-the server is authenticated, the channel is secure against man-in-the-middle
-attacks, but completely anonymous sessions are inherently vulnerable to such
-attacks. Anonymous servers cannot authenticate clients. If the server is
-authenticated, its certificate message must provide a valid certificate chain
-leading to an acceptable certificate authority. Similarly, authenticated
-clients must supply an acceptable certificate to the server. Each party is
-responsible for verifying that the other's certificate is valid and has not
-expired or been revoked.
+We assume the attacker to be an active network attacker, which means it
+has complete control over the network used to communicate between the parties {{RFC3552}}.
+Even under these conditions, the handshake should provide the properties listed below.
+Note that these properties are not necessarily independent, but reflect
+the protocol consumers' needs.
 
-[[TODO: Rewrite this because the master_secret is not used this way any
-more after Hugo's changes.]]
-The general goal of the key exchange process is to create a master_secret
-known to the communicating parties and not to attackers (see
-{{key-schedule}}). The master_secret is required to generate the
-Finished messages and record protection keys (see {{finished}} and
-{{traffic-key-calculation}}). By sending a correct Finished message, parties thus prove
-that they know the correct master_secret.
+Establishing the same session keys.
+: The handshake needs to output the same set of session keys on both sides of
+the handshake, provided that it completes successfully on each endpoint
+(See {{CK01}}; defn 1, part 1).
 
-####  Diffie-Hellman Key Exchange with Authentication
+Secrecy of the session keys.
+: The shared session keys should be known only to the communicating
+  parties and not to the attacker (See {{CK01}}; defn 1, part 2).
+  Note that in a unilaterally authenticated connection, the attacker can establish
+  its own session keys with the server, but those session keys are distinct from
+  those established by the client.
 
-When Diffie-Hellman key exchange is used, the client and server use
-the "key_share" extension to send
-temporary Diffie-Hellman parameters. The signature in the certificate
-verify message (if present) covers the entire handshake up to that
-point and thus attests the certificate holder's desire to use the
-the ephemeral DHE keys.
+Peer Authentication.
+: The client's view of the peer identity should reflect the server's
+  identity. If the client is authenticated, the server's view of the
+  peer identity should match the client's identity.
 
-Peers SHOULD validate each other's public key Y (dh_Ys offered by
-the server or DH_Yc offered by the client) by ensuring that 1 < Y <
-p-1.  This simple check ensures that the remote peer is properly
-behaved and isn't forcing the local system into a small subgroup.
+Uniqueness of the session keys:
+: Any two distinct handshakes should produce distinct, unrelated session
+  keys. Individual session keys produced by a handshake should also be distinct
+  and unrelated.
 
-Additionally, using a fresh key for each handshake provides Perfect
-Forward Secrecy. Implementations SHOULD generate a new X for each
-handshake when using DHE cipher suites.
+Downgrade protection.
+: The cryptographic parameters should be the same on both sides and
+  should be the same as if the peers had been communicating in the
+  absence of an attack (See {{BBFKZG16}}; defns 8 and 9}).
 
-###  Version Rollback Attacks
+Forward secret with respect to long-term keys
+: If the long-term keying material (in this case the signature keys in certificate-based
+  authentication modes or the external/resumption PSK in PSK with (EC)DHE modes) is compromised after
+  the handshake is complete, this does not compromise the security of the
+  session key (See {{DOW92}}), as long as the session key itself has
+  been erased. The forward secrecy property is not satisfied
+  when PSK is used in the "psk_ke" PskKeyExchangeMode.
 
-Because TLS includes substantial improvements over SSL Version 2.0, attackers
-may try to make TLS-capable clients and servers fall back to Version 2.0. This
-attack can occur if (and only if) two TLS-capable parties use an SSL 2.0
-handshake. (See also {{backwards-compatibility-security-restrictions}}.)
+Key Compromise Impersonation (KCI) resistance
+: In a mutually-authenticated connection with certificates, peer authentication
+   should hold even if the local long-term secret was compromised before the
+   connection was established (see {{HGFS15}}). For example, if a client's
+   signature key is compromised, it should not be possible to impersonate
+   arbitrary servers to that client in subsequent handshakes.
 
-Although the solution using non-random PKCS #1 block type 2 message padding is
-inelegant, it provides a reasonably secure way for Version 3.0 servers to
-detect the attack. This solution is not secure against attackers who can
-brute-force the key and substitute a new ENCRYPTED-KEY-DATA message containing
-the same key (but with normal padding) before the application-specified wait
-threshold has expired. Altering the padding of the least-significant 8 bytes of
-the PKCS padding does not impact security for the size of the signed hashes and
-RSA key lengths used in the protocol, since this is essentially equivalent to
-increasing the input block size by 8 bytes.
+Protection of endpoint identities.
+: The server's identity (certificate) should be protected against passive
+  attackers. The client's identity should be protected against both passive
+  and active attackers.
+{:br}
 
-###  Detecting Attacks Against the Handshake Protocol
+Informally, the signature-based modes of TLS 1.3 provide for the
+establishment of a unique, secret, shared key established by an
+(EC)DHE key exchange and authenticated by the server's signature over
+the handshake transcript, as well as tied to the server's identity by
+a MAC. If the client is authenticated by a certificate, it also signs
+over the handshake transcript and provides a MAC tied to both
+identities. {{SIGMA}} describes the design and analysis of this type of key
+exchange protocol. If fresh (EC)DHE keys are used for each connection,
+then the output keys are forward secret.
 
-An attacker might try to influence the handshake exchange to make the parties
-select different encryption algorithms than they would normally choose.
+The external PSK and resumption PSK bootstrap from a long-term shared
+secret into a unique per-connection set of short-term session keys. This
+secret may have been established in a previous handshake. If
+PSK with (EC)DHE key establishment is used, these session keys will also be forward
+secret. The resumption PSK has been designed so that the
+resumption master secret computed by connection N and needed to form
+connection N+1 is separate from the traffic keys used by connection N,
+thus providing forward secrecy between the connections.
+In addition, if multiple tickets are established on the same
+connection, they are associated with different keys, so compromise of
+the PSK associated with one ticket does not lead to the compromise of
+connections established with PSKs associated with other tickets.
+This property is most interesting if tickets are stored in a database
+(and so can be deleted) rather than if they are self-encrypted.
 
-For this attack, an attacker must actively change one or more handshake
-messages. If this occurs, the client and server will compute different values
-for the handshake message hashes. As a result, the parties will not accept each
-others' Finished messages. Without the static secret, the attacker cannot
-repair the Finished messages, so the attack will be discovered.
+The PSK binder value forms a binding between a PSK
+and the current handshake, as well as between the session where the
+PSK was established and the session where it was used. This binding
+transitively includes the original handshake transcript, because that
+transcript is digested into the values which produce the Resumption
+Master Secret. This requires that both the KDF used to produce the
+resumption master secret and the MAC used to compute the binder be collision
+resistant. See {{key-derivation-and-hkdf}} for more on this.
+Note: The binder does not cover the binder values from other
+PSKs, though they are included in the Finished MAC.
+
+Note: TLS does not currently permit the server to send a certificate_request
+message in non-certificate-based handshakes (e.g., PSK).
+If this restriction were to be relaxed in future, the
+client's signature would not cover the server's certificate directly.
+However, if the PSK was established through a NewSessionTicket, the client's
+signature would transitively cover the server's certificate through
+the PSK binder. {{PSK-FINISHED}}
+describes a concrete attack on constructions that do not bind to
+the server's certificate (see also {{Kraw16}}). It is unsafe to use certificate-based client
+authentication when the client might potentially share the same
+PSK/key-id pair with two different endpoints. Implementations MUST NOT combine
+external PSKs with certificate-based authentication of either the
+client or the server.
+
+If an exporter is used, then it produces values which are unique
+and secret (because they are generated from a unique session key).
+Exporters computed with different labels and contexts are computationally
+independent, so it is not feasible to compute one from another or
+the session secret from the exported value. Note: exporters can
+produce arbitrary-length values. If exporters are to be
+used as channel bindings, the exported value MUST be large
+enough to provide collision resistance. The exporters provided in
+TLS 1.3 are derived from the same handshake contexts as the
+early traffic keys and the application traffic keys respectively,
+and thus have similar security properties. Note that they do
+not include the client's certificate; future applications
+which wish to bind to the client's certificate may need
+to define a new exporter that includes the full handshake
+transcript.
+
+For all handshake modes, the Finished MAC (and where present, the
+signature), prevents downgrade attacks. In addition, the use of
+certain bytes in the random nonces as described in {{server-hello}}
+allows the detection of downgrade to previous TLS versions.
+See {{BBFKZG16}} for more detail on TLS 1.3 and downgrade.
+
+As soon as the client and the server have exchanged enough information
+to establish shared keys, the remainder of the handshake is encrypted,
+thus providing protection against passive attackers, even if the
+computed shared key is not authenticated. Because the server
+authenticates before the client, the client can ensure that if it
+authenticates to the server, it only
+reveals its identity to an authenticated server. Note that implementations
+must use the provided record padding mechanism during the handshake
+to avoid leaking information about the identities due to length.
+The client's proposed PSK identities are not encrypted, nor is the
+one that the server selects.
+
+### Key Derivation and HKDF
+
+Key derivation in TLS 1.3 uses the HKDF function defined in {{RFC5869}} and
+its two components, HKDF-Extract and HKDF-Expand. The full rationale for the HKDF
+construction can be found in [Kraw10] and the rationale for the way it is used
+in TLS 1.3 in [KW16].  Throughout this document, each
+application of HKDF-Extract is followed by one or more invocations of
+HKDF-Expand. This ordering should always be followed (including in future
+revisions of this document), in particular, one SHOULD NOT use an output of
+HKDF-Extract as an input to another application of HKDF-Extract without an
+HKDF-Expand in between. Consecutive applications of HKDF-Expand are allowed as
+long as these are differentiated via the key and/or the labels.
+
+Note that HKDF-Expand implements a pseudorandom function (PRF) with both inputs and
+outputs of variable length. In some of the uses of HKDF in this document
+(e.g., for generating exporters and the resumption_master_secret), it is necessary
+that the application of HKDF-Expand be collision-resistant, namely, it should
+be infeasible to find two different inputs to HKDF-Expand that output the same
+value. This requires the underlying hash function to be collision resistant
+and the output length from HKDF-Expand to be of size at least 256 bits (or as
+much as needed for the hash function to prevent finding collisions).
+
+### Client Authentication
+
+A client that has sent authentication data to a server, either during
+the handshake or in post-handshake authentication, cannot be sure if
+the server afterwards considers the client to be authenticated or not.
+If the client needs to determine if the server considers the
+connection to be unilaterally or mutually authenticated, this has to
+be provisioned by the application layer. See {{CHHSV17}} for details.
+In addition, the analysis of post-handshake authentication from
+[Kraw16] shows that the client identified by the certificate sent in
+the post-handshake phase possesses the traffic key. This party is
+therefore the client that participated in the original handshake or
+one to whom the original client delegated the traffic key (assuming
+that the traffic key has not been compromised).
+
+### 0-RTT
+
+The 0-RTT mode of operation generally provides similar security
+properties as 1-RTT data, with the two exceptions that the 0-RTT
+encryption keys do not provide full forward secrecy and that the
+server is not able to guarantee uniqueness of the handshake
+(non-replayability) without keeping potentially undue amounts of
+state. See {{early-data-indication}} for one mechanism to limit
+the exposure to replay.
+
+### Exporter Independence
+
+The exporter_master_secret and early_exporter_master_secret are
+derived to be independent of the traffic keys and therefore do
+not represent a threat to the security of traffic encrypted with
+those keys. However, because these secrets can be used to
+compute any exporter value, they SHOULD be erased as soon as
+possible. If the total set of exporter labels is known, then
+implementations SHOULD pre-compute the inner Derive-Secret
+stage of the exporter computation for all those labels,
+then erase the \[early_]exporter_master_secret, followed by
+each inner values as soon as it is known that it will not be
+needed again.
+
+### Post-Compromise Security
+
+TLS does not provide security for handshakes which take place after the peer's
+long-term secret (signature key or external PSK) is compromised. It therefore
+does not provide post-compromise security {{CCG16}}, sometimes also referred to
+as backwards or future secrecy. This is in contrast to KCI resistance, which
+describes the security guarantees that a party has after its own long-term
+secret has been compromised.
+
+### External References
+
+The reader should refer to the following references for analysis of the
+TLS handshake: {{DFGS15}} {{CHSV16}} {{DFGS16}} {{KW16}} {{Kraw16}} {{FGSW16}}
+{{LXZFH16}} {{FG17}} {{BBK17}}.
 
 
-## Protecting Application Data
+## Record Layer {#security-record-layer}
 
-The shared secrets are hashed with the handshake transcript
-to produce unique record protection secrets for each connection.
+The record layer depends on the handshake producing strong traffic secrets
+which can be used to derive bidirectional encryption keys and nonces.
+Assuming that is true, and the keys are used for no more data than
+indicated in {{limits-on-key-usage}} then the record layer should provide the following
+guarantees:
 
-Outgoing data is protected using an AEAD algorithm before transmission. The
-authentication data includes the sequence number, message type, message length,
-and the message contents. The message type field is necessary to ensure that messages
-intended for one TLS record layer client are not redirected to another. The
-sequence number ensures that attempts to delete or reorder messages will be
-detected. Since sequence numbers are 64 bits long, they should never overflow.
-Messages from one party cannot be inserted into the other's output, since they
-use independent keys.
+Confidentiality.
+: An attacker should not be able to determine the plaintext contents
+  of a given record.
+{::comment}Cite IND-CPA?{:/comment}
+
+Integrity.
+: An attacker should not be able to craft a new record which is
+  different from an existing record which will be accepted by the receiver.
+{::comment}Cite INT-CTXT?{:/comment}
+
+Order protection/non-replayability
+: An attacker should not be able to cause the receiver to accept a
+  record which it has already accepted or cause the receiver to accept
+  record N+1 without having first processed record N.
+
+Length concealment.
+: Given a record with a given external length, the attacker should not be able
+to determine the amount of the record that is content versus padding.
+
+Forward secrecy after key change.
+: If the traffic key update mechanism described in {{key-update}} has been
+  used and the previous generation key is deleted, an attacker who compromises
+  the endpoint should not be able to decrypt traffic encrypted with the old key.
+{:br}
+
+Informally, TLS 1.3 provides these properties by AEAD-protecting the
+plaintext with a strong key. AEAD encryption {{RFC5116}} provides confidentiality
+and integrity for the data. Non-replayability is provided by using
+a separate nonce for each record, with the nonce being derived from
+the record sequence number ({{nonce}}), with the sequence
+number being maintained independently at both sides thus records which
+are delivered out of order result in AEAD deprotection failures.
+In order to prevent mass cryptanalysis when the same plaintext is
+repeatedly encrypted by different users under the same key
+(as is commonly the case for HTTP), the nonce is formed by mixing
+the sequence number with a secret per-connection initialization
+vector derived along with the traffic keys.
+See {{BT16}} for analysis of this construction.
+
+The re-keying technique in TLS 1.3 (see {{updating-traffic-keys}}) follows the
+construction of the serial generator in [REKEY], which shows that re-keying can
+allow keys to be used for a larger number of encryptions than without
+re-keying. This relies on the security of the HKDF-Expand-Label function as a
+pseudorandom function (PRF).  In addition, as long as this function is truly
+one way, it is not possible to compute traffic keys from prior to a key change
+(forward secrecy).
+
+TLS does not provide security for data which is communicated on a connection
+after a traffic secret of that connection is compromised. That is, TLS does not
+provide post-compromise security/future secrecy/backward secrecy with respect
+to the traffic secret. Indeed, an attacker who learns a traffic secret can
+compute all future traffic secrets on that connection.  Systems which want such
+guarantees need to do a fresh handshake and establish a new connection with an
+(EC)DHE exchange.
+
+### External References
+
+The reader should refer to the following references for analysis of the TLS record layer:
+{{BMMT15}} {{BT16}} {{BDFKPPRSZZ16}} {{BBK17}}.
 
 
-## Denial of Service
+## Traffic Analysis
 
-TLS is susceptible to a number of denial-of-service (DoS) attacks. In
-particular, an attacker who initiates a large number of TCP connections can
-cause a server to consume large amounts of CPU doing asymmetric crypto
-operations. However, because TLS is generally used over TCP, it is difficult for the
-attacker to hide their point of origin if proper TCP SYN randomization is used
-{{RFC1948}} by the TCP stack.
+TLS is susceptible to a variety of traffic analysis attacks based on
+observing the length and timing of encrypted packets
+{{?CLINIC=DOI.10.1007/978-3-319-08506-7_8}}
+{{?HCJ16=DOI.10.1186/s13635-016-0030-7}}.
+This is particularly easy when there is a small
+set of possible messages to be distinguished, such as for a video
+server hosting a fixed corpus of content, but still provides usable
+information even in more complicated scenarios.
 
-Because TLS runs over TCP, it is also susceptible to a number of DoS attacks on
-individual connections. In particular, attackers can forge RSTs, thereby
-terminating connections, or forge partial TLS records, thereby causing the
-connection to stall. These attacks cannot in general be defended against by a
-TCP-using protocol. Implementors or users who are concerned with this class of
-attack should use IPsec AH {{RFC4302}} or ESP {{RFC4303}}.
+TLS does not provide any specific defenses against this form of attack
+but does include a padding mechanism for use by applications: The
+plaintext protected by the AEAD function consists of content plus
+variable-length padding, which allows the application to produce
+arbitrary length encrypted records as well as padding-only cover traffic to
+conceal the difference between periods of transmission and periods
+of silence. Because the
+padding is encrypted alongside the actual content, an attacker cannot
+directly determine the length of the padding, but may be able to
+measure it indirectly by the use of timing channels exposed during
+record processing (i.e., seeing how long it takes to process a
+record or trickling in records to see which ones elicit a response
+from the server). In general, it is not known how to remove all of
+these channels because even a constant time padding removal function will
+then feed the content into data-dependent functions.
+
+Note: Robust
+traffic analysis defences will likely lead to inferior performance
+due to delay in transmitting packets and increased traffic volume.
 
 
-## Final Notes
+## Side Channel Attacks
 
-For TLS to be able to provide a secure connection, both the client and server
-systems, keys, and applications must be secure. In addition, the implementation
-must be free of security errors.
+In general, TLS does not have specific defenses against side-channel
+attacks (i.e., those which attack the communications via secondary
+channels such as timing) leaving those to the implementation of the relevant
+cryptographic primitives. However, certain features of TLS are
+designed to make it easier to write side-channel resistant code:
 
-The system is only as strong as the weakest key exchange and authentication
-algorithm supported, and only trustworthy cryptographic functions should be
-used. Short public keys and anonymous servers should be used with great
-caution. Implementations and users must be careful when deciding which
-certificates and certificate authorities are acceptable; a dishonest
-certificate authority can do tremendous damage.
+- Unlike previous versions of TLS which used a composite
+  MAC-then-encrypt structure, TLS 1.3 only uses AEAD algorithms,
+  allowing implementations to use self-contained constant-time
+  implementations of those primitives.
+
+- TLS uses a uniform "bad_record_mac" alert for all decryption
+  errors, which is intended to prevent an attacker from gaining
+  piecewise insight into portions of the message.  Additional resistance
+  is provided by terminating the connection on such errors; a new
+  connection will have different cryptographic material, preventing
+  attacks against the cryptographic primitives that require multiple
+  trials.
+
+Information leakage through side channels can occur at layers above
+TLS, in application protocols and the applications that use
+them. Resistance to side-channel attacks depends on applications and
+application protocols separately ensuring that confidential
+information is not inadvertently leaked.
+
+
+## Replay Attacks on 0-RTT {#replay-0rtt}
+
+Replayable 0-RTT data presents a number of security threats to
+TLS-using applications, unless those applications are specifically
+engineered to be safe under replay
+(minimally, this means idempotent, but in many cases may
+also require other stronger conditions, such as constant-time
+response). Potential attacks include:
+
+- Duplication of actions which cause side effects (e.g., purchasing an
+item or transferring money) to be duplicated, thus harming the site or
+the user.
+
+- Attackers can store and replay 0-RTT messages in order to
+re-order them with respect to other messages (e.g., moving
+a delete to after a create).
+
+- Exploiting cache timing behavior to discover the content of 0-RTT
+messages by replaying a 0-RTT message to a different cache node
+and then using a separate connection to measure request latency,
+to see if the two requests address the same resource.
+
+If data can be replayed a large number of times, additional attacks
+become possible, such as making repeated measurements of the
+the speed of cryptographic operations. In addition, they may
+be able to overload rate-limiting systems. For further description of
+these attacks, see {{Mac17}}.
+
+Ultimately, servers have the responsibility to protect themselves
+against attacks employing 0-RTT data replication. The mechanisms
+described in {{anti-replay}} are intended to
+prevent replay at the TLS layer but do not provide complete protection
+against receiving multiple copies of client data.
+TLS 1.3 falls back to the 1-RTT
+handshake when the server does not have any information about the
+client, e.g., because it is in a different cluster which does not
+share state or because the ticket has been deleted as described in
+{{single-use-tickets}}. If the application layer protocol retransmits
+data in this setting, then it is possible for an attacker to induce
+message duplication by sending the ClientHello to both the original cluster
+(which processes the data immediately) and another cluster which will
+fall back to 1-RTT and process the data upon application layer
+replay. The scale of this attack is limited by the client's
+willingness to retry transactions and therefore only allows a limited amount
+of duplication, with each copy appearing as a new connection at
+the server.
+
+If implemented correctly, the mechanisms described in
+{{single-use-tickets}} and {{client-hello-recording}} prevent a
+replayed ClientHello and its associated 0-RTT data from being accepted
+multiple times by any cluster with consistent state; for servers
+which limit the use of 0-RTT to one cluster for a single ticket, then a given
+ClientHello and its associated 0-RTT data will only be accepted once.
+However, if state is not completely consistent,
+then an attacker might be able to have multiple copies of the data be
+accepted during the replication window.
+Because clients do not know the exact details of server behavior, they
+MUST NOT send messages in early data which are not safe to have
+replayed and which they would not be willing to retry across multiple
+1-RTT connections.
+
+Application protocols MUST NOT use 0-RTT data without a profile that
+defines its use. That profile needs to identify which messages or
+interactions are safe to use with 0-RTT and how to handle the
+situation when the server rejects 0-RTT and falls back to 1-RTT.
+
+In addition, to avoid accidental misuse, TLS implementations MUST NOT
+enable 0-RTT (either sending or accepting) unless specifically
+requested by the application and MUST NOT automatically resend 0-RTT
+data if it is rejected by the server unless instructed by the
+application. Server-side applications may wish to implement special
+processing for 0-RTT data for some kinds of application traffic (e.g.,
+abort the connection, request that data be resent at the application
+layer, or delay processing until the handshake completes). In order to
+allow applications to implement this kind of processing, TLS
+implementations MUST provide a way for the application to determine if
+the handshake has completed.
+
+### Replay and Exporters
+
+Replays of the ClientHello produce the same early exporter, thus
+requiring additional care by applications which use these exporters.
+In particular, if these exporters are used as an authentication
+channel binding (e.g., by signing the output of the exporter)
+an attacker who compromises the PSK can transplant authenticators
+between connections without compromising the authentication key.
+
+In addition, the early exporter SHOULD NOT be used to generate
+server-to-client encryption keys because that would entail
+the reuse of those keys. This parallels the use of the early
+application traffic keys only in the client-to-server direction.
 
 
 # Working Group Information
 
 The discussion list for the IETF TLS working group is located at the e-mail
 address <tls@ietf.org>. Information on the group and information on how to
-subscribe to the list is at <https://www1.ietf.org/mailman/listinfo/tls>
+subscribe to the list is at <https://www.ietf.org/mailman/listinfo/tls>
 
 Archives of the list can be found at:
 <https://www.ietf.org/mail-archive/web/tls/current/index.html>
@@ -4438,11 +5924,21 @@ Archives of the list can be found at:
   Alacrity Ventures \\
   ChristopherA@AlacrityManagement.com
 
+* Richard Barnes \\
+  Cisco \\
+  rlb@ipv.sx
+
 * Steven M. Bellovin \\
   Columbia University \\
   smb@cs.columbia.edu
 
-* Benjamin Beurdouche
+* David Benjamin \\
+  Google \\
+  davidben@google.com
+
+* Benjamin Beurdouche \\
+  INRIA & Microsoft Research \\
+  benjamin.beurdouche@ens.fr
 
 * Karthikeyan Bhargavan (co-author of [RFC7627]) \\
   INRIA \\
@@ -4460,9 +5956,21 @@ Archives of the list can be found at:
   IBM \\
   canetti@watson.ibm.com
 
+* Matt Caswell \\
+  OpenSSL \\
+  matt@openssl.org
+
 * Pete Chown \\
   Skygate Technology Ltd \\
   pc@skygate.co.uk
+
+* Katriel Cohn-Gordon \\
+  University of Oxford \\
+  me@katriel.co.uk
+
+* Cas Cremers \\
+  University of Oxford \\
+  cas.cremers@cs.ox.ac.uk
 
 * Antoine Delignat-Lavaud (co-author of [RFC7627]) \\
   INRIA \\
@@ -4487,7 +5995,28 @@ Archives of the list can be found at:
 * Anil Gangolli \\
   anil@busybuddha.org
 
-* David M. Garrett
+* David M. Garrett \\
+  dave@nulldereference.com
+
+* Alessandro Ghedini \\
+  Cloudflare Inc. \\
+  alessandro@cloudflare.com
+
+* Daniel Kahn Gillmor \\
+  ACLU \\
+  dkg@fifthhorseman.net
+
+* Matthew Green \\
+  Johns Hopkins University \\
+  mgreen@cs.jhu.edu
+
+* Jens Guballa \\
+  ETAS \\
+  jens.guballa@etas.com
+
+* Felix Guenther \\
+  TU Darmstadt \\
+  mail@felixguenther.info
 
 * Vipul Gupta (co-author of [RFC4492]) \\
   Sun Microsystems Laboratories \\
@@ -4505,11 +6034,30 @@ Archives of the list can be found at:
   Independent Consultant \\
   david.hopwood@blueyonder.co.uk
 
-* Daniel Kahn Gillmor \\
-  ACLU \\
-  dkg@fifthhorseman.net
+* Marko Horvat \\
+  MPI-SWS \\
+  mhorvat@mpi-sws.org
+
+* Jonathan Hoyland \\
+  Royal Holloway, University of London
+
+* Subodh Iyengar \\
+  Facebook \\
+  subodh@fb.com
+
+* Benjamin Kaduk \\
+  Akamai \\
+  kaduk@mit.edu
+
+* Hubert Kario \\
+  Red Hat Inc. \\
+  hkario@redhat.com
 
 * Phil Karlton (co-author of SSL 3.0)
+
+* Leon Klingele \\
+  Independent \\
+  mail@leonklingele.de
 
 * Paul Kocher (co-author of SSL 3.0) \\
   Cryptography Research \\
@@ -4517,15 +6065,35 @@ Archives of the list can be found at:
 
 * Hugo Krawczyk \\
   IBM \\
-  hugo@ee.technion.ac.il
+  hugokraw@us.ibm.com
 
 * Adam Langley (co-author of [RFC7627]) \\
   Google \\
   agl@google.com
 
+* Olivier Levillain \\
+  ANSSI \\
+  olivier.levillain@ssi.gouv.fr
+
+* Xiaoyin Liu \\
+  University of North Carolina at Chapel Hill \\
+  xiaoyin.l@outlook.com
+
 * Ilari Liusvaara \\
   Independent \\
   ilariliusvaara@welho.com
+
+* Atul Luykx \\
+  K.U. Leuven \\
+  atul.luykx@kuleuven.be
+
+* Colm MacCarthaigh \\
+  Amazon Web Services \\
+  colm@allcosts.net
+
+* Carl Mehner \\
+  USAA \\
+  carl.mehner@usaa.com
 
 * Jan Mikkelsen \\
   Transactionware \\
@@ -4535,13 +6103,25 @@ Archives of the list can be found at:
   Google \\
   bodo@openssl.org
 
+* Kyle Nekritz \\
+  Facebook \\
+  knekritz@fb.com
+
 * Erik Nygren \\
   Akamai Technologies \\
   erik+ietf@nygren.org
 
 * Magnus Nystrom \\
-  RSA Security \\
-  magnus@rsasecurity.com
+  Microsoft \\
+  mnystrom@microsoft.com
+
+* Kazuho Oku \\
+  DeNA Co., Ltd. \\
+  kazuhooku@gmail.com
+
+* Kenny Paterson \\
+  Royal Holloway, University of London \\
+  kenny.paterson@rhul.ac.uk
 
 * Alfredo Pironti (co-author of [RFC7627]) \\
   INRIA \\
@@ -4559,23 +6139,75 @@ Archives of the list can be found at:
   Netscape Communications \\
   relyea@netscape.com
 
+* Kyle Rose \\
+  Akamai Technologies \\
+  krose@krose.org
+
 * Jim Roskind \\
-  Netscape Communications \\
-  jar@netscape.com
+  Amazon \\
+  jroskind@amazon.com
 
 * Michael Sabin
+
+* Joe Salowey \\
+  Tableau Software \\
+  joe@salowey.net
+
+* Rich Salz \\
+  Akamai \\
+  rsalz@akamai.com
+
+* Sam Scott \\
+  Royal Holloway, University of London \\
+  me@samjs.co.uk
 
 * Dan Simon \\
   Microsoft, Inc. \\
   dansimon@microsoft.com
 
+* Brian Smith \\
+  Independent \\
+  brian@briansmith.org
+
+* Brian Sniffen \\
+  Akamai Technologies \\
+  ietf@bts.evenmere.org
+
+* Nick Sullivan \\
+  Cloudflare Inc. \\
+  nick@cloudflare.com
+
 * Bjoern Tackmann \\
   University of California, San Diego \\
   btackmann@eng.ucsd.edu
 
+* Tim Taubert \\
+  Mozilla \\
+  ttaubert@mozilla.com
+
 * Martin Thomson \\
   Mozilla \\
   mt@mozilla.com
+
+* Sean Turner \\
+  sn3rd \\
+  sean@sn3rd.com
+
+* Steven Valdez \\
+  Google \\
+  svaldez@google.com
+
+* Filippo Valsorda \\
+  Cloudflare Inc. \\
+  filippo@cloudflare.com
+
+* Thyla van der Merwe \\
+  Royal Holloway, University of London \\
+  tjvdmerwe@gmail.com
+
+* Victor Vasiliev \\
+  Google \\
+  vasilvv@google.com
 
 * Tom Weinstein
 
@@ -4583,6 +6215,14 @@ Archives of the list can be found at:
   Ecole Normale Superieure, Paris \\
   hoeteck@alum.mit.edu
 
+* David Wong \\
+  NCC Group \\
+  david.wong@nccgroup.trust
+
 * Tim Wright \\
   Vodafone \\
   timothy.wright@vodafone.com
+
+* Kazu Yamamoto \\
+  Internet Initiative Japan Inc. \\
+  kazu@iij.ad.jp

--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -1,4 +1,4 @@
-----
+---
 title: The Transport Layer Security (TLS) Protocol Version 1.3
 abbrev: TLS
 docname: draft-ietf-tls-tls13-latest

--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -1,4 +1,4 @@
-﻿---
+----
 title: The Transport Layer Security (TLS) Protocol Version 1.3
 abbrev: TLS
 docname: draft-ietf-tls-tls13-latest

--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -5924,12 +5924,12 @@ server-to-client encryption keys because that would entail
 the reuse of those keys. This parallels the use of the early
 application traffic keys only in the client-to-server direction.
 
-## Static (EC) DH Shares
+## Static (EC)DH Shares
 
 For various reasons, some implementations may be tempted to use static
-(EC) DH private key. Using such keys lowers the security guarantees of
-TLS 1.3. Adversaries that get access to the static (EC) DH private key
-can now get access to the content of the communication. Adversaries that
+(EC)DH private keys. Using such keys lowers the security guarantees of
+TLS 1.3. Adversaries that get access to the static (EC)DH private key
+can get access to the content of the communication. Adversaries that
 acquire the key in real-time can compromise the confidentiality of the
 conversation. Adversaries that acquire the key later can use it to
 access the content of recorded sessions, thus breaking the forward

--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -5924,7 +5924,7 @@ server-to-client encryption keys because that would entail
 the reuse of those keys. This parallels the use of the early
 application traffic keys only in the client-to-server direction.
 
-## Static DH Shares
+## Static (EC) DH Shares
 
 For various reasons, some implementations may be tempted to use static
 (EC) DH private key. Using such keys lowers the security guarantees of

--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -1542,7 +1542,7 @@ TLS supports three basic key exchange modes:
 - A combination of a symmetric key and Diffie-Hellman
 
 Which mode is used depends on the negotiated cipher suite. Conceptually,
-the handshake establishes two secrets which are used to derive all the
+the handshake establishes three secrets which are used to derive all the
 keys.
 
 Ephemeral Secret (ES): A secret which is derived from fresh (EC)DHE
@@ -1553,8 +1553,12 @@ Ephemeral Secret (ES): A secret which is derived from fresh (EC)DHE
 Static Secret (SS): A secret which may be derived from static or
    semi-static keying material, such as a pre-shared key or the
    server's semi-static (EC)DH share.
+   
+Master Secret (SS): A secret derived from both the static 
+   and the ephemeral secret.
 
-In some cases, as with the DH handshake shown in {{tls-full}}, these
+In some cases, as with the DH handshake shown in {{tls-full}}, 
+ephemeral and shared
 secrets are the same, but having both allows for a uniform key
 derivation scheme for all cipher modes.
 

--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -5903,7 +5903,7 @@ server-to-client encryption keys because that would entail
 the reuse of those keys. This parallels the use of the early
 application traffic keys only in the client-to-server direction.
 
-## Static (EC)DH Shares
+## Static DH Shares
 
 For various reasons, some implementations may be tempted to use static
 (EC) DH private key. Using such keys lowers the security guarantees of

--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -1,4 +1,4 @@
----
+﻿---
 title: The Transport Layer Security (TLS) Protocol Version 1.3
 abbrev: TLS
 docname: draft-ietf-tls-tls13-latest
@@ -5903,6 +5903,21 @@ server-to-client encryption keys because that would entail
 the reuse of those keys. This parallels the use of the early
 application traffic keys only in the client-to-server direction.
 
+## Static (EC)DH Shares
+
+For various reasons, some implementations may be tempted to use static
+(EC) DH private key. Using such keys lowers the security guarantees of
+TLS 1.3. Adversaries that get access to the static (EC) DH private key
+can now get access to the content of the communication. Adversaries that
+acquire the key in real-time can compromise the confidentiality of the
+conversation. Adversaries that acquire the key later can use it to
+access the content of recorded sessions, thus breaking the forward
+secrecy promise of the protocol. TLS 1.3 clients should detect the use
+of static (EC)DH keys by corresponding servers, and should treat servers
+using such keys as compromised. Clients can perform this detection by
+comparing keys proposed by the same server at different times, or by
+cooperating with other clients to compare the keys proposed to them by
+sets of servers.
 
 # Working Group Information
 


### PR DESCRIPTION
As discussed on the mailing list, here is a short proposal to document the "static (EC) DH private key" sharing attack.