### PR TITLE
Outdated references to ITU-T/ISO/IEC specifications

### DIFF
--- a/draft-ietf-tls-rfc8446bis.md
+++ b/draft-ietf-tls-rfc8446bis.md
@@ -48,11 +48,11 @@ normative:
   RFC5116:
   X690:
        title: "Information technology - ASN.1 encoding Rules: Specification of Basic Encoding Rules (BER), Canonical Encoding Rules (CER) and Distinguished Encoding Rules (DER)"
-       date: November 2015
+       date: February 2021
        author:
          org: ITU-T
        seriesinfo:
-         ISO/IEC: 8825-1:2002
+         ISO/IEC 8824-1:2021
   DH76:
         title: "New Directions in Cryptography"
         author:
@@ -112,9 +112,11 @@ informative:
        date: 2003
   X501:
        title: "Information Technology - Open Systems Interconnection - The Directory: Models"
-       date: 1993
+       date: October 2019
+       author:
+         org: ITU-T
        seriesinfo:
-         ITU-T: X.501
+         ISO/IEC 9594-2:2020
   PSK-FINISHED:
        title: "Revision 10: possible attack if client authentication is allowed during PSK"
        date: 2015


### PR DESCRIPTION
- The references to X501 and X690 are to very old version. Ignore this part if that is intentional.

https://www.itu.int/rec/T-REC-X.690-202102-I/en
https://www.itu.int/rec/T-REC-X.501-201910-I/en
https://webstore.iec.ch/publication/68163

- The references to X501 and X690 have differenct format where X609 refer to both ITU-T and ISO/IEC while X501 only refer to ITU-T. Ignore this part if that is intentional.

- The X690 reference seems incorrect. Seems like it refers to the 2015 version of ITU-T and the 2002 version of ISO
    "ISO/IEC 8825-1:2002, November 2015."