### PR TITLE
reference the security section about external identities in PSK description

### DIFF
--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -3191,8 +3191,8 @@ not present or does not validate, the server MUST abort the handshake.
 Servers SHOULD NOT attempt to validate multiple binders; rather they
 SHOULD select a single PSK and validate solely the binder that
 corresponds to that PSK.
-See \[{{client-hello-recording}}] for the security rationale for this
-requirement.
+See \[{{client-hello-recording}}] and \[{{psk-identity-exposure}}] for the
+security rationale for this requirement.
 In order to accept PSK key establishment, the
 server sends a "pre_shared_key" extension indicating the selected
 identity.


### PR DESCRIPTION
As naïve handling of external identities may cause the server to
be vulnerable to identity enumeration attacks, refer the section
that discusses that danger in the PSK section itself.