### PR TITLE
Random Number Generation and Seeding

### DIFF
--- a/draft-ietf-tls-rfc8446bis.md
+++ b/draft-ietf-tls-rfc8446bis.md
@@ -93,6 +93,7 @@ informative:
   RFC7465:
   RFC7568:
   RFC7685:
+  RFC8937:
 
   SSL2:
        title: "The SSL Protocol"
@@ -5060,7 +5061,8 @@ provides several recommendations to assist implementors.
 
 ## Random Number Generation and Seeding
 
-TLS requires a cryptographically secure pseudorandom number generator (CSPRNG).
+TLS requires a cryptographically secure pseudorandom number generator (CSPRNG)
+or a true random number generator (TRNG).
 In most cases, the operating system provides an appropriate facility such
 as /dev/urandom, which should be used absent other (e.g., performance) concerns.
 It is RECOMMENDED to use an existing CSPRNG implementation in
@@ -5080,6 +5082,10 @@ Implementations can provide extra security against
 this form of attack by using separate CSPRNGs to generate public and
 private values.
 
+{{RFC8937}} describes a RECOMMENDED way for security protocol implementations
+to augment their (pseudo)random number generators using a long-term private key
+and a deterministic signature function. This improves randomness from broken or
+otherwise subverted random number generators.
 
 ## Certificates and Authentication
 


### PR DESCRIPTION
Does not "require" a PRNG, a TRNG works as well.

Since TLS 1.3 was published, CFRG has published RFC 8937. I think RFC 8937 is a great idea. I think it would be good if TLS 1.3 pointed implementors to that. Given the history of Dual EC, tls extended random, and that several different signal intelligence agencies have been controlling hardware security companies like Crypto AG in secret I think it is essential to not trust a single of randomness.

https://www.google.com/url?sa=t&rct=j&q=&esrc=s&source=web&cd=&cad=rja&uact=8&ved=2ahUKEwjN39aenfvuAhWvtIsKHQ-wArgQFjABegQIAxAD&url=https%3A%2F%2Fwww.washingtonpost.com%2Fgraphics%2F2020%2Fworld%2Fnational-security%2Fcia-crypto-encryption-machines-espionage%2F&usg=AOvVaw0gGtw_W1_z-DVSlMSqi9Zr