### PR TITLE
Unify client and server certificate selection text

### DIFF
--- a/draft-ietf-tls-rfc8446bis.md
+++ b/draft-ietf-tls-rfc8446bis.md
@@ -3118,13 +3118,13 @@ The following rules apply to the certificates sent by the client or server:
   certificates in the certificate chain SHOULD be issued by one of the listed
   CAs.
 
-The following rules additionally apply to certificates sent by the client:
+The following rule additionally applies to certificates sent by the client:
 
 - If the CertificateRequest message contained a non-empty "oid_filters"
   extension, the end-entity certificate MUST match the extension OIDs
   that are recognized by the client, as described in {{oid-filters}}.
 
-The following rules additionally apply to certificates sent by the server:
+The following rule additionally applies to certificates sent by the server:
 
 - The "server_name" {{RFC6066}} extension is used to guide certificate
   selection. As servers MAY require the presence of the "server_name" extension,

--- a/draft-ietf-tls-rfc8446bis.md
+++ b/draft-ietf-tls-rfc8446bis.md
@@ -3137,13 +3137,16 @@ Certificates that are self-signed
 or certificates that are expected to be trust anchors are not validated as
 part of the chain and therefore MAY be signed with any algorithm.
 
-If the server cannot produce a certificate chain that is signed only via the
+If the sender is the server, and the server
+cannot produce a certificate chain that is signed only via the
 indicated supported algorithms, then it SHOULD continue the handshake by sending
 a certificate chain of its choice that may include algorithms that are not known
-to be supported by the peer.
+to be supported by the client.
 This fallback chain SHOULD NOT use the deprecated SHA-1 hash algorithm in general,
-but MAY do so if the peer's advertisement permits it,
-and MUST NOT do so otherwise. Clients MAY send a fallback chain as above, or
+but MAY do so if the client's advertisement permits it,
+and MUST NOT do so otherwise.
+
+If the sender is the client, the client MAY use a fallback chain as above, or
 continue the handshake anonymously.
 
 If the receiver cannot construct an acceptable chain using the provided
@@ -3153,8 +3156,6 @@ handshake with an appropriate certificate-related alert (by default,
 
 If the sender has multiple certificates, it chooses one of them based on the
 above-mentioned criteria (in addition to other criteria, such as transport-layer endpoint, local configuration, and preferences).
-Future TLS extensions may extend this criteria to further guide this selection
-process.
 
 #### Receiving a Certificate Message
 

--- a/draft-ietf-tls-rfc8446bis.md
+++ b/draft-ietf-tls-rfc8446bis.md
@@ -3142,7 +3142,7 @@ indicated supported algorithms, then it SHOULD continue the handshake by sending
 a certificate chain of its choice that may include algorithms that are not known
 to be supported by the peer.
 This fallback chain SHOULD NOT use the deprecated SHA-1 hash algorithm in general,
-but MAY do so if the peers's advertisement permits it,
+but MAY do so if the peer's advertisement permits it,
 and MUST NOT do so otherwise. Clients MAY send a fallback chain as above, or
 continue the handshake anonymously.
 


### PR DESCRIPTION
I noticed this as I was looking for where we officially wrote down the implications of the X.509 Key Usage extension. We wrote it down for the server, but forgot to for the client.

The root issue is that we unified certificate negotiation in TLS 1.3 (ClientHello/Certificate and CertificateRequest/Certificate are now nice and symmetric), but forgot to correspondingly unify some of this prose. As a result, we said the same thing in different ways, and forgot different things in either place.

This change merges the two.