### PR TITLE
Send server plaintext records with a different content type.

### DIFF
--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -1640,6 +1640,10 @@ of a connection. Handshake messages are supplied to the TLS record layer, where
 they are encapsulated within one or more TLSPlaintext or TLSCiphertext structures, which are
 processed and transmitted as specified by the current active connection state.
 
+Implementations MUST send these messages with the "handshake" ContentType, with the exception of
+server plaintext messages (ServerHello and HelloRetryRequest) which MUST be sent using the
+"server_plaintext_handshake" ContentType.
+
 %%% Handshake Protocol
 
        enum {
@@ -3821,6 +3825,11 @@ record or fragmented across several records, provided that:
 Implementations MUST NOT send zero-length fragments of Handshake
 types, even if those fragments contain padding.
 
+Clients receiving plaintext records of type server_plaintext_handshake MUST treat them
+exactly as if they were of type handshake. Implementations receiving records of type
+server_plaintext_handshake in any other situation MUST terminate the connection with an
+"unexpected_message" alert.
+
 Alert messages ({{alert-protocol}}) MUST NOT be fragmented across
 records and multiple Alert messages MUST NOT be coalesced into a
 single TLSPlaintext record. In other words, a record with an Alert
@@ -3841,6 +3850,7 @@ MAY be split across multiple records or coalesced into a single record.
            alert(21),
            handshake(22),
            application_data(23),
+           server_plaintext_handshake(99),
            (255)
        } ContentType;
 


### PR DESCRIPTION
We've (Facebook) been experimenting with some tweaks to the record layer to try to work around middlebox interference issues when negotiating TLS 1.3 on the internet. Initial results using a different content type for server plaintext handshake messages show significant improvement, in particular against the two most common issues we see (on mobile clients):
1) access_denied alert received on the client
2) missing server hello (but the rest of the connection continues)
We're still collecting data, but assuming this continues to show deployment improvement I think this change makes a lot of sense with minimal complication added to the protocol.

Note that I picked the value at random and that is what we've been experimenting with, but I assume any other value would work too.