### PR TITLE
legacy PSKs note

### DIFF
--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -3118,12 +3118,15 @@ resumption handshake, and there is no need for the server to associate an SNI va
 ticket. Clients, however, SHOULD store the SNI with the PSK to fulfill
 the requirements of {{NSTMessage}}.
 
-Implementor's note: the most straightforward way to implement the
+Implementor's note: when session resumption is the primary use case of PSKs
+the most straightforward way to implement the
 PSK/cipher suite matching requirements is to negotiate the cipher
 suite first and then exclude any incompatible PSKs. Any unknown PSKs
 (e.g., they are not in the PSK database or are encrypted with an
 unknown key) SHOULD simply be ignored. If no acceptable PSKs are
 found, the server SHOULD perform a non-PSK handshake if possible.
+If backwards compatibility is important, client provided, externally
+established PSKs SHOULD influence cipher suite selection.
 
 Prior to accepting PSK key establishment, the server MUST validate the
 corresponding binder value (see {{psk-binder}} below). If this value is


### PR DESCRIPTION
Given that it's common to select the strongest cipher by default
(thus likely using SHA-384 PRF) and that the default Hash associated
with a PSK is SHA-256, simple upgrade of server and client
to TLS 1.3 may cause handshake failures if only PSK key exchanges
were configured and the existing implementor's note is followed.