### PR TITLE
Security Property - Protection of endpoint identities

### DIFF
--- a/draft-ietf-tls-rfc8446bis.md
+++ b/draft-ietf-tls-rfc8446bis.md
@@ -5436,7 +5436,8 @@ Protection of endpoint identities:
 : The server's identity (certificate) should be protected against passive
   attackers. The client's identity (certificate) should be protected against
   both passive and active attackers. This property does not hold for cipher
-  suites without confidentiality.
+  suites without confidentiality; while this specification does not define any such cipher suites,
+  other documents may do so.
 {:br}
 
 Informally, the signature-based modes of TLS 1.3 provide for the

--- a/draft-ietf-tls-rfc8446bis.md
+++ b/draft-ietf-tls-rfc8446bis.md
@@ -5434,8 +5434,9 @@ Key Compromise Impersonation (KCI) resistance:
 
 Protection of endpoint identities:
 : The server's identity (certificate) should be protected against passive
-  attackers. The client's identity should be protected against both passive
-  and active attackers.
+  attackers. The client's identity (certificate) should be protected against
+  both passive and active attackers. This property does not hold for cipher
+  suites without confidentiality.
 {:br}
 
 Informally, the signature-based modes of TLS 1.3 provide for the


### PR DESCRIPTION
As discussed on the TLS list. It seems like cipher suites without confidentiality is already registered. Feel free to reformulate in any way. Refering to the cipher suites in the document is not very useful for the reader, and it does not seem to be a rule that a NULL encryption could not be recommended even if that seems very unlikely.

I also suggest adding "(certificate)" after client identity. The security property does obviously not hold for PSK authentication.