### PR TITLE
Correct NST extensions length

### DIFF
--- a/draft-ietf-tls-rfc8446bis.md
+++ b/draft-ietf-tls-rfc8446bis.md
@@ -3341,7 +3341,7 @@ handshake, for example.
            uint32 ticket_age_add;
            opaque ticket_nonce<0..255>;
            opaque ticket<1..2^16-1>;
-           Extension extensions<0..2^16-2>;
+           Extension extensions<0..2^16-1>;
        } NewSessionTicket;
 
 ticket_lifetime:


### PR DESCRIPTION
All other extensions blocks have a max length of 2^16-1 except this one which was 2^16-2.