### PR TITLE
Minor edits from Sue Hares's GenArt review:

### DIFF
--- a/draft-ietf-tls-rfc8446bis.md
+++ b/draft-ietf-tls-rfc8446bis.md
@@ -597,7 +597,7 @@ are many minor differences.
   be more consistent and to remove superfluous messages such as
   ChangeCipherSpec (except when needed for middlebox compatibility).
 
-- Elliptic curve algorithms are now in the base spec, and new signature
+- Elliptic curve algorithms are now in the base spec and new signature
   algorithms, such as EdDSA, are included. TLS 1.3 removed point format
   negotiation in favor of a single point format for each curve.
 
@@ -2988,7 +2988,7 @@ ClientHello and including only those messages that were sent:
 ClientHello, HelloRetryRequest, ClientHello, ServerHello,
 EncryptedExtensions, server CertificateRequest, server Certificate,
 server CertificateVerify, server Finished, EndOfEarlyData, client
-Certificate, client CertificateVerify, client Finished.
+Certificate, client CertificateVerify, and client Finished.
 
 In general, implementations can implement the transcript by keeping a
 running transcript hash value based on the negotiated hash. Note,


### PR DESCRIPTION
https://datatracker.ietf.org/doc/review-ietf-tls-rfc8446bis-11-genart-lc-hares-2024-11-15/

Sue listed two other categories of text change she suggests:

1. Semicolons:

  One confusing nit is the usage of ";" in the following locations.
  The definition of ";" according to scholarly writing for the
  usage of (clause-1);(clause-2) is that the clauses are equivalent.

I believe our usage is correct per CMS 5.89.

2. --

   Use of text offset by -- (text) ---

These are in place of em-dashes and should be rendered correctly in the final RFC.