### PR TITLE
Remove misleading clause.

### DIFF
--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -5279,8 +5279,7 @@ lacking a "server_name" extension by terminating the connection with a
 ## Protocol Invariants
 
 This section describes invariants that TLS endpoints and middleboxes MUST
-follow. It also applies to earlier versions, which assumed these rules but did
-not document them.
+follow. It also applies to earlier versions of TLS.
 
 TLS is designed to be securely and compatibly extensible. Newer clients or
 servers, when communicating with newer peers, should negotiate the


### PR DESCRIPTION
ClientHello, etc., processing rules are in earlier versions too. We're just
calling out some corollaries of it all.