### PR TITLE
IANA alignment

### DIFF
--- a/rfc9846.md
+++ b/rfc9846.md
@@ -5084,8 +5084,8 @@ alert in the TLS Alerts registry with the value given in {{alert-protocol}}.
 IANA has updated added references to this document for the status_request and
 supported_groups entries in the TLS ExtensionType Values registry.
 
-IANA has updated the TLS ExtensionType values in the "TLS 1.3" column for 
-cached_info to "CH, EE" and renegotiation_info to "CH, SH".
+IANA has updated the TLS ExtensionType value in the "TLS 1.3" column for 
+cached_info to "CH, EE".
 
 --- back
 

--- a/rfc9846.md
+++ b/rfc9846.md
@@ -1892,7 +1892,7 @@ appears, it MUST abort the handshake with an "illegal_parameter" alert.
 | quic_transport_parameters {{RFC9001}} | CH, EE |
 | ticket_request {{RFC9149}} | CH, EE|
 | ech_outer_extensions {{RFC9849}} | CH |
-| renegotiation_info {{RFC5746}} | CH, SH |
+| renegotiation_info {{RFC5746}} | - |
 {: #extensions-list title="TLS Extensions"}
 
 Note: This table includes only extensions marked

--- a/rfc9846.md
+++ b/rfc9846.md
@@ -97,6 +97,7 @@ informative:
   RFC9149:
   RFC9257:
   RFC9258:
+  RFC9261:
   RFC9345:
   RFC9849:
 
@@ -1784,11 +1785,11 @@ A number of TLS messages contain tag-length-value encoded extensions structures.
        } Extension;
 
        enum {
-           server_name(0),                             /* RFC 6066 */
-           max_fragment_length(1),                     /* RFC 6066 */
-           status_request(5),                          /* RFC 6066 */
-           supported_groups(10),                       /* RFC 8422, 7919 */
-           signature_algorithms(13),                   /* RFC 8446 */
+           server_name(0),                             /* RFC 6066, 9261 */
+           max_fragment_length(1),                     /* RFC 6066, 8449 */
+           status_request(5),                          /* RFC 9846, 6066 */
+           supported_groups(10),                       /* RFC 9846, 8422, 7919 */
+           signature_algorithms(13),                   /* RFC 9846 */
            use_srtp(14),                               /* RFC 5764 */
            heartbeat(15),                              /* RFC 6520 */
            application_layer_protocol_negotiation(16), /* RFC 7301 */
@@ -1796,16 +1797,16 @@ A number of TLS messages contain tag-length-value encoded extensions structures.
            client_certificate_type(19),                /* RFC 7250 */
            server_certificate_type(20),                /* RFC 7250 */
            padding(21),                                /* RFC 7685 */
-           pre_shared_key(41),                         /* RFC 8446 */
-           early_data(42),                             /* RFC 8446 */
-           supported_versions(43),                     /* RFC 8446 */
-           cookie(44),                                 /* RFC 8446 */
-           psk_key_exchange_modes(45),                 /* RFC 8446 */
-           certificate_authorities(47),                /* RFC 8446 */
-           oid_filters(48),                            /* RFC 8446 */
-           post_handshake_auth(49),                    /* RFC 8446 */
-           signature_algorithms_cert(50),              /* RFC 8446 */
-           key_share(51),                              /* RFC 8446 */
+           pre_shared_key(41),                         /* RFC 9846 */
+           early_data(42),                             /* RFC 9846 */
+           supported_versions(43),                     /* RFC 9846 */
+           cookie(44),                                 /* RFC 9846 */
+           psk_key_exchange_modes(45),                 /* RFC 9846 */
+           certificate_authorities(47),                /* RFC 9846 */
+           oid_filters(48),                            /* RFC 9846 */
+           post_handshake_auth(49),                    /* RFC 9846 */
+           signature_algorithms_cert(50),              /* RFC 9846 */
+           key_share(51),                              /* RFC 9846 */
            (65535)
        } ExtensionType;
 
@@ -1857,11 +1858,11 @@ appears, it MUST abort the handshake with an "illegal_parameter" alert.
 
 | Extension                                |   TLS 1.3   |
 |:-----------------------------------------|------------:|
