### PR TITLE
Forced additions to the abstract

### DIFF
--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -536,6 +536,9 @@ This document specifies version 1.3 of the Transport Layer Security
 (TLS) protocol.  TLS allows client/server applications to
 communicate over the Internet in a way that is designed to prevent eavesdropping,
 tampering, and message forgery.
+
+This document updates RFCs 4492, 5705, and 6066 and it obsoletes
+RFCs 5077, 5246, and 6961.
 --- middle
 
 


### PR DESCRIPTION
The I-D checklist requires that updates and obsoletes be included in the abstract; thought RFC.  I personally feel this is [redacted] stupid, but I do not think that we should risk a process appeal to fight this battle.