### PR TITLE
Updating second ClientHello based on HelloRetryRequest

### DIFF
--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -1771,6 +1771,12 @@ ClientHello when the server has responded to its ClientHello with a
 HelloRetryRequest. In that case, the client MUST send the same
 ClientHello (without modification) except:
 
+- cipher_suites only lists the one cipher suite provided in the
+  HelloRetryRequest.
+
+- Updating the "supported_versions" extension to only list the
+  version provided in server_version.
+
 - If a "key_share" extension was supplied in the HelloRetryRequest,
   replacing the list of shares with a list containing a single
   KeyShareEntry from the indicated group.


### PR DESCRIPTION
Section 4.1.2 lists the specific items that may be changed when sending a second ClientHello in response to a HelloRetryRequest. Since the HelloRetryRequest specifies a server_version and cipher_suite, then it seems that there is no reason for the second ClientHello to offer any version or cipher suite other than the ones in the HelloRetryRequest.