### PR TITLE
Editorial changes

### DIFF
--- a/rfc9846.md
+++ b/rfc9846.md
@@ -4,8 +4,8 @@ abbrev: TLS
 docname: draft-ietf-tls-rfc8446bis-latest
 submissiontype: IETF
 category: std
-updates: 5705, 6066, 7627, 8422
-obsoletes: 8446
+updates: 5705, 6066, 7627
+obsoletes: 5077, 5246, 6961, 8422, 8446
 
 v: 3
 ipr: pre5378Trust200902
@@ -426,7 +426,7 @@ This document specifies version 1.3 of the Transport Layer Security
 over the Internet in a way that is designed to prevent eavesdropping,
 tampering, and message forgery.
 
-This document updates RFCs 5705, 6066, 7627, and 8422 and obsoletes
+This document updates RFCs 5705, 6066, and 7627 and obsoletes
 RFCs 5077, 5246, 6961, 8422, and 8446. This document also specifies
 new requirements for TLS 1.2 implementations.
 --- middle
@@ -4854,7 +4854,7 @@ TLS-compliant application MUST implement the following TLS extensions:
   * Cookie                 ("cookie"; {{cookie}})
   * Signature Algorithms   ("signature_algorithms"; {{signature-algorithms}})
   * Signature Algorithms Certificate  ("signature_algorithms_cert"; {{signature-algorithms}})
-  * Negotiated Groups      ("supported_groups"; {{supported-groups}})
+  * Supported Groups       ("supported_groups"; {{supported-groups}})
   * Key Share              ("key_share"; {{key-share}})
   * Server Name Indication ("server_name"; Section 3 of {{RFC6066}})
 


### PR DESCRIPTION
- Fixing the inconsistencies between abstract and header:
  - adding all obsolete drafts from the abstract to the heading 
  - fixing that 8422 is not both updated and obsoleted
- Changed "Negotiated Groups" to "Supported Groups". The term "Negotiated Groups" is only used once and never again.

Eric Rescorla wrote:
>I'm now trying to recall why we did this. ISTM that given that we are
>obsoleting 5246 (already done in 8446), we should obsolete all the
>other specs that only meaningfully apply to 5246. Here's the
>list:
>
> * RFC 5077: Transport Layer Security (TLS) Session Resumption without
>Server-Side State
> * RFC 5246: The Transport Layer Security (TLS) Protocol Version 1.2
> * RFC 5705: Keying Material Exporters for Transport Layer Security (TLS)
> * RFC 6066: Transport Layer Security (TLS) Extensions: Extension
>Definitions
> * RFC 6961: The Transport Layer Security (TLS) Multiple Certificate Status
>Request Extension
> * RFC 7627: Transport Layer Security (TLS) Session Hash and Extended
>Master Secret Extension
> * RFC 8422: Elliptic Curve Cryptography (ECC) Cipher Suites for Transport
>Layer Security (TLS)
>   Versions 1.2 and Earlier

Note that 5705, 6066, and 7627 are still listed as updated and not obsoleted. My understanding from your answer above is that they should all be obsoleted.