### PR TITLE
Clarify requirements between key_share in HRR and SH.

### DIFF
--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -2819,9 +2819,11 @@ by the client that the server has selected for the negotiated key exchange.
 Servers MUST NOT send a KeyShareEntry for any group not
 indicated in the "supported_groups" extension and
 MUST NOT send a KeyShareEntry when using the "psk_ke" PskKeyExchangeMode.
-If a HelloRetryRequest was received by the client, the client MUST verify that the
-selected NamedGroup in the ServerHello is the same as that in the HelloRetryRequest. If this check
-fails, the client MUST abort the handshake with an "illegal_parameter" alert.
+If using (EC)DHE key establishment, and a HelloRetryRequest containing a
+"key_share" extension was received by the client, the client MUST verify that the
+selected NamedGroup in the ServerHello is the same as that in the HelloRetryRequest.
+If this check fails, the client MUST abort the handshake with an "illegal_parameter"
+alert.
 
 ####  Diffie-Hellman Parameters {#ffdhe-param}
 


### PR DESCRIPTION
This clarifies two items relevant to stateless HelloRetryRequests:
1) If a HelloRetryRequest does not contain a key_share extension, the negotiated group does not have to match the non-existent selected group in the HRR.
2) If a HelloRetryRequest does select a group, the server can still choose to use psk_ke key exchange. When sending a stateless HelloRetryRequest, the server may not know if it will accept a PSK yet. This allows the server to still select a group in the HelloRetryRequest which it would need for a full handshake, but later decide to accept the PSK with psk_ke mode.