### PR TITLE
not-same might be greater, this is less

### DIFF
--- a/draft-ietf-tls-rfc8446bis.md
+++ b/draft-ietf-tls-rfc8446bis.md
@@ -2881,7 +2881,7 @@ servers which are authenticating with an external PSK
 MUST NOT send the CertificateRequest message either in the main handshake
 or request post-handshake authentication.
 {{RFC8773}} provides an extension to permit this,
-but has not received the level of analysis as this specification.
+but has received less analysis then this specification.
 
 ## Authentication Messages
 

--- a/draft-ietf-tls-rfc8446bis.md
+++ b/draft-ietf-tls-rfc8446bis.md
@@ -2881,7 +2881,7 @@ servers which are authenticating with an external PSK
 MUST NOT send the CertificateRequest message either in the main handshake
 or request post-handshake authentication.
 {{RFC8773}} provides an extension to permit this,
-but has received less analysis then this specification.
+but has received less analysis than this specification.
 
 ## Authentication Messages
 


### PR DESCRIPTION
So say that, alternative to #1335.

Closes #1335.