### PR TITLE
Forbid the sender from sending duplicate supported groups entries.

### DIFF
--- a/draft-ietf-tls-rfc8446bis.md
+++ b/draft-ietf-tls-rfc8446bis.md
@@ -2245,7 +2245,8 @@ Finite Field Groups (DHE):
 {:br }
 
 Items in "named_group_list" are ordered according to the sender's
-preferences (most preferred choice first).
+preferences (most preferred choice first). The "named_group_list"
+MUST NOT contain any duplicate entries.
 
 As of TLS 1.3, servers are permitted to send the "supported_groups"
 extension to the client. Clients MUST NOT act upon any information

--- a/draft-ietf-tls-rfc8446bis.md
+++ b/draft-ietf-tls-rfc8446bis.md
@@ -2246,7 +2246,7 @@ Finite Field Groups (DHE):
 
 Items in "named_group_list" are ordered according to the sender's
 preferences (most preferred choice first). The "named_group_list"
-MUST NOT contain any duplicate entries.  A sender MAY abort a connection
+MUST NOT contain any duplicate entries.  A recipient MAY abort a connection
 with a fatal illegal_parameter alert if it detects a duplicate entry.
 
 As of TLS 1.3, servers are permitted to send the "supported_groups"

--- a/draft-ietf-tls-rfc8446bis.md
+++ b/draft-ietf-tls-rfc8446bis.md
@@ -2246,7 +2246,8 @@ Finite Field Groups (DHE):
 
 Items in "named_group_list" are ordered according to the sender's
 preferences (most preferred choice first). The "named_group_list"
-MUST NOT contain any duplicate entries.
+MUST NOT contain any duplicate entries.  A sender MAY abort a connection
+with a fatal illegal_parameter alert if it detects a duplicate entry.
 
 As of TLS 1.3, servers are permitted to send the "supported_groups"
 extension to the client. Clients MUST NOT act upon any information


### PR DESCRIPTION
Supported Groups is intimately tied to Key Share, where Key Share must be sent in the preference order specified by Supported Groups. 

Duplicate Key Shares for a group are already forbidden from being sent, but allowing duplicates in Supported Groups makes this a bit muddled if supported groups is permitted to be, for example,  ABA and the client sends key share B then A.  

Now, nothing sane should actually be sending duplicate supported groups in a preference order, but it's still not forbidden to do so today. I'm suggesting we just not allow this so server side implementations can reject attempts to do so.