### PR TITLE
Be more explicit on PSS requirements

### DIFF
--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -2349,8 +2349,12 @@ RSASSA-PSS algorithms
   digest used in the mask generation function and the digest being signed are
   both the corresponding hash algorithm as defined in {{SHS}}. When used in
   signed TLS handshake messages, the length of the salt MUST be equal to the
-  length of the digest output.  This codepoint is new in this document and is also
-  defined for use with TLS 1.2.
+  length of the digest output. An RSA public key (OID rsaEncryption) MUST be
+  supported, an RSASSA-PSS public key (OID id-RSASSA-PSS) MAY be supported.
+  When used as signature algorithm in certificates, the same parameters as used
+  for TLS handshake messages MUST be supported but other parameters MAY be used.
+  This codepoint is new in this document and is also defined for use with TLS
+  1.2.
 
 EdDSA algorithms
 : Indicates a signature algorithm using EdDSA as defined in

--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -88,6 +88,7 @@ informative:
   RFC5077:
   RFC5116:
   RFC5246:
+  RFC5756:
   RFC5764:
   RFC5929:
   RFC6176:
@@ -2349,12 +2350,16 @@ RSASSA-PSS algorithms
   digest used in the mask generation function and the digest being signed are
   both the corresponding hash algorithm as defined in {{SHS}}. When used in
   signed TLS handshake messages, the length of the salt MUST be equal to the
-  length of the digest output. An RSA public key (OID rsaEncryption) MUST be
-  supported, an RSASSA-PSS public key (OID id-RSASSA-PSS) MAY be supported.
-  When used as signature algorithm in certificates, the same parameters as used
-  for TLS handshake messages MUST be supported but other parameters MAY be used.
+  length of the digest output.
+  When used as signature algorithm in certificates, the length of the salt
+  SHOULD be equal to the length of the digest output, but other salt lengths MAY
+  be used.
   This codepoint is new in this document and is also defined for use with TLS
   1.2.
+: An RSA public key (OID rsaEncryption) MUST be supported, an RSASSA-PSS public
+  key (OID id-RSASSA-PSS {{RFC5756}}) without parameters MUST be supported (such
+  that any hash algorithm and salt length can be used), while an RSASSA-PSS
+  public key (OID id-RSASSA-PSS) with parameters MAY be supported.
 
 EdDSA algorithms
 : Indicates a signature algorithm using EdDSA as defined in


### PR DESCRIPTION
This PR intends to clarify the requirements for PSS support.

The requirements are intentionally minimal to reduce implementation efforts, but recognizes that some other implementations may be more complete. Notes:

- "Supporting PSS signatures on certificates is a mandatory requirement and I think we should be very clear about the parameters we permit." https://www.ietf.org/mail-archive/web/tls/current/msg23007.html
- Martin Rex wishes to remove TLS requirements on signature algorithms for certificates, hence the "MAY" for other PSS parameters in this PR. https://www.ietf.org/mail-archive/web/tls/current/msg23021.html
- Regardless, rsa_pss_sha256 is currently MTI for CertificateVerify and certificates, hence the strong MUST wording in this PR.
- It does not say anything about non-end-entity certificates, that's up to the PKI verifier. Consider case "CA Key: rsa-pss; EE signature: rsa-pss; EE key: rsa" from https://www.ietf.org/mail-archive/web/tls/current/msg24453.html
- PSS params in certificates are explicitly not restricted, satisfying https://www.ietf.org/mail-archive/web/tls/current/msg24457.html

From what I have heard, boringssl does not (or will not?) implement any PSS support in the certificates (yet?). Don't know if anything should be changed here to reflect that decision, but I thought it is worth mentioning. It is possible that I'll follow boringssl's example in tris.

If a TLS extension is introduced later, hopefully that improves interop with odd keys and signatures that are optional in this PR (PSS pubkey or custom salt lengths).