### PR TITLE
certificate_authorities is defined in this document, not in RFC 6066

### DIFF
--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -3362,7 +3362,7 @@ The following rules apply to the certificates sent by the server:
   digitalSignature bit MUST be set if the Key Usage extension is present) with
   a signature scheme indicated in the client's "signature_algorithms" extension.
 
-- The "server_name" and "certificate_authorities" extensions {{RFC6066}} are used to
+- The "server_name" {{RFC6066}} and "certificate_authorities" extensions are used to
   guide certificate selection. As servers MAY require the presence of the "server_name"
   extension, clients SHOULD send this extension, when applicable.
 


### PR DESCRIPTION
Minor change to where RFC 6066 is referenced.