### PR TITLE
Security considerations for reusing keys in multiple key establishments

### DIFF
--- a/draft-ietf-tls-rfc8446bis.md
+++ b/draft-ietf-tls-rfc8446bis.md
@@ -5394,6 +5394,8 @@ cache lookups in web browsers.
 Clients and Servers SHOULD NOT reuse a key share for multiple connections. Reuse
 of a key share allows passive observers to correlate different connections. Reuse
 of a client key share to the same server additionally allows the server to correlate different connections.
+Additionally, if a key is reused in multiple key-establishment operations, i.e., a static key, this
+undermines forward secrecy and makes exploitation of side-channel attacks and implementation flaws much easier.
 
 It is RECOMMENDED that the labels for external identities be selected so that they
 do not provide additional information about the identity of the


### PR DESCRIPTION
See https://mailarchive.ietf.org/arch/msg/tls/KepJCOX3F_ABti_JYDWrvQGx07U/

---

>RFC8446bis explicitly defines key reuse as a SHOULD NOT.

It would be good if RFC8446bis could clarify what this 'key reuse' means. As discussed earlier, this term can have at least three very different meanings. Many formal analysis experts have understood TLS 1.3 as specifying that keys should be used for only one execution of key establishment.
https://mailarchive.ietf.org/arch/msg/tls/MOqSAplAYQuA6AwkKfHCphQUlKU/

If 'key reuse' includes using the same key in more than one execution of key establishment, RFC 8446bis should explain that such 'key reuse' undermines forward secrecy and makes exploitation of side-channel attacks and implementation flaws much easier.

While RFC 8446 fails to define the term 'ephemeral', specifications using ML-KEM points normatively to FIPS 203, which in turn points normatively to SP 800-227, which has very precise definitions for 'ephemeral' and 'static'. Since X25519MLKEM768 is already the de facto standard for TLS key exchange, TLS specifications should avoid using the terms 'ephemeral' and 'static' in ways that conflict with FIPS 203.

I do not oppose other people using static keys in TLS for visibility; I just strongly agree with SP 1800-37 that it is a bad solution for visibility, and if allowed in a TLS WG document, the security implications should be clearly described.

I am not sure whether the current situation is the result of ideological fighting, privacy theater, or a combination of both. Beyond the existing uncertainty regarding whether static keys are permitted, the current approach of not explicitly negotiating static keys is strictly worse than the solutions in TLS 1.2 and in draft-rhrd-tls-tls13-visibility.

---
