### PR TITLE
Clarify transcript hash

### DIFF
--- a/rfc9846.md
+++ b/rfc9846.md
@@ -1300,6 +1300,47 @@ MUST abort the handshake with an "unexpected_message" alert.
 New handshake message types are assigned by IANA as described in
 {{iana-considerations}}.
 
+### The Transcript Hash
+
+Many of the cryptographic computations in TLS make use of a transcript
+hash. This value is computed by hashing the concatenation of
+each included handshake message, including the handshake
+message header carrying the handshake message type and length fields,
+but not including record layer headers. I.e.,
+
+     Transcript-Hash(M1, M2, ... Mn) = Hash(M1 || M2 || ... || Mn)
+
+As an exception to this general rule, when the server responds to a
+ClientHello with a HelloRetryRequest, the value of ClientHello1 is
+replaced with a special synthetic handshake message of handshake
+type "message_hash" containing Hash(ClientHello1). I.e.,
+
+     Transcript-Hash(ClientHello1, HelloRetryRequest, ... Mn) =
+         Hash(message_hash ||        /* Handshake type */
+              00 00 Hash.length  ||   /* Handshake message length (bytes) */
+              Hash(ClientHello1) ||  /* Hash of ClientHello1 */
+              HelloRetryRequest  || ... || Mn)
+
+The reason for this construction is to allow the server to do a
+stateless HelloRetryRequest by storing just the hash of ClientHello1
+in the cookie, rather than requiring it to export the entire intermediate
+hash state (see {{cookie}}).
+
+When a range of messages is specified with "...", the transcript hash
+is taken from the sequence of handshake messages that were sent or received
+during the main handshake, starting and ending at the specified messages.
+In this document, it is taken from the following sequence of handshake
+messages: ClientHello, HelloRetryRequest, ClientHello, ServerHello,
+EncryptedExtensions, server CertificateRequest, server Certificate,
+server CertificateVerify, server Finished, EndOfEarlyData, client
+Certificate, client CertificateVerify, and client Finished. TLS extensions may
+add or remove messages, in which case the transcript hash will reflect the
+modified sequence.
+
+In general, implementations can implement the transcript by keeping a
+running transcript hash value based on the negotiated hash. Note,
+however, that subsequent post-handshake authentications do not include
+each other, just the messages through the end of the main handshake.
 
 ## Key Exchange Messages
 
