### PR TITLE
Move The Transcript Hash to earlier in the document

### DIFF
--- a/draft-ietf-tls-rfc8446bis.md
+++ b/draft-ietf-tls-rfc8446bis.md
@@ -1283,7 +1283,8 @@ processed and transmitted as specified by the current active connection state.
        } Handshake;
 
 Protocol messages MUST be sent in the order defined in
-{{the-transcript-hash}} and shown in the diagrams in {{protocol-overview}}.
+{{the-transcript-hash}} and shown in the diagrams in {{protocol-overview}},
+unless modified by a TLS extension.
 A peer which receives a handshake message in an unexpected order
 MUST abort the handshake with an "unexpected_message" alert.
 

--- a/draft-ietf-tls-rfc8446bis.md
+++ b/draft-ietf-tls-rfc8446bis.md
@@ -2995,13 +2995,16 @@ stateless HelloRetryRequest by storing just the hash of ClientHello1
 in the cookie, rather than requiring it to export the entire intermediate
 hash state (see {{cookie}}).
 
-For concreteness, the transcript hash is always taken from the
-following sequence of handshake messages, starting at the first
-ClientHello and including only those messages that were sent:
-ClientHello, HelloRetryRequest, ClientHello, ServerHello,
+When a range of messages is specified with "...", the transcript hash
+is taken from the sequence of handshake messages that were sent or received
+during the main handshake, starting and ending at the specified messages.
+In this document, it is taken from the following sequence of handshake
+messages: ClientHello, HelloRetryRequest, ClientHello, ServerHello,
 EncryptedExtensions, server CertificateRequest, server Certificate,
 server CertificateVerify, server Finished, EndOfEarlyData, client
-Certificate, client CertificateVerify, and client Finished.
+Certificate, client CertificateVerify, and client Finished. TLS extensions may
+add or remove messages, in which case the transcript hash will reflect the
+modified sequence.
 
 In general, implementations can implement the transcript by keeping a
 running transcript hash value based on the negotiated hash. Note,


### PR DESCRIPTION
*Only look at the last commit in this stack. This PR includes https://github.com/tlswg/tls13-spec/pull/1401, https://github.com/tlswg/tls13-spec/pull/1402, and https://github.com/tlswg/tls13-spec/pull/1403. GitHub is bad at stacked PRs. I'll rebase this one once decisions on the other three PRs is made.*

It is a little strange that it is buried inside Authentication Messages, but then it's referenced all throughout the document. This seems enough of a core component of the handshake protocol to describe it first.

NB: This will cause almost all the section numbers between RFC 8446 and rfc8446bis to be different. Folks will need to take some care when updating references.