### PR TITLE
Clarify that trailing data in extensions is forbidden.

### DIFF
--- a/draft-ietf-tls-rfc8446bis.md
+++ b/draft-ietf-tls-rfc8446bis.md
@@ -1655,6 +1655,13 @@ Here:
 - "extension_data" contains information specific to the particular
   extension type.
 
+The contents of the "extension_data" field are typically defined by an
+extension-specific structure defined in the TLS presentation language. Unless
+otherwise specified, trailing data is forbidden. That is, senders MUST NOT
+include data after the structure in the "extension_data" field, and receivers
+MUST abort the handshake with a "decode_error" alert if there is data left
+over after parsing the structure.
+
 The list of extension types is maintained by IANA as described in
 {{iana-considerations}}.
 


### PR DESCRIPTION
This was already a compliance requirement, but spell it out more explicitly.

Closes #1219.