### PR TITLE
Privacy and PSK identifiers

### DIFF
--- a/draft-ietf-tls-rfc8446bis.md
+++ b/draft-ietf-tls-rfc8446bis.md
@@ -5355,7 +5355,7 @@ will generally be possible for an external observer to track
 clients and/or servers across connections. Use of the
 Encrypted Client Hello {{?I-D.ietf-tls-esni}} extension can
 mitigate this risk, as can mechanisms external to TLS that
-rotate the PSK identity.
+rotate or encrypt the PSK identity.
 
 
 ## Unauthenticated Operation


### PR DESCRIPTION
Based on Christian Huitema discussion of potential solutions.
https://mailarchive.ietf.org/arch/msg/tls/QuKsIu1gZFDfLn1x-ZnOE_LQxyc/

Encrypting the PSK identity using mechanisms external to TLS is missing in the current text. I added as little as possible. I did not go into details of the external encryption (could be asymmetric, symmetric group key, or pairwise symmetric with trial decryption).
