### PR TITLE
Use /* comments */ rather than //

### DIFF
--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -3172,9 +3172,9 @@ replaced with a special synthetic handshake message of handshake
 type "message_hash" containing Hash(ClientHello1). I.e.,
 
      Transcript-Hash(ClientHello1, HelloRetryRequest, ... MN) =
-         Hash(message_hash ||        // Handshake type
-              00 00 Hash.length ||   // Handshake message length (bytes)
-              Hash(ClientHello1) ||  // Hash of ClientHello1
+         Hash(message_hash ||        /* Handshake type */
+              00 00 Hash.length ||   /* Handshake message length (bytes) */
+              Hash(ClientHello1) ||  /* Hash of ClientHello1 */
               HelloRetryRequest ... MN)
 
 The reason for this construction is to allow the server to do a
@@ -3217,7 +3217,7 @@ Structure of this message:
        struct {
            select(certificate_type){
                case RawPublicKey:
-                 // From RFC 7250 ASN.1_subjectPublicKeyInfo
+                 /* From RFC 7250 ASN.1_subjectPublicKeyInfo */
                  opaque ASN1_subjectPublicKeyInfo<1..2^24-1>;
 
                case X509:


### PR DESCRIPTION
The presentation language only specifies `/* ... */` as a comment. It
doesn't really apply to the `Transcript-Hash`, but it seems good to be
consistent.