### PR TITLE
fix .version mentions with either .legacy_version or supported_versions

### DIFF
--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -5475,8 +5475,8 @@ TLSPlaintext.legacy_record_version MUST be ignored by all implementations.
 The value of TLSCiphertext.legacy_record_version MAY be ignored,
 or MAY be validated to match the fixed constant value.
 Version negotiation is performed using only the handshake versions
-(ClientHello.legacy_version, as well as the
-ClientHello, HelloRetryRequest and ServerHello "supported_versions" extension).
+(ClientHello.legacy_version, ServerHello.legacy_version, as well as the
+ClientHello, HelloRetryRequest and ServerHello "supported_versions" extensions).
 In order to maximize interoperability with older endpoints, implementations
 that negotiate the use of TLS 1.0-1.2 SHOULD set the record layer
 version number to the negotiated version for the ServerHello and all

--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -1874,7 +1874,7 @@ ClientHello. Note that this method of detecting optional data differs
 from the normal TLS method of having a variable-length field, but it
 is used for compatibility with TLS before extensions were defined.
 TLS 1.3 servers will need to perform this check first and only
-attempt to negotiate TLS 1.3 if a "supported_version" extension
+attempt to negotiate TLS 1.3 if the "supported_versions" extension
 is present.
 If negotiating a version of TLS prior to 1.3, a server MUST check that
 the message either contains no data after legacy_compression_methods

--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -2259,7 +2259,7 @@ RFC EDITOR: PLEASE REMOVE THIS SECTION
 While the eventual version indicator for the RFC version of TLS 1.3 will
 be 0x0304, implementations of draft versions of this specification SHOULD
 instead advertise 0x7f00 | draft_version
-in ServerHello and HelloRetryRequest "supported_versions" extension.
+in the ServerHello and HelloRetryRequest "supported_versions" extension.
 For instance, draft-17 would be encoded as the 0x7f11.
 This allows pre-RFC implementations to safely negotiate with each other,
 even if they would otherwise be incompatible.
@@ -5475,8 +5475,8 @@ TLSPlaintext.legacy_record_version MUST be ignored by all implementations.
 The value of TLSCiphertext.legacy_record_version MAY be ignored,
 or MAY be validated to match the fixed constant value.
 Version negotiation is performed using only the handshake versions
-(ClientHello.legacy_version, as well as
-ClientHello and ServerHello "supported_versions" extension).
+(ClientHello.legacy_version, as well as the
+ClientHello, HelloRetryRequest and ServerHello "supported_versions" extension).
 In order to maximize interoperability with older endpoints, implementations
 that negotiate the use of TLS 1.0-1.2 SHOULD set the record layer
 version number to the negotiated version for the ServerHello and all
@@ -5484,7 +5484,7 @@ records thereafter.
 
 For maximum compatibility with previously non-standard behavior and misconfigured
 deployments, all implementations SHOULD support validation of certification paths
-based on the expectations in this document, even when handling prior TLS versions
+based on the expectations in this document, even when handling prior TLS versions'
 handshakes. (see {{server-certificate-selection}})
 
 TLS 1.2 and prior supported an "Extended Master Secret" {{RFC7627}} extension

--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -1912,7 +1912,7 @@ Structure of this message:
 version
 : In previous versions of TLS, this field was used for version negotiation
   and represented the selected version number for the connection. Unfortunately,
-  some middleboxes fail when presented with new values. 
+  some middleboxes fail when presented with new values.
   In TLS 1.3, the TLS server indicates its version using the
   "supported_versions" extension ({{supported-versions}}),
   and the legacy_version field MUST
@@ -2259,7 +2259,7 @@ RFC EDITOR: PLEASE REMOVE THIS SECTION
 While the eventual version indicator for the RFC version of TLS 1.3 will
 be 0x0304, implementations of draft versions of this specification SHOULD
 instead advertise 0x7f00 | draft_version
-in ServerHello.version, and HelloRetryRequest.server_version.
+in ServerHello and HelloRetryRequest "supported_versions" extension.
 For instance, draft-17 would be encoded as the 0x7f11.
 This allows pre-RFC implementations to safely negotiate with each other,
 even if they would otherwise be incompatible.
@@ -5475,8 +5475,8 @@ TLSPlaintext.legacy_record_version MUST be ignored by all implementations.
 The value of TLSCiphertext.legacy_record_version MAY be ignored,
 or MAY be validated to match the fixed constant value.
 Version negotiation is performed using only the handshake versions
-(ClientHello.legacy_version,
-ClientHello "supported_versions" extension, and ServerHello.version).
+(ClientHello.legacy_version, as well as
+ClientHello and ServerHello "supported_versions" extension).
 In order to maximize interoperability with older endpoints, implementations
 that negotiate the use of TLS 1.0-1.2 SHOULD set the record layer
 version number to the negotiated version for the ServerHello and all
@@ -5611,9 +5611,9 @@ Implementations MUST NOT negotiate TLS 1.3 or later using an SSL version 2.0 com
 CLIENT-HELLO. Implementations are NOT RECOMMENDED to accept an SSL version 2.0 compatible
 CLIENT-HELLO in order to negotiate older versions of TLS.
 
-Implementations MUST NOT send a ClientHello.legacy_version or ServerHello.version
+Implementations MUST NOT send a ClientHello.legacy_version or ServerHello.legacy_version
 set to 0x0300 or less. Any endpoint receiving a Hello message with
-ClientHello.legacy_version or ServerHello.version set to 0x0300 MUST
+ClientHello.legacy_version or ServerHello.legacy_version set to 0x0300 MUST
 abort the handshake with a "protocol_version" alert.
 
 Implementations MUST NOT send any records with a version less than 0x0300.

--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -5484,7 +5484,7 @@ records thereafter.
 
 For maximum compatibility with previously non-standard behavior and misconfigured
 deployments, all implementations SHOULD support validation of certification paths
-based on the expectations in this document, even when handling prior TLS versions'
+based on the expectations in this document, even when handling prior TLS versions
 handshakes. (see {{server-certificate-selection}})
 
 TLS 1.2 and prior supported an "Extended Master Secret" {{RFC7627}} extension

--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -1909,7 +1909,7 @@ Structure of this message:
            Extension extensions<6..2^16-1>;
        } ServerHello;
 
-version
+legacy_version
 : In previous versions of TLS, this field was used for version negotiation
   and represented the selected version number for the connection. Unfortunately,
   some middleboxes fail when presented with new values.


### PR DESCRIPTION
Some of the places in the draft were still using .version field
referrences in ServerHello and HelloRetryRequest, those were replaced
with either .legacy_version field or "supporeted_versions" extension.