### PR TITLE
Recommending deterministic ECDSA for IoT devices without any security…

### DIFF
--- a/draft-ietf-tls-rfc8446bis.md
+++ b/draft-ietf-tls-rfc8446bis.md
@@ -5159,8 +5159,10 @@ Cryptographic details:
   generator (see {{random-number-generation-and-seeding}}) when generating Diffie-Hellman
   private values, the ECDSA "k" parameter, and other security-critical values?
   It is RECOMMENDED that implementations implement "deterministic ECDSA"
-  as specified in {{!RFC6979}}.
-
+  as specified in {{!RFC6979}}. Note that purely deterministic ECC signatures such as
+  deterministic ECDSA and EdDSA may be vulnerable to certain side-channel and fault
+  injection attacks in easily accessible IoT devices.
+  
 - Do you zero-pad Diffie-Hellman public key values and shared
   secrets to the group size (see {{ffdhe-param}} and {{finite-field-diffie-hellman}})?
 


### PR DESCRIPTION
… considerations is not good.

Deterministic ECDSA is good in many cases but may not be the best case in accesable IoT devices.

In the last 5 years, there has been a large amount of academic papers showing that purely deterministic ECC algorithms in accesable IoT devices suffers from side-channel and fault injection attacks. For a list of papers see e.g. Section 1 of https://tools.ietf.org/html/draft-mattsson-cfrg-det-sigs-with-noise-02

Recommending deterministic ECDSA for IoT devices without any security considerations is not good...

Would be good with some further guidance. Section 1 of https://tools.ietf.org/html/draft-mattsson-cfrg-det-sigs-with-noise-02 is probably the best overview but it is a draft. Any of the paper references there would do. No standardized solutions yet.