### PR TITLE
Document no NUL bytes in labels

### DIFF
--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -4436,7 +4436,8 @@ Hash.length is its output length in bytes. Messages are the concatenation of the
 indicated handshake messages, including the handshake message type
 and length fields, but not including record layer headers. Note that
 in some cases a zero-length Context (indicated by "") is passed to
-HKDF-Expand-Label.
+HKDF-Expand-Label.  The Labels specified in this document are all
+ASCII strings, and do not include a trailing NUL byte.
 
 Note: with common hash functions, any label longer than 12 characters
 requires an additional iteration of the hash function to compute.


### PR DESCRIPTION
As mentioned by @Andrei-Popov in
https://www.ietf.org/mail-archive/web/tls/current/msg24561.html .