### PR TITLE
Allow the padding extension to change on HRR.

### DIFF
--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -1787,6 +1787,9 @@ ClientHello (without modification) except:
   any PSKs which are incompatible with the server's indicated
   cipher suite.
 
+- Optionally adding, removing, or changing the length of the "padding"
+  extension {{RFC7685}}.
+
 Because TLS 1.3 forbids renegotiation, if a server has negotiated TLS
 1.3 and receives a ClientHello at any other time, it MUST terminate
 the connection with an "unexpected_message" alert.


### PR DESCRIPTION
The padding extension is typically computed as part of serializing the
ClientHello, in hopes of targetting a particular size. As specified right now,
the second ClientHello must not use this same logic and instead must retain the
previous extension sizethough this would likely not hit the same target size.

The server's going to ignore it anyway, so allow it to be recalcuated. This
avoids unnecessary state in clients and extra logic to serialize the first and
second ClientHellos differently.