### PR TITLE
Clarify certificate extensions

### DIFF
--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -3325,11 +3325,12 @@ certificate_list
 
 extensions:
 : A set of extension values for the CertificateEntry. The "Extension"
-  format is defined in {{extensions}}. Valid extensions include
-  OCSP Status extension ({{RFC6066}}) and
-  SignedCertificateTimestamps ({{!RFC6962}}).  An extension MUST only be present
-  in a Certificate message if the corresponding
-  ClientHello extension was presented in the initial handshake.
+  format is defined in {{extensions}}. Valid extensions for server certificates
+  include OCSP Status extension ({{RFC6066}}) and
+  SignedCertificateTimestamps ({{!RFC6962}}). Extensions in the Certificate
+  message from the server MUST correspond to one from the ClientHello message,
+  extensions in the Certificate from the client MUST correspond with an
+  extension in the CertificateRequest message from the server.
   If an extension applies to the entire chain, it SHOULD be included
   in the first CertificateEntry.
 {:br }


### PR DESCRIPTION
The peer must advertise extensions before they can be sent with a
certificate message.

Fixes #1111