@@ -2986,47 +3027,6 @@ for each scenario:
 | Post-Handshake | ClientHello ... client Finished + CertificateRequest | [sender]_application_traffic_secret_N |
 {: #hs-ctx-and-keys title="Authentication Inputs"}
 
-### The Transcript Hash
-
-Many of the cryptographic computations in TLS make use of a transcript
-hash. This value is computed by hashing the concatenation of
-each included handshake message, including the handshake
-message header carrying the handshake message type and length fields,
-but not including record layer headers. I.e.,
-
-     Transcript-Hash(M1, M2, ... Mn) = Hash(M1 || M2 || ... || Mn)
-
-As an exception to this general rule, when the server responds to a
-ClientHello with a HelloRetryRequest, the value of ClientHello1 is
-replaced with a special synthetic handshake message of handshake
-type "message_hash" containing Hash(ClientHello1). I.e.,
-
-     Transcript-Hash(ClientHello1, HelloRetryRequest, ... Mn) =
-         Hash(message_hash ||        /* Handshake type */
-              00 00 Hash.length  ||   /* Handshake message length (bytes) */
-              Hash(ClientHello1) ||  /* Hash of ClientHello1 */
-              HelloRetryRequest  || ... || Mn)
-
-The reason for this construction is to allow the server to do a
-stateless HelloRetryRequest by storing just the hash of ClientHello1
-in the cookie, rather than requiring it to export the entire intermediate
-hash state (see {{cookie}}).
-
-When a range of messages is specified with "...", the transcript hash
-is taken from the sequence of handshake messages that were sent or received
-during the main handshake, starting and ending at the specified messages.
-In this document, it is taken from the following sequence of handshake
-messages: ClientHello, HelloRetryRequest, ClientHello, ServerHello,
-EncryptedExtensions, server CertificateRequest, server Certificate,
-server CertificateVerify, server Finished, EndOfEarlyData, client
-Certificate, client CertificateVerify, and client Finished. TLS extensions may
-add or remove messages, in which case the transcript hash will reflect the
-modified sequence.
-
-In general, implementations can implement the transcript by keeping a
-running transcript hash value based on the negotiated hash. Note,
-however, that subsequent post-handshake authentications do not include
-each other, just the messages through the end of the main handshake.
 
 ###  Certificate
 

--- a/rfc9846.md
+++ b/rfc9846.md
@@ -3011,13 +3011,16 @@ stateless HelloRetryRequest by storing just the hash of ClientHello1
 in the cookie, rather than requiring it to export the entire intermediate
 hash state (see {{cookie}}).
 
-For concreteness, the transcript hash is always taken from the
-following sequence of handshake messages, starting at the first
-ClientHello and including only those messages that were sent:
-ClientHello, HelloRetryRequest, ClientHello, ServerHello,
+When a range of messages is specified with "...", the transcript hash
+is taken from the sequence of handshake messages that were sent or received
+during the main handshake, starting and ending at the specified messages.
+In this document, it is taken from the following sequence of handshake
+messages: ClientHello, HelloRetryRequest, ClientHello, ServerHello,
 EncryptedExtensions, server CertificateRequest, server Certificate,
 server CertificateVerify, server Finished, EndOfEarlyData, client
-Certificate, client CertificateVerify, and client Finished.
+Certificate, client CertificateVerify, and client Finished. TLS extensions may
+add or remove messages, in which case the transcript hash will reflect the
+modified sequence.
 
 In general, implementations can implement the transcript by keeping a
 running transcript hash value based on the negotiated hash. Note,

--- a/rfc9846.md
+++ b/rfc9846.md
@@ -1317,7 +1317,7 @@ type "message_hash" containing Hash(ClientHello1). I.e.,
 
      Transcript-Hash(ClientHello1, HelloRetryRequest, ... Mn) =
          Hash(message_hash ||        /* Handshake type */
-              00 00 Hash.length  ||   /* Handshake message length (bytes) */
+              00 00 Hash.length  ||  /* Handshake message length (bytes) */
               Hash(ClientHello1) ||  /* Hash of ClientHello1 */
               HelloRetryRequest  || ... || Mn)
 
@@ -1330,7 +1330,7 @@ When a range of messages is specified with "...", the transcript hash
 is taken from the sequence of handshake messages that were sent or received
 during the main handshake, starting and ending at the specified messages.
 In this document, it is taken from the following sequence of handshake
-messages: ClientHello, HelloRetryRequest, ClientHello, ServerHello,
+messages (some of which might be omitted): ClientHello, HelloRetryRequest, ClientHello, ServerHello,
 EncryptedExtensions, server CertificateRequest, server Certificate,
 server CertificateVerify, server Finished, EndOfEarlyData, client
 Certificate, client CertificateVerify, and client Finished. TLS extensions may
@@ -1338,7 +1338,8 @@ add or remove messages, in which case the transcript hash will reflect the
 modified sequence.
 
 In general, implementations can implement the transcript by keeping a
-running transcript hash value based on the negotiated hash. Note,
+running transcript hash value based on the negotiated hash, once
+the hash has been selected in the ServerHello. Note,
 however, that subsequent post-handshake authentications do not include
 each other, just the messages through the end of the main handshake.
 

--- a/rfc9846.md
+++ b/rfc9846.md
@@ -1313,7 +1313,7 @@ but not including record layer headers. I.e.,
 As an exception to this general rule, when the server responds to a
 ClientHello with a HelloRetryRequest, the value of ClientHello1 is
 replaced with a special synthetic handshake message of handshake
-type "message_hash" containing Hash(ClientHello1). I.e.,
+type "message_hash" (254) containing Hash(ClientHello1). I.e.,
 
      Transcript-Hash(ClientHello1, HelloRetryRequest, ... Mn) =
          Hash(message_hash ||        /* Handshake type */
@@ -1339,9 +1339,11 @@ modified sequence.
 
 In general, implementations can implement the transcript by keeping a
 running transcript hash value based on the negotiated hash, once
-the hash has been selected in the ServerHello. Note,
-however, that subsequent post-handshake authentications do not include
-each other, just the messages through the end of the main handshake.
+the hash has been selected in the ServerHello.
+
+Note, however, that subsequent post-handshake authentications do not
+include each other, just the messages through the end of the main
+handshake.
 
 ## Key Exchange Messages
 

--- a/rfc9846.md
+++ b/rfc9846.md
@@ -1292,7 +1292,8 @@ processed and transmitted as specified by the current active connection state.
        } Handshake;
 
 Protocol messages MUST be sent in the order defined in
-{{the-transcript-hash}} and shown in the diagrams in {{protocol-overview}}.
+{{the-transcript-hash}} and shown in the diagrams in {{protocol-overview}},
+unless modified by a TLS extension.
 A peer which receives a handshake message in an unexpected order
 MUST abort the handshake with an "unexpected_message" alert.
 


### PR DESCRIPTION
This adopts some of  @davidben's clarifications about the transcript but not the redefinition.