### PR TITLE
Specify type aliases.

### DIFF
--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -1453,6 +1453,9 @@ brackets.
 Single-byte entities containing uninterpreted data are of type
 opaque.
 
+A type alias T' for an existing type T is defined by:
+
+       T T';
 
 ##  Vectors
 


### PR DESCRIPTION
Now `uint16 ProtocolVersion;` is defined by the presentation language.