### PR TITLE
Update extensions list

### DIFF
--- a/rfc9846.md
+++ b/rfc9846.md
@@ -1829,8 +1829,8 @@ A number of TLS messages contain tag-length-value encoded extensions structures.
            (65535)
        } ExtensionType;
 
-Note: This list includes only extensions marked "Recommended" at the
-time of this writing.
+Note: This list includes only extensions marked
+"Recommended" and allowed for TLS 1.3 at the time of this writing.
 
 Here:
 
@@ -1914,7 +1914,7 @@ appears, it MUST abort the handshake with an "illegal_parameter" alert.
 {: #extensions-list title="TLS Extensions"}
 
 Note: This table includes only extensions marked
-"Recommended" at the time of this writing.
+"Recommended" and allowed for TLS 1.3 at the time of this writing.
 
 When multiple extensions of different types are present, the
 extensions MAY appear in any order, with the exception of

--- a/rfc9846.md
+++ b/rfc9846.md
@@ -1785,17 +1785,19 @@ A number of TLS messages contain tag-length-value encoded extensions structures.
 
        enum {
            server_name(0),                             /* RFC 6066 */
-           max_fragment_length(1),                     /* RFC 6066 */
            status_request(5),                          /* RFC 6066 */
            supported_groups(10),                       /* RFC 8422, 7919 */
            signature_algorithms(13),                   /* RFC 8446 */
            use_srtp(14),                               /* RFC 5764 */
            heartbeat(15),                              /* RFC 6520 */
            application_layer_protocol_negotiation(16), /* RFC 7301 */
-           signed_certificate_timestamp(18),           /* RFC 6962 */
            client_certificate_type(19),                /* RFC 7250 */
            server_certificate_type(20),                /* RFC 7250 */
            padding(21),                                /* RFC 7685 */
+           compress_certificate(27),                   /* RFC 8879 */
+           record_size_limit(28),                      /* RFC 8449 */
+           delegated_credential(34),                   /* RFC 9345 */
+           supported_ekt_ciphers(39),                  /* RFC 8870 */
            pre_shared_key(41),                         /* RFC 8446 */
            early_data(42),                             /* RFC 8446 */
            supported_versions(43),                     /* RFC 8446 */
@@ -1806,8 +1808,18 @@ A number of TLS messages contain tag-length-value encoded extensions structures.
            post_handshake_auth(49),                    /* RFC 8446 */
            signature_algorithms_cert(50),              /* RFC 8446 */
            key_share(51),                              /* RFC 8446 */
+           transparency_info(52),                      /* RFC 9162 */
+           external_id_hash(55),                       /* RFC 8844 */
+           external_session_id(56),                    /* RFC 8844 */
+           quic_transport_parameters(57),              /* RFC 9001 */
+           ticket_request(58),                         /* RFC 9149 */
+           ech_outer_extensions(64768),                /* RFC 9849 */
+           encrypted_client_hello(65037),              /* RFC 9849 */
            (65535)
        } ExtensionType;
+
+Note: This list includes only extensions marked "Recommended" at the
+time of this writing.
 
 Here:
 
@@ -1867,16 +1879,15 @@ appears, it MUST abort the handshake with an "illegal_parameter" alert.
 | client_certificate_type {{RFC7250}}        |      CH, EE |
 | server_certificate_type {{RFC7250}}        |      CH, EE |
 | padding {{RFC7685}}                        |          CH |
-| cached_info {{RFC7924}}                    | CH, EE |
 | compress_certificate {{RFC8879}}           | CH, CR |
 | record_size_limit {{RFC8449}}              | CH, EE |
 | delegated_credential {{RFC9345}}          | CH, CR, CT |
 | supported_ekt_ciphers {{RFC8870}}          | CH, EE |
 | pre_shared_key {{RFC8446}}       |      CH, SH |
 | early_data {{RFC8446}}           | CH, EE, NST |
-| psk_key_exchange_modes {{RFC8446}}|          CH |
-| cookie {{RFC8446}}               |     CH, HRR |
 | supported_versions {{RFC8446}}   | CH, SH, HRR |
+| cookie {{RFC8446}}               |     CH, HRR |
+| psk_key_exchange_modes {{RFC8446}}|          CH |
 | certificate_authorities {{RFC8446}}|      CH, CR |
 | oid_filters {{RFC8446}}          |          CR |
 | post_handshake_auth {{RFC8446}}  |          CH |
@@ -5348,17 +5359,19 @@ might receive them from older TLS implementations.
 
        enum {
            server_name(0),                             /* RFC 6066 */
-           max_fragment_length(1),                     /* RFC 6066 */
            status_request(5),                          /* RFC 6066 */
            supported_groups(10),                       /* RFC 8422, 7919 */
            signature_algorithms(13),                   /* RFC 8446 */
            use_srtp(14),                               /* RFC 5764 */
            heartbeat(15),                              /* RFC 6520 */
            application_layer_protocol_negotiation(16), /* RFC 7301 */
-           signed_certificate_timestamp(18),           /* RFC 6962 */
            client_certificate_type(19),                /* RFC 7250 */
            server_certificate_type(20),                /* RFC 7250 */
            padding(21),                                /* RFC 7685 */
+           compress_certificate(27),                   /* RFC 8879 */
+           record_size_limit(28),                      /* RFC 8449 */
+           delegated_credential(34),                   /* RFC 9345 */
+           supported_ekt_ciphers(39),                  /* RFC 8870 */
            pre_shared_key(41),                         /* RFC 8446 */
            early_data(42),                             /* RFC 8446 */
            supported_versions(43),                     /* RFC 8446 */
@@ -5369,6 +5382,13 @@ might receive them from older TLS implementations.
            post_handshake_auth(49),                    /* RFC 8446 */
            signature_algorithms_cert(50),              /* RFC 8446 */
            key_share(51),                              /* RFC 8446 */
+           transparency_info(52),                      /* RFC 9162 */
+           external_id_hash(55),                       /* RFC 8844 */
+           external_session_id(56),                    /* RFC 8844 */
+           quic_transport_parameters(57),              /* RFC 9001 */
+           ticket_request(58),                         /* RFC 9149 */
+           ech_outer_extensions(64768),                /* RFC 9849 */
+           encrypted_client_hello(65037),              /* RFC 9849 */
            (65535)
        } ExtensionType;
 

--- a/rfc9846.md
+++ b/rfc9846.md
@@ -49,6 +49,16 @@ normative:
   RFC8174:
   RFC5116:
   RFC8701:
+  RFC9846:
+       title: "The Transport Layer Security (TLS) Protocol Version 1.3 (PLACEHOLDER)"
+       date: May 2026
+       author:
+         - ins: E. Rescorla
+           fullname: E. Rescorla
+           surname: Rescorla
+       seriesinfo:
+         RFC: "9846"
+       target: https://www.rfc-editor.org/info/rfc9846
 
   X690:
        title: "Information technology - ASN.1 encoding Rules: Specification of Basic Encoding Rules (BER), Canonical Encoding Rules (CER) and Distinguished Encoding Rules (DER)"

--- a/rfc9846.md
+++ b/rfc9846.md
@@ -5071,9 +5071,8 @@ by IANA:
   rsa_pss_pss_sha256, rsa_pss_pss_sha384, rsa_pss_pss_sha512, and ed25519.
   The
   "Recommended" column is assigned a value of "N" unless explicitly
- requested, and adding a value with a "Recommended" value of "Y"
- requires Standards Action {{RFC8126}}.  IESG Approval is REQUIRED
- for a Y->N transition.
+  requested. See {{?RFC9847}} for additional information about "Recommended"
+  column values and settings.
 
  - TLS PskKeyExchangeMode registry: Values in the
    range 0-253 (decimal) are assigned via Specification Required
@@ -5083,20 +5082,28 @@ by IANA:
    populated with psk_ke (0) and psk_dhe_ke (1).  Both are marked as
    "Recommended".  The
    "Recommended" column is assigned a value of "N" unless explicitly
-   requested, and adding a value with a "Recommended" value of "Y"
-   requires Standards Action {{RFC8126}}.  IESG Approval is REQUIRED
-   for a Y->N transition.
+   requested. See {{?RFC9847}} for additional information about "Recommended"
+   column values and settings.
 
 ## Changes for this RFC {#bis-changes}
 
 IANA has updated all references to {{RFC8446}} in the IANA
 registries with references to this document.
 
+IANA has updated the "Recommended" column procedures to match {{RFC9847}} for
+the TLS SignatureScheme and PskKeyExchangeMode registries.
+
 IANA has renamed the "extended_master_secret" value
 in the TLS ExtensionType Values registry to "extended_main_secret".
 
 IANA has created  a value for the "general_error"
 alert in the TLS Alerts registry with the value given in {{alert-protocol}}.
+
+IANA has updated added references to this document for the status_request and
+supported_groups entries in the TLS ExtensionType Values registry.
+
+IANA has updated the TLS ExtensionType value in the "TLS 1.3" column for
+cached_info to "CH, EE".
 
 --- back
 

--- a/rfc9846.md
+++ b/rfc9846.md
@@ -97,6 +97,7 @@ informative:
   RFC9149:
   RFC9257:
   RFC9258:
+  RFC9261;
   RFC9345:
   RFC9849:
 
@@ -1787,7 +1788,7 @@ A number of TLS messages contain tag-length-value encoded extensions structures.
            server_name(0),                             /* RFC 6066 */
            status_request(5),                          /* RFC 6066 */
            supported_groups(10),                       /* RFC 8422, 7919 */
-           signature_algorithms(13),                   /* RFC 8446 */
+           signature_algorithms(13),                   /* RFC 9846 */
            use_srtp(14),                               /* RFC 5764 */
            heartbeat(15),                              /* RFC 6520 */
            application_layer_protocol_negotiation(16), /* RFC 7301 */
@@ -1798,16 +1799,16 @@ A number of TLS messages contain tag-length-value encoded extensions structures.
            record_size_limit(28),                      /* RFC 8449 */
            delegated_credential(34),                   /* RFC 9345 */
            supported_ekt_ciphers(39),                  /* RFC 8870 */
-           pre_shared_key(41),                         /* RFC 8446 */
-           early_data(42),                             /* RFC 8446 */
-           supported_versions(43),                     /* RFC 8446 */
-           cookie(44),                                 /* RFC 8446 */
-           psk_key_exchange_modes(45),                 /* RFC 8446 */
-           certificate_authorities(47),                /* RFC 8446 */
-           oid_filters(48),                            /* RFC 8446 */
-           post_handshake_auth(49),                    /* RFC 8446 */
-           signature_algorithms_cert(50),              /* RFC 8446 */
-           key_share(51),                              /* RFC 8446 */
+           pre_shared_key(41),                         /* RFC 9846 */
+           early_data(42),                             /* RFC 9846 */
+           supported_versions(43),                     /* RFC 9846 */
+           cookie(44),                                 /* RFC 9846 */
+           psk_key_exchange_modes(45),                 /* RFC 9846 */
+           certificate_authorities(47),                /* RFC 9846 */
+           oid_filters(48),                            /* RFC 9846 */
+           post_handshake_auth(49),                    /* RFC 9846 */
+           signature_algorithms_cert(50),              /* RFC 9846 */
+           key_share(51),                              /* RFC 9846 */
            transparency_info(52),                      /* RFC 9162 */
            external_id_hash(55),                       /* RFC 8844 */
            external_session_id(56),                    /* RFC 8844 */
@@ -1872,7 +1873,7 @@ appears, it MUST abort the handshake with an "illegal_parameter" alert.
 | server_name {{RFC6066}}                    |      CH, EE |
 | status_request {{RFC6066}}                 |  CH, CR, CT |
 | supported_groups {{RFC7919}}               |      CH, EE |
-| signature_algorithms {{RFC8446}}           |      CH, CR |
+| signature_algorithms {{RFC9846}}           |      CH, CR |
 | use_srtp {{RFC5764}}                       |      CH, EE |
 | heartbeat {{RFC6520}}                      |      CH, EE |
 | application_layer_protocol_negotiation {{RFC7301}}|      CH, EE |
@@ -1883,16 +1884,16 @@ appears, it MUST abort the handshake with an "illegal_parameter" alert.
 | record_size_limit {{RFC8449}}              | CH, EE |
 | delegated_credential {{RFC9345}}          | CH, CR, CT |
 | supported_ekt_ciphers {{RFC8870}}          | CH, EE |
-| pre_shared_key {{RFC8446}}       |      CH, SH |
-| early_data {{RFC8446}}           | CH, EE, NST |
-| supported_versions {{RFC8446}}   | CH, SH, HRR |
-| cookie {{RFC8446}}               |     CH, HRR |
-| psk_key_exchange_modes {{RFC8446}}|          CH |
-| certificate_authorities {{RFC8446}}|      CH, CR |
-| oid_filters {{RFC8446}}          |          CR |
-| post_handshake_auth {{RFC8446}}  |          CH |
-| signature_algorithms_cert {{RFC8446}}|      CH, CR |
-| key_share {{RFC8446}}            | CH, SH, HRR |
+| pre_shared_key {{RFC9846}}       |      CH, SH |
+| early_data {{RFC9846}}           | CH, EE, NST |
+| supported_versions {{RFC9846}}   | CH, SH, HRR |
+| cookie {{RFC9846}}               |     CH, HRR |
+| psk_key_exchange_modes {{RFC9846}}|          CH |
+| certificate_authorities {{RFC9846}}|      CH, CR |
+| oid_filters {{RFC9846}}          |          CR |
+| post_handshake_auth {{RFC9846}}  |          CH |
+| signature_algorithms_cert {{RFC9846}}|      CH, CR |
+| key_share {{RFC9846}}            | CH, SH, HRR |
 | transparency_info {{RFC9162}}    | CH, CR, CT |
 | external_id_hash {{RFC8844}}     | CH, EE |
 | external_session_id {{RFC8844}}  | CH, EE |
@@ -5361,7 +5362,7 @@ might receive them from older TLS implementations.
            server_name(0),                             /* RFC 6066 */
            status_request(5),                          /* RFC 6066 */
            supported_groups(10),                       /* RFC 8422, 7919 */
-           signature_algorithms(13),                   /* RFC 8446 */
+           signature_algorithms(13),                   /* RFC 9846 */
            use_srtp(14),                               /* RFC 5764 */
            heartbeat(15),                              /* RFC 6520 */
            application_layer_protocol_negotiation(16), /* RFC 7301 */
@@ -5372,16 +5373,16 @@ might receive them from older TLS implementations.
            record_size_limit(28),                      /* RFC 8449 */
            delegated_credential(34),                   /* RFC 9345 */
            supported_ekt_ciphers(39),                  /* RFC 8870 */
-           pre_shared_key(41),                         /* RFC 8446 */
-           early_data(42),                             /* RFC 8446 */
-           supported_versions(43),                     /* RFC 8446 */
-           cookie(44),                                 /* RFC 8446 */
-           psk_key_exchange_modes(45),                 /* RFC 8446 */
-           certificate_authorities(47),                /* RFC 8446 */
-           oid_filters(48),                            /* RFC 8446 */
-           post_handshake_auth(49),                    /* RFC 8446 */
-           signature_algorithms_cert(50),              /* RFC 8446 */
-           key_share(51),                              /* RFC 8446 */
+           pre_shared_key(41),                         /* RFC 9846 */
+           early_data(42),                             /* RFC 9846 */
+           supported_versions(43),                     /* RFC 9846 */
+           cookie(44),                                 /* RFC 9846 */
+           psk_key_exchange_modes(45),                 /* RFC 9846 */
+           certificate_authorities(47),                /* RFC 9846 */
+           oid_filters(48),                            /* RFC 9846 */
+           post_handshake_auth(49),                    /* RFC 9846 */
+           signature_algorithms_cert(50),              /* RFC 9846 */
+           key_share(51),                              /* RFC 9846 */
            transparency_info(52),                      /* RFC 9162 */
            external_id_hash(55),                       /* RFC 8844 */
            external_session_id(56),                    /* RFC 8844 */

--- a/rfc9846.md
+++ b/rfc9846.md
@@ -107,7 +107,7 @@ informative:
   RFC9149:
   RFC9257:
   RFC9258:
-  RFC9261;
+  RFC9261:
   RFC9345:
   RFC9849:
 

--- a/rfc9846.md
+++ b/rfc9846.md
@@ -1795,9 +1795,9 @@ A number of TLS messages contain tag-length-value encoded extensions structures.
        } Extension;
 
        enum {
-           server_name(0),                             /* RFC 6066 */
-           status_request(5),                          /* RFC 6066 */
-           supported_groups(10),                       /* RFC 8422, 7919 */
+           server_name(0),                             /* RFC 6066, 9261 */
+           status_request(5),                          /* RFC 6066, 9846 */
+           supported_groups(10),                       /* RFC 7919, 9846 */
            signature_algorithms(13),                   /* RFC 9846 */
            use_srtp(14),                               /* RFC 5764 */
            heartbeat(15),                              /* RFC 6520 */
@@ -1880,9 +1880,9 @@ appears, it MUST abort the handshake with an "illegal_parameter" alert.
 
 | Extension                                |   TLS 1.3   |
 |:-----------------------------------------|------------:|
-| server_name {{RFC6066}}                    |      CH, EE |
-| status_request {{RFC6066}}                 |  CH, CR, CT |
-| supported_groups {{RFC7919}}               |      CH, EE |
+| server_name {{RFC6066}} {{RFC9261}}        |  CH, EE, CR |
+| status_request {{RFC6066}} {{RFC9846}}     |  CH, CR, CT |
+| supported_groups {{RFC7919}} {{RFC9846}}   |      CH, EE |
 | signature_algorithms {{RFC9846}}           |      CH, CR |
 | use_srtp {{RFC5764}}                       |      CH, EE |
 | heartbeat {{RFC6520}}                      |      CH, EE |
@@ -5369,9 +5369,9 @@ might receive them from older TLS implementations.
        } Extension;
 
        enum {
-           server_name(0),                             /* RFC 6066 */
-           status_request(5),                          /* RFC 6066 */
-           supported_groups(10),                       /* RFC 8422, 7919 */
+           server_name(0),                             /* RFC 6066, 9261 */
+           status_request(5),                          /* RFC 6066, 9846 */
+           supported_groups(10),                       /* RFC 7919, 9846 */
            signature_algorithms(13),                   /* RFC 9846 */
            use_srtp(14),                               /* RFC 5764 */
            heartbeat(15),                              /* RFC 6520 */

--- a/rfc9846.md
+++ b/rfc9846.md
@@ -1858,14 +1858,12 @@ appears, it MUST abort the handshake with an "illegal_parameter" alert.
 | Extension                                |   TLS 1.3   |
 |:-----------------------------------------|------------:|
 | server_name {{RFC6066}}                    |      CH, EE |
-| max_fragment_length {{RFC6066}}            |      CH, EE |
 | status_request {{RFC6066}}                 |  CH, CR, CT |
 | supported_groups {{RFC7919}}               |      CH, EE |
 | signature_algorithms {{RFC8446}}           |      CH, CR |
 | use_srtp {{RFC5764}}                       |      CH, EE |
 | heartbeat {{RFC6520}}                      |      CH, EE |
 | application_layer_protocol_negotiation {{RFC7301}}|      CH, EE |
-| signed_certificate_timestamp {{RFC6962}}   |  CH, CR, CT |
 | client_certificate_type {{RFC7250}}        |      CH, EE |
 | server_certificate_type {{RFC7250}}        |      CH, EE |
 | padding {{RFC7685}}                        |          CH |
@@ -1885,11 +1883,12 @@ appears, it MUST abort the handshake with an "illegal_parameter" alert.
 | signature_algorithms_cert {{RFC8446}}|      CH, CR |
 | key_share {{RFC8446}}            | CH, SH, HRR |
 | transparency_info {{RFC9162}}    | CH, CR, CT |
-| connection_id {{RFC9146}}        | CH, SH |
 | external_id_hash {{RFC8844}}     | CH, EE |
 | external_session_id {{RFC8844}}  | CH, EE |
 | quic_transport_parameters {{RFC9001}} | CH, EE |
 | ticket_request {{RFC9149}} | CH, EE|
+| ech_outer_extensions {{RFC9849}} | CH |
+| encrypted_client_hello {{RFC9849}} | CH, HRR, EE |
 {: #extensions-list title="TLS Extensions"}
 
 Note: This table includes only extensions marked


### PR DESCRIPTION
This PR updates the extension list to match the now-current extensions that are Recommended=Y.

I note that this includes a bunch of non-core extensions, but those were also in 8846, so I just followed the same nominal policy. 

@martinthomson  thoughts?