### PR TITLE
using SHOULD intead of MUST for 0x0301 in CH1.

### DIFF
--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -4122,7 +4122,7 @@ fragment
 This document describes TLS 1.3, which uses the version 0x0304.
 This version value is historical, deriving from the use of 0x0301
 for TLS 1.0 and 0x0300 for SSL 3.0. In order to maximize backwards
-compatibility, records containing an initial ClientHello MUST have version
+compatibility, records containing an initial ClientHello SHOULD have version
 0x0301 and a record containing a second ClientHello or
 a ServerHello MUST have version
 0x0303, reflecting TLS 1.0 and TLS 1.2 respectively.


### PR DESCRIPTION
`legacy_record_version` says:

> This value MUST be set to 0x0303 for all records generated by a TLS 1.3 implementation other than an initial ClientHello (i.e., one not generated after a HelloRetryRequest), where it *MAY* also be 0x0301 for compatibility purposes.

But the following text follows:

> n order to maximize backwards compatibility, records containing an initial ClientHello *MUST* have version 0x0301 and a record containing a second ClientHello or a ServerHello MUST have version 0x0303, reflecting TLS 1.0 and TLS 1.2

MAY and MUST mismatch. Let's s/MUST/SHOULD/