### PR TITLE
Clarify that double brackets are not part of the presentation language

### DIFF
--- a/draft-ietf-tls-rfc8446bis.md
+++ b/draft-ietf-tls-rfc8446bis.md
@@ -980,6 +980,9 @@ This document deals with the formatting of data in an external representation.
 The following very basic and somewhat casually defined presentation syntax will
 be used.
 
+In the definitions below, optional components of this syntax are denoted by
+enclosing them in "\[\[ \]\]" (double brackets).
+
 
 ##  Basic Block Size
 
@@ -999,9 +1002,6 @@ or big-endian format.
 ##  Miscellaneous
 
 Comments begin with "/\*" and end with "\*/".
-
-Optional components are denoted by enclosing them in "\[\[ \]\]" (double
-brackets).
 
 Single-byte entities containing uninterpreted data are of type
 opaque.


### PR DESCRIPTION
They denote optional components of the presentation language and are not literal components of the presentation language itself.

Fixes #1315