### PR TITLE
Clarify that the message sequence may change with extensions

### DIFF
--- a/draft-ietf-tls-rfc8446bis.md
+++ b/draft-ietf-tls-rfc8446bis.md
@@ -2995,13 +2995,16 @@ stateless HelloRetryRequest by storing just the hash of ClientHello1
 in the cookie, rather than requiring it to export the entire intermediate
 hash state (see {{cookie}}).
 
-For concreteness, the transcript hash is always taken from the
-following sequence of handshake messages, starting at the first
-ClientHello and including only those messages that were sent:
-ClientHello, HelloRetryRequest, ClientHello, ServerHello,
+When a range of messages is specified with "...", the transcript hash
+is taken from the sequence of handshake messages that were sent or received
+during the main handshake, starting and ending at the specified messages.
+In this document, it is taken from the following sequence of handshake
+messages: ClientHello, HelloRetryRequest, ClientHello, ServerHello,
 EncryptedExtensions, server CertificateRequest, server Certificate,
 server CertificateVerify, server Finished, EndOfEarlyData, client
-Certificate, client CertificateVerify, and client Finished.
+Certificate, client CertificateVerify, and client Finished. TLS extensions may
+add or remove messages, in which case the transcript hash will reflect the
+modified sequence.
 
 In general, implementations can implement the transcript by keeping a
 running transcript hash value based on the negotiated hash. Note,


### PR DESCRIPTION
As previously written, it suggests the message sequence does not change at all, but it is actually (as the text suggests), the transcript of everything sent or received.

This still doesn't quite make us robust to extensions. The CertificateVerify and Finished messages are defined in terms of this "Handshake Context" that is written using phrases like

* "later of EncryptedExtensions/CertificateRequest"
* "later of server Finished/EndOfEarlyData"
* "ClientHello ... client Finished + CertificateRequest"

And then sometimes Certificate and CertificateVerify are explicitly appended to it. Interestingly, that is also a bit goofy because we don't always account for those messages not existing in the prose.

This PR leaves all that alone for now, because I haven't quite written something down for that yet. (I think the right wording is to say "hash all the messages up to but not including Finished/CertificateVerify.)