### PR TITLE
rpk misbinding and clarification

### DIFF
--- a/draft-ietf-tls-rfc8446bis.md
+++ b/draft-ietf-tls-rfc8446bis.md
@@ -767,8 +767,8 @@ Certificate:
   authenticate with a certificate). Note that if raw
   public keys {{RFC7250}} or the cached information extension
   {{?RFC7924}} are in use, then this message will not
-  contain a X.509 certificate but rather some other value corresponding
-  to the server's long-term key.  \[{{certificate}}]
+  contain a certificate but rather some other value corresponding to
+  the server's long-term key.  \[{{certificate}}]
 
 CertificateVerify:
 : A signature over the entire handshake using the private key


### PR DESCRIPTION
Changes in PR:

Section 2: Protocol Overview: It is technically incorrect to say that if the Certificate message contains a raw public key then the message will not contain a certificate. Especially when we later say "If the RawPublicKey certificate type was negotiated". Adding the X.509 makes it explicit what is intended.

Typo: remove a stray "or" in Appendix.

Add self as contributor.
