### PR TITLE
dropping RFC4681 (user mapping) reference)

### DIFF
--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -78,7 +78,6 @@ informative:
   RFC4346:
   RFC4366:
   RFC4492:
-  RFC4681:
   RFC5077:
   RFC5116:
   RFC5246:


### PR DESCRIPTION
Address an I-D nit.