### PR TITLE
Fix reference

### DIFF
--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -120,7 +120,7 @@ informative:
          -
            ins: E. Barker
          -
-           ins: Lily Chen
+           ins: L. Chen
          -
            ins: A. Roginsky
          -


### PR DESCRIPTION
Including the first name of the author in "ins" causes xml2rfc to produce junk.