### PR TITLE
Nits

### DIFF
--- a/rfc9846.md
+++ b/rfc9846.md
@@ -2420,7 +2420,7 @@ if one is violated.
 
 Clients and Servers MUST NOT reuse a key share for multiple
 connections.  Because {{RFC8446}} permitted reuse, receiving
-implementations MUST permit reuse by the peer to prevent
+implementations MUST permit reuse by the peer in order to prevent
 interoperability issues.
 
 In a HelloRetryRequest message, the "extension_data" field of this

--- a/rfc9846.md
+++ b/rfc9846.md
@@ -1668,7 +1668,7 @@ Random set to the special value of the SHA-256 of
       CF 21 AD 74 E5 9A 61 11 BE 1D 8C 02 1E 65 B8 91
       C2 A2 11 16 7A BB 8C 5E 07 9E 09 E2 C8 A8 33 9C
 
-Upon receiving a ServerHello message, implementations
+Upon receiving a message with type server_hello, implementations
 MUST first examine the Random value and, if it matches
 this value, process it as described in {{hello-retry-request}}.
 

--- a/rfc9846.md
+++ b/rfc9846.md
@@ -5850,7 +5850,7 @@ using the "Encrypted Client Hello" extension {{RFC9849}}.
 If an external PSK identity is used for multiple connections, then it
 will generally be possible for an external observer to track
 clients and/or servers across connections. Use of the
-"Encrypted Client Hello" extension {{RFC9849}} can
+Encrypted Client Hello extension {{RFC9849}} can
 mitigate this risk, as can mechanisms external to TLS that
 rotate or encrypt the PSK identity.
 

--- a/rfc9846.md
+++ b/rfc9846.md
@@ -520,7 +520,7 @@ extension {{RFC7627}}, and elliptic curve definitions for TLS 1.2 {{RFC8422}}.
 It also obsoletes the TLS ticket mechanism defined in {{RFC5077}} and replaces it with the mechanism
 defined in {{resumption-and-psk}}. Because TLS 1.3 changes the way keys are derived, it
 updates {{RFC5705}} as described in {{exporters}};
-exporters no longer distinguish between having no context and having an empty context.It also changes
+exporters no longer distinguish between having no context and having an empty context. It also changes
 how Online Certificate Status Protocol (OCSP) messages are carried and therefore updates {{RFC6066}}
 and obsoletes {{RFC6961}} as described in {{ocsp-and-sct}}.
 
@@ -770,7 +770,7 @@ in the diagram above):
 In the Key Exchange phase, the client sends the ClientHello
 ({{client-hello}}) message, which contains a random nonce
 (ClientHello.random); its offered protocol versions; a list of
-symmetric cipher/hash pairs; either a list of Diffie-Hellman key shares (in the
+symmetric cipher/hash pairs; either a list of asymmetric key exchange shares (in the
 "key_share" ({{key-share}}) extension), a list of pre-shared key labels (in the
 "pre_shared_key" ({{pre-shared-key-extension}}) extension), or both; and
 potentially additional extensions.  Additional fields and/or messages
@@ -783,7 +783,7 @@ parameters. The combination of the ClientHello
 and the ServerHello determines the shared keys. If asymmetric
 key establishment is in use, then the ServerHello
 contains a "key_share" extension with the server's ephemeral
-Diffie-Hellman share; the server's share MUST be in the same group as one of the
+asymmetric key exchange share; the server's share MUST be in the same group as one of the
 client's shares. If PSK key establishment is
 in use, then the ServerHello contains a "pre_shared_key"
 extension indicating which of the client's offered PSKs was selected.
@@ -829,7 +829,7 @@ Finished:
 : A MAC (Message Authentication Code) over the entire handshake.
   This message provides key confirmation for the shared secrets established in
   the handshake
-  binds the endpoint's identity to the exchanged keys, and in PSK mode
+  , binds the endpoint's identity to the exchanged keys, and in PSK mode
   also authenticates the handshake. [{{finished}}]
 {:br }
 
@@ -968,7 +968,7 @@ discussed in {{RFC4086}}. Deriving a shared secret from a password or other
 low-entropy sources is not secure. A low-entropy secret, or password, is
 subject to dictionary attacks based on the PSK binder.  The specified PSK
 authentication is not a strong password-based authenticated key exchange even
-when used with Diffie-Hellman key establishment.  Specifically, it does not
+when used with asymmetric key establishment.  Specifically, it does not
 prevent an attacker that can observe the handshake from performing
 a brute-force attack on the password/pre-shared key.
 
@@ -1668,7 +1668,7 @@ Random set to the special value of the SHA-256 of
       CF 21 AD 74 E5 9A 61 11 BE 1D 8C 02 1E 65 B8 91
       C2 A2 11 16 7A BB 8C 5E 07 9E 09 E2 C8 A8 33 9C
 
-Upon receiving a message with type server_hello, implementations
+Upon receiving a ServerHello message, implementations
 MUST first examine the Random value and, if it matches
 this value, process it as described in {{hello-retry-request}}.
 
@@ -2121,7 +2121,7 @@ RSASSA-PSS RSAE algorithms:
   both the corresponding hash algorithm as defined in {{!SHS}}.
   The length of the Salt MUST be equal to the length of the output of the
   digest algorithm. If the public key is carried
-  in an X.509 certificate, it MUST use the rsaEncryption OID {{!RFC5280}}.
+  in an X.509 certificate, it MUST use the rsaEncryption OID {{!RFC3279}}.
 
 EdDSA algorithms:
 : Indicates a signature algorithm using EdDSA as defined in
@@ -2160,7 +2160,7 @@ Legacy algorithms:
 
 The signatures on certificates that are self-signed or certificates that are
 trust anchors are not validated, since they begin a certification path (see
-{{RFC5280, Section 3.2}}).  A certificate that begins a certification
+{{!RFC5280, Section 3.2}}).  A certificate that begins a certification
 path MAY use a signature algorithm that is not advertised as being supported
 in the "signature_algorithms" and "signature_algorithms_cert" extensions.
 
@@ -2335,7 +2335,7 @@ Finite Field Groups (DHE):
 Items in "named_group_list" are ordered according to the sender's
 preferences (most preferred choice first). The "named_group_list"
 MUST NOT contain any duplicate entries.  A recipient MAY abort a connection
-with a fatal illegal_parameter alert if it detects a duplicate entry.
+with a fatal "illegal_parameter" alert if it detects a duplicate entry.
 
 As of TLS 1.3, servers are permitted to send the "supported_groups"
 extension to the client. Clients MUST NOT act upon any information
@@ -2420,7 +2420,7 @@ if one is violated.
 
 Clients and Servers MUST NOT reuse a key share for multiple
 connections.  Because {{RFC8446}} permitted reuse, receiving
-implementations MUST permit reuse by the peer in order to prevent
+implementations MUST permit reuse by the peer to prevent
 interoperability issues.
 
 In a HelloRetryRequest message, the "extension_data" field of this
@@ -2643,7 +2643,7 @@ MUST behave in one of three ways:
   Even though the server sends a message accepting early data, the actual early
   data itself may already be in flight by the time the server generates this message.
 
-In order to accept early data, the server MUST have selected the first
+To accept early data, the server MUST have selected the first
 key offered in the client's "pre_shared_key" extension. In addition,
 it MUST verify that the following values are the same as those
 associated with the selected PSK:
@@ -2874,7 +2874,7 @@ of the handshake.
 Clients are permitted to "stream" 0-RTT data until they
 receive the server's Finished, only then sending the EndOfEarlyData
 message, followed by the rest of the handshake.
-In order to avoid deadlocks, when accepting "early_data",
+To avoid deadlocks, when accepting "early_data",
 servers MUST process the client's ClientHello and then immediately
 send their flight of messages, rather than waiting for the client's
 EndOfEarlyData message before sending its ServerHello.
@@ -3648,7 +3648,7 @@ if the key repeats, the IV is also independently generated, so the
 chance of a joint key/IV collision is much lower.
 To provide an extra margin of security, sending implementations MUST
 NOT allow the epoch -- and hence the number of key updates --
-to exceed 2<sup>48</sup>-1.  In order to allow this value to be changed later
+to exceed 2<sup>48</sup>-1.  To allow this value to be changed later
 -- for instance for ciphers with more than 128-bit keys --
 receiving implementations MUST NOT enforce this
 rule.  If a sending implementation receives a KeyUpdate with
@@ -4135,11 +4135,11 @@ wait to receive a "close_notify" alert before closing their read side of the
 connection, though doing so would introduce the possibility of truncation.
 
 Application protocols MAY choose to flush their send buffers and immediately
-send a close_notify upon receiving a close_notify, but this allows an attacker
-to influence the data that the peer receives by delaying the close_notify or
+send a "close_notify" upon receiving a "close_notify", but this allows an attacker
+to influence the data that the peer receives by delaying the "close_notify" or
 by delaying the transport-level delivery of the application's packets. These
 issues can be addressed at the application layer, for instance by ignoring
-packets received after transmitting the close_notify.
+packets received after transmitting the "close_notify".
 
 If the application protocol using TLS provides that any data may be carried
 over the underlying transport after the TLS connection is closed, the TLS
@@ -5728,7 +5728,7 @@ otherwise subverted random number generators.
 ## Certificates and Authentication
 
 Implementations are responsible for verifying the integrity of certificates and
-should generally support certificate revocation messages. Absent a specific
+should generally support certificate revocation messages; see {{ocsp-and-sct}}. Absent a specific
 indication from an application profile, certificates should
 always be verified to ensure proper signing by a trusted certificate authority
 (CA). The selection and addition of trust anchors should be done very carefully.
@@ -5845,12 +5845,12 @@ this trivially identifies the user to a passive attacker,
 unlike the client's Certificate, which is encrypted. There are a number of potential
 ways to avoid this risk, including (1) using random identity labels,
 (2) pre-encrypting the identity under a key known to the server, or (3)
-using the Encrypted Client Hello extension {{RFC9849}}.
+using the "Encrypted Client Hello" extension {{RFC9849}}.
 
 If an external PSK identity is used for multiple connections, then it
 will generally be possible for an external observer to track
 clients and/or servers across connections. Use of the
-Encrypted Client Hello extension {{RFC9849}} can
+"Encrypted Client Hello" extension {{RFC9849}} can
 mitigate this risk, as can mechanisms external to TLS that
 rotate or encrypt the PSK identity.
 
@@ -6225,7 +6225,7 @@ resistant. See {{key-derivation-and-hkdf}} for more on this.
 Note: The binder does not cover the binder values from other
 PSKs, though they are included in the Finished MAC.
 
-Note: This specification does not currently permit the server to send a certificate_request
+Note: This specification does not currently permit the server to send a CertificateRequest
 message in non-certificate-based handshakes (e.g., PSK).
 If this restriction were to be relaxed in future, the
 client's signature would not cover the server's certificate directly.
@@ -6393,7 +6393,7 @@ a separate nonce for each record, with the nonce being derived from
 the record sequence number ({{nonce}}), with the sequence
 number being maintained independently at both sides; thus, records which
 are delivered out of order result in AEAD deprotection failures.
-In order to prevent mass cryptanalysis when the same plaintext is
+To prevent mass cryptanalysis when the same plaintext is
 repeatedly encrypted by different users under the same key
 (as is commonly the case for HTTP), the nonce is formed by mixing
 the sequence number with a secret per-connection initialization
@@ -6560,7 +6560,7 @@ data if it is rejected by the server unless instructed by the
 application. Server-side applications may wish to implement special
 processing for 0-RTT data for some kinds of application traffic (e.g.,
 abort the connection, request that data be resent at the application
-layer, or delay processing until the handshake completes). In order to
+layer, or delay processing until the handshake completes). To
 allow applications to implement this kind of processing, TLS
 implementations MUST provide a way for the application to determine if
 the handshake has completed.

--- a/rfc9846.md
+++ b/rfc9846.md
@@ -2643,7 +2643,7 @@ MUST behave in one of three ways:
   Even though the server sends a message accepting early data, the actual early
   data itself may already be in flight by the time the server generates this message.
 
-To accept early data, the server MUST have selected the first
+In order to accept early data, the server MUST have selected the first
 key offered in the client's "pre_shared_key" extension. In addition,
 it MUST verify that the following values are the same as those
 associated with the selected PSK:

--- a/rfc9846.md
+++ b/rfc9846.md
@@ -828,8 +828,8 @@ CertificateVerify:
 Finished:
 : A MAC (Message Authentication Code) over the entire handshake.
   This message provides key confirmation for the shared secrets established in
-  the handshake
-  , binds the endpoint's identity to the exchanged keys, and in PSK mode
+  the handshake,
+  binds the endpoint's identity to the exchanged keys, and in PSK mode
   also authenticates the handshake. [{{finished}}]
 {:br }
 


### PR DESCRIPTION
Nits to:

- Fix space in s1
- Add comma in Finished message description
- replace "in order to ..." with "to ..."
- more replaces for EDH/ECDHE with asymmetric
    - Wasn't sure about also converting [s9.2 "supported_groups" and "key_share" text](https://tlswg.org/tls13-spec/rfc9846.html#name-mandatory-to-implement-exte) "using DHE or ECDHE key exchange" to "using DHE or ECDHE key exchange"
- Consistency WRT referring to messages and quotes around fields