### PR TITLE
Clarify that X.509 certificates carried over TLS are DER-encoded.

### DIFF
--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -3337,7 +3337,7 @@ extensions:
 If the corresponding certificate type extension
 ("server_certificate_type" or "client_certificate_type") was not negotiated
 in Encrypted Extensions, or the X.509 certificate type was negotiated, then each
-CertificateEntry contains an X.509 certificate. The sender's
+CertificateEntry contains a DER-encoded X.509 certificate. The sender's
 certificate MUST come in the first CertificateEntry in the list.  Each
 following certificate SHOULD directly certify one preceding it.
 Because certificate validation requires that trust anchors be


### PR DESCRIPTION
Without specifying the encoding, I don't think it's actually defined how
you transit the certificates. RFC 5280 only says that the TBSCertificate
is DER-encoded for computing the signature, which still allows insanity like XER-encoded everything
with the receiver re-encoding the TBSCertificate to DER before verifying
the signature.