### PR TITLE
RFC 8773 TLS 1.3 Extension for Certificate-Based Authentication with …

### DIFF
--- a/draft-ietf-tls-rfc8446bis.md
+++ b/draft-ietf-tls-rfc8446bis.md
@@ -93,6 +93,7 @@ informative:
   RFC7465:
   RFC7568:
   RFC7685:
+  RFC8773:
 
   SSL2:
        title: "The SSL Protocol"
@@ -5534,10 +5535,12 @@ the PSK binder. {{PSK-FINISHED}}
 describes a concrete attack on constructions that do not bind to
 the server's certificate (see also {{Kraw16}}). It is unsafe to use certificate-based client
 authentication when the client might potentially share the same
-PSK/key-id pair with two different endpoints.  Implementations MUST
-NOT combine external PSKs with certificate-based authentication of
-either the client or server. Future specifications MAY provide an
-extension to permit this.
+PSK/key-id pair with two different endpoints. The
+"tls_cert_with_extern_psk" extension {{RFC8773}} allows a server
+and client to authenticate with a combination of a certificate and an external
+pre-shared key (PSK). Unless the "tls_cert_with_extern_psk" extension
+is used, implementations MUST NOT combine external PSKs with
+certificate-based authentication of either the client or server.
 
 If an exporter is used, then it produces values which are unique
 and secret (because they are generated from a unique session key).


### PR DESCRIPTION
"Implementations MUST NOT combine external PSKs with certificate-based authentication of
either the client or server. Future specifications MAY provide an
extension to permit this."

This can now be made a bit more specific