### PR TITLE
Discuss tracking implications of session resumption.

### DIFF
--- a/draft-ietf-tls-rfc8446bis.md
+++ b/draft-ietf-tls-rfc8446bis.md
@@ -376,6 +376,13 @@ informative:
          ins: T. Shrimpton
        target: https://eprint.iacr.org/2018/634
 
+  FETCH:
+       title: "Fetch Standard"
+       date: Living Standard
+       author:
+         org: WHATWG
+       target: https://fetch.spec.whatwg.org/
+
 --- abstract
 
 This document specifies version 1.3 of the Transport Layer Security
@@ -5162,6 +5169,12 @@ as the number of connections that a client might use; for example, a web browser
 using HTTP/1.1 {{RFC7230}} might open six connections to a server. Servers SHOULD
 issue new tickets with every connection. This ensures that clients are
 always able to use a new ticket when creating a new connection.
+
+Offering a ticket to a server additionally allows the server to correlate
+different connections. This is possible independent of ticket reuse. Client
+applications SHOULD NOT offer tickets across connections that are meant to be
+uncorrelated. For example, {{FETCH}} defines network partition keys to separate
+cache lookups in web browsers.
 
 
 ## Unauthenticated Operation


### PR DESCRIPTION
In WG discussion of draft-vvv-tls-cross-sni-resumption-00, tracking
implications came up. While that draft does expand the set of servers
that can cross-resume, it's not a new issue. For instance, on the Web,
if https://a.example and https://b.example both include a subresource to
a common https://tracker.example, TLS session resumption may be used to
correlate activity across the two sites.

Add some text to discuss this. This is distinct from the single-use
ticket mitigation, which only covers correlation by passive observers.
Correlation by the server itself is pretty much inherent to session
resumption and other cache-like optimizations. Instead, the text points
this out and gives an example of how applications can keep their
resumption scopes consistent with their privacy goals.

Fixes #1201.

(CC @vasilvv)