-| server_name {{RFC6066}}                    |      CH, EE |
-| max_fragment_length {{RFC6066}}            |      CH, EE |
-| status_request {{RFC6066}}                 |  CH, CR, CT |
-| supported_groups {{RFC7919}}               |      CH, EE |
-| signature_algorithms {{RFC8446}}           |      CH, CR |
+| server_name {{RFC6066}} {{RFC9261}}        |  CH, EE, CR |
+| max_fragment_length {{RFC6066}} {{RFC8449}}|      CH, EE |
+| status_request {{RFC9846}} {{RFC6066}}     |  CH, CR, CT |
+| supported_groups {{RFC9846}} {{RFC7919}}   |      CH, EE |
+| signature_algorithms {{RFC9846}}           |      CH, CR |
 | use_srtp {{RFC5764}}                       |      CH, EE |
 | heartbeat {{RFC6520}}                      |      CH, EE |
 | application_layer_protocol_negotiation {{RFC7301}}|      CH, EE |
@@ -1874,22 +1875,24 @@ appears, it MUST abort the handshake with an "illegal_parameter" alert.
 | record_size_limit {{RFC8449}}              | CH, EE |
 | delegated_credential {{RFC9345}}          | CH, CR, CT |
 | supported_ekt_ciphers {{RFC8870}}          | CH, EE |
-| pre_shared_key {{RFC8446}}       |      CH, SH |
-| early_data {{RFC8446}}           | CH, EE, NST |
-| psk_key_exchange_modes {{RFC8446}}|          CH |
-| cookie {{RFC8446}}               |     CH, HRR |
-| supported_versions {{RFC8446}}   | CH, SH, HRR |
-| certificate_authorities {{RFC8446}}|      CH, CR |
-| oid_filters {{RFC8446}}          |          CR |
-| post_handshake_auth {{RFC8446}}  |          CH |
-| signature_algorithms_cert {{RFC8446}}|      CH, CR |
-| key_share {{RFC8446}}            | CH, SH, HRR |
+| pre_shared_key {{RFC9846}}       |      CH, SH |
+| early_data {{RFC9846}}           | CH, EE, NST |
+| supported_versions {{RFC9846}}   | CH, SH, HRR |
+| cookie {{RFC9846}}               |     CH, HRR |
+| psk_key_exchange_modes {{RFC9846}}|          CH |
+| certificate_authorities {{RFC9846}}|      CH, CR |
+| oid_filters {{RFC9846}}          |          CR |
+| post_handshake_auth {{RFC9846}}  |          CH |
+| signature_algorithms_cert {{RFC9846}}|      CH, CR |
+| key_share {{RFC9846}}            | CH, SH, HRR |
 | transparency_info {{RFC9162}}    | CH, CR, CT |
 | connection_id {{RFC9146}}        | CH, SH |
 | external_id_hash {{RFC8844}}     | CH, EE |
 | external_session_id {{RFC8844}}  | CH, EE |
 | quic_transport_parameters {{RFC9001}} | CH, EE |
 | ticket_request {{RFC9149}} | CH, EE|
