### PR TITLE
Fix TLSInnerPlaintext limit

### DIFF
--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -2490,7 +2490,7 @@ extensions.
 
 The "post_handshake_auth" extension is used to indicate that a client is willing
 to perform post-handshake authentication {{post-handshake-authentication}}. Servers
-MUST not send a post-handshake CertificateRequest to clients which do not
+MUST NOT send a post-handshake CertificateRequest to clients which do not
 offer this extension. Servers MUST NOT send this extension.
 
 The "extension_data" field of the "post_handshake_auth" extension is zero
@@ -4073,7 +4073,7 @@ a non-zero octet in the cleartext, it MUST terminate the
 connection with an "unexpected_message" alert.
 
 The presence of padding does not change the overall record size limitations
-- the full encoded TLSInnerPlaintext MUST not exceed 2^14 + 1 octets. If the
+- the full encoded TLSInnerPlaintext MUST NOT exceed 2^14 + 1 octets. If the
 maximum fragment length is reduced, as for example by the max_fragment_length
 extension from [RFC6066], then the reduced limit applies to the full plaintext,
 including the content type and padding.

--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -4073,10 +4073,10 @@ a non-zero octet in the cleartext, it MUST terminate the
 connection with an "unexpected_message" alert.
 
 The presence of padding does not change the overall record size limitations
-- the full encoded TLSInnerPlaintext MUST not exceed 2^14 octets. If the maximum
-fragment length is reduced, as for example by the max_fragment_length extension
-from [RFC6066], then the reduced limit applies to the full plaintext,
-including the padding.
+- the full encoded TLSInnerPlaintext MUST not exceed 2^14 + 1 octets. If the
+maximum fragment length is reduced, as for example by the max_fragment_length
+extension from [RFC6066], then the reduced limit applies to the full plaintext,
+including the content type and padding.
 
 Selecting a padding policy that suggests when and how much to pad is a
 complex topic and is beyond the scope of this specification. If the


### PR DESCRIPTION
The TLSPlaintext size is at most 2^14, so the TLSInnerPlaintext must be
at least one more to fit the content type. This matches with the end of
the record payload protection section.