### PR TITLE
external psk selfie attack

### DIFF
--- a/draft-ietf-tls-rfc8446bis.md
+++ b/draft-ietf-tls-rfc8446bis.md
@@ -6140,7 +6140,7 @@ this form of attack by treating the cases where there is no
 valid PSK identity and where there is an identity but it has an
 invalid binder identically.
 
-## Sharing PSKs across protocol versions
+## Sharing PSKs Across Protocol Versions
 
 TLS 1.3 takes a conservative approach to PSKs by binding them to a
 specific KDF.  By contrast, TLS 1.2 allows PSKs to be used with any


### PR DESCRIPTION
Acknowledging the Seflie attack when using external PSKs and adding pointers to RFC 9257/9258 for guidance on how to avoid.