### PR TITLE
Clarify rules around "supported_versions" extension in SH and HRR

### DIFF
--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -2011,10 +2011,10 @@ legacy_compression_method
 
 extensions
 : A list of extensions.  The ServerHello MUST only include extensions
-  which are required to establish the cryptographic context. Currently
-  the only such extensions are "key_share" and "pre_shared_key".
-  All current TLS 1.3 ServerHello messages will contain one of these
-  two extensions, or both when using a PSK with (EC)DHE key establishment.
+  which are required to establish the cryptographic context and negotiate
+  the protocol version. All TLS 1.3 ServerHello messages MUST contain the
+  "supported_versions" extension, and at least one of either the "pre_shared_key"
+  or "key_share" extensions, or both when using a PSK with (EC)DHE key establishment.
   The remaining extensions are sent separately in the EncryptedExtensions
   message.
 {:br }
@@ -2131,6 +2131,9 @@ supplied in the ServerHello is the same as that in the
 HelloRetryRequest and otherwise abort the handshake with an
 "illegal_parameter" alert.
 
+The value of selected_version in the HelloRetryRequest "supported_versions"
+extension MUST be retained in ServerHello, and a client MUST abort the
+handshake with an "illegal_parameter" alert if the value changes.
 
 ##  Extensions
 

--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -2013,10 +2013,10 @@ extensions
 : A list of extensions.  The ServerHello MUST only include extensions
   which are required to establish the cryptographic context and negotiate
   the protocol version. All TLS 1.3 ServerHello messages MUST contain the
-  "supported_versions" extension, and at least one of either the "pre_shared_key"
-  or "key_share" extensions, or both when using a PSK with (EC)DHE key establishment.
-  The remaining extensions are sent separately in the EncryptedExtensions
-  message.
+  "supported_versions" extension.  Current ServerHello messages contain
+  either the "pre_shared_key" or "key_share" extensions, or both when using
+  a PSK with (EC)DHE key establishment. The remaining extensions are sent
+  separately in the EncryptedExtensions message.
 {:br }
 
 For backward compatibility reasons with middleboxes
@@ -2132,7 +2132,7 @@ HelloRetryRequest and otherwise abort the handshake with an
 "illegal_parameter" alert.
 
 The value of selected_version in the HelloRetryRequest "supported_versions"
-extension MUST be retained in ServerHello, and a client MUST abort the
+extension MUST be retained in the ServerHello, and a client MUST abort the
 handshake with an "illegal_parameter" alert if the value changes.
 
 ##  Extensions


### PR DESCRIPTION
Issue 1: supported_versions is required in TLS 1.3 SH.
Issue 2: supported_versions.selected_version must be identical in HRR and SH