### PR TITLE
Adjust the wording around KCI attacks

### DIFF
--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -5875,11 +5875,11 @@ Forward secret with respect to long-term keys
   when PSK is used in the "psk_ke" PskKeyExchangeMode.
 
 Key Compromise Impersonation (KCI) resistance
-: In a mutually-authenticated connection with certificates, peer authentication
-   should hold even if the local long-term secret was compromised before the
-   connection was established (see {{HGFS15}}). For example, if a client's
-   signature key is compromised, it should not be possible to impersonate
-   arbitrary servers to that client in subsequent handshakes.
+: In a mutually-authenticated connection with certificates, compromising the long-term
+  secret of one actor should not compromise that actor’s authentication of their peer in
+  the given connection (see {{HGFS15}}). For example, if a client's signature key is
+  compromised, it should not be possible to impersonate arbitrary servers to that client
+  in subsequent handshakes.
 
 Protection of endpoint identities.
 : The server's identity (certificate) should be protected against passive

--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -5876,7 +5876,7 @@ Forward secret with respect to long-term keys
 
 Key Compromise Impersonation (KCI) resistance
 : In a mutually-authenticated connection with certificates, compromising the long-term
-  secret of one actor should not compromise that actor’s authentication of their peer in
+  secret of one actor should not break that actor’s authentication of their peer in
   the given connection (see {{HGFS15}}). For example, if a client's signature key is
   compromised, it should not be possible to impersonate arbitrary servers to that client
   in subsequent handshakes.


### PR DESCRIPTION
The previous wording implied that a session in which an actor's key has been compromised should enjoy "peer authentication", which is defined just above to mean that both parties should authenticate each other. This adjusts the wording to make it clear what we intend, which is that compromising Alice's key should not allow you to impersonate Bob to Alice. (cc @cascremers)