+| ech_outer_extensions {{RFC9849}} | CH |
+| renegotiation_info {{RFC5746}} | CH, SH |
 {: #extensions-list title="TLS Extensions"}
 
 Note: This table includes only extensions marked
@@ -5050,10 +5053,9 @@ by IANA:
   rsa_pss_pss_sha256, rsa_pss_pss_sha384, rsa_pss_pss_sha512, and ed25519.
   The
   "Recommended" column is assigned a value of "N" unless explicitly
- requested, and adding a value with a "Recommended" value of "Y"
- requires Standards Action {{RFC8126}}.  IESG Approval is REQUIRED
- for a Y->N transition.
-
+  requested. See {{?RFC9847}} for additional information about "Recommended"
+  column values and settings.
+ 
  - TLS PskKeyExchangeMode registry: Values in the
    range 0-253 (decimal) are assigned via Specification Required
    {{RFC8126}}.  The values 254 and 255 (decimal) are
@@ -5062,20 +5064,28 @@ by IANA:
    populated with psk_ke (0) and psk_dhe_ke (1).  Both are marked as
    "Recommended".  The
    "Recommended" column is assigned a value of "N" unless explicitly
-   requested, and adding a value with a "Recommended" value of "Y"
-   requires Standards Action {{RFC8126}}.  IESG Approval is REQUIRED
-   for a Y->N transition.
+   requested. See {{?RFC9847}} for additional information about "Recommended"
+   column values and settings.
 
 ## Changes for this RFC {#bis-changes}
 
 IANA has updated all references to {{RFC8446}} in the IANA
 registries with references to this document.
 
+IANA has updated the "Recommended" column procedures to match {{RFC9847}} for
+the TLS SignatureScheme and PskKeyExchangeMode registries.
+
 IANA has renamed the "extended_master_secret" value
 in the TLS ExtensionType Values registry to "extended_main_secret".
 
 IANA has created  a value for the "general_error"
 alert in the TLS Alerts registry with the value given in {{alert-protocol}}.
+
+IANA has updated added references to this document for the status_request and
+supported_groups entries in the TLS ExtensionType Values registry.
+
+IANA has updated the TLS ExtensionType values in the "TLS 1.3" column for 
+cached_info to "CH, EE" and renegotiation_info to "CH, SH".
 
 --- back
 
@@ -5348,11 +5358,11 @@ might receive them from older TLS implementations.
        } Extension;
 
        enum {
-           server_name(0),                             /* RFC 6066 */
-           max_fragment_length(1),                     /* RFC 6066 */
-           status_request(5),                          /* RFC 6066 */
-           supported_groups(10),                       /* RFC 8422, 7919 */
-           signature_algorithms(13),                   /* RFC 8446 */
+           server_name(0),                             /* RFC 6066, 9261 */
+           max_fragment_length(1),                     /* RFC 6066, 8449 */
+           status_request(5),                          /* RFC 9846, 6066 */
+           supported_groups(10),                       /* RFC 9846, 8422, 7919 */
+           signature_algorithms(13),                   /* RFC 9846 */
            use_srtp(14),                               /* RFC 5764 */
            heartbeat(15),                              /* RFC 6520 */
            application_layer_protocol_negotiation(16), /* RFC 7301 */
@@ -5360,16 +5370,16 @@ might receive them from older TLS implementations.
            client_certificate_type(19),                /* RFC 7250 */
            server_certificate_type(20),                /* RFC 7250 */
            padding(21),                                /* RFC 7685 */
-           pre_shared_key(41),                         /* RFC 8446 */
-           early_data(42),                             /* RFC 8446 */
-           supported_versions(43),                     /* RFC 8446 */
-           cookie(44),                                 /* RFC 8446 */
-           psk_key_exchange_modes(45),                 /* RFC 8446 */
-           certificate_authorities(47),                /* RFC 8446 */
-           oid_filters(48),                            /* RFC 8446 */
-           post_handshake_auth(49),                    /* RFC 8446 */
-           signature_algorithms_cert(50),              /* RFC 8446 */
-           key_share(51),                              /* RFC 8446 */
+           pre_shared_key(41),                         /* RFC 9846 */
+           early_data(42),                             /* RFC 9846 */
+           supported_versions(43),                     /* RFC 9846 */
+           cookie(44),                                 /* RFC 9846 */
+           psk_key_exchange_modes(45),                 /* RFC 9846 */
+           certificate_authorities(47),                /* RFC 9846 */
+           oid_filters(48),                            /* RFC 9846 */
+           post_handshake_auth(49),                    /* RFC 9846 */
+           signature_algorithms_cert(50),              /* RFC 9846 */
+           key_share(51),                              /* RFC 9846 */
            (65535)
        } ExtensionType;
 


### PR DESCRIPTION
Not entirely sure about all of these.

- ExtensionType presentation language (front and back):
    - `server_name`: RFC 9261 adds "CR" to the TLS 1.3 column. - Added Informative reference to RFC 9261?
    - `max_fragment_length`: IANA also references 8449.
    - `status_request`: RFC 9846 updates how to do it so we should add a reference to IANA entry.
    - `supported_algorithms`: RFC 9846 updates how to do it so we should add a reference to IANA entry.
- TLS Extensions table:
    - `supported_versions` & `psk_key_exchange_modes`: swapped order to match IANA registry order.
    - `ech_outer_extensions`: added as it is now marked Recommended.
    - `renegotiation_info`: added because it is marked as Recommended - maybe it shouldn’t be Recommended=Y?
- IANA Considerations
    - To avoid different rules for the SignatureScheme and PskKeyExchangeMode registries refer (informatively?) to RFC 9847.
    - This documents updates `status_request` and `supported_groups` so asked IANA to add a reference to this RFC.
    - In the IANA registry, the `cached_info` TLS 1.3 column is currently "-". This document makes it "CH, EE".
    - Added “CH, SH" to `renegotiation_info` TLS 1.3 column, *BUT* see earlier